### PR TITLE
feat(vega): add `vega sql` — direct SQL/DSL against a data source

### DIFF
--- a/skills/openbkn/SKILL.md
+++ b/skills/openbkn/SKILL.md
@@ -69,7 +69,7 @@ openbkn auth status | whoami | token | list | use <url> | switch <url> <user-id>
 | `config` | 平台 CLI 配置 | `config show` / `config set <key> <value>` |
 | `bkn` | 知识网络 + Schema + 查询 + 本地包 | `list`/`get`/`search`/`stats`/`export`、`object-type/relation-type/action-type list/get/create/update/delete`、`action-type query/execute/inputs`、`metric …`、`concept-group …`、`action-log/action-schedule/job …`、`subgraph`、`relation-type-paths`、`resources`、`push <dir>`/`pull <kn> [dir]`、`validate <dir>`、`create-from-catalog <catalog> --name …`、`create-from-csv <catalog> --files <glob> --name …`（`--build`、`--pk-map t:col`） |
 | `resource` | Vega-backend 资源 | `list`/`get`/`find --name`/`query`/`delete` |
-| `vega` | Catalog + 索引构建 | `catalog list/get`、`catalog resources`、`connector-types`、`build`（索引 BuildTask）+ 状态 |
+| `vega` | Catalog + 索引构建 + SQL | `catalog list/get`、`catalog resources`、`connector-types`、`sql --resource-type <t> --query "<sql>"`（直连 MySQL/PG/OpenSearch，SQL 用 `{{resource-id}}` 占位）、`build`（索引 BuildTask）+ 状态 |
 | `context` | MCP 检索 | `info`（全局 tool 目录，无需 KN）、`search-schema`、`query-object-instance`、`find-skills`、`tools <kn>`、`tool-call <name> [--arg k=v]`、`call-method <method>`、`resources/templates/prompts`、`query-instance-subgraph`/`get-logic-properties`/`get-action-info`；新工具用 `info`/`tools` 发现 + `tool-call` 调用，无需改 CLI |
 | `agent` | Decision Agent | `list`/`personal-list`/`template-list`/`get`/`create`/`update`/`delete`/`publish`、`chat <id> -m "…" [--stream]`、`sessions`、`history`、`trace`、`skill list/add/remove` |
 | `model` | 模型工厂 | `llm/small list/get/add/edit/delete/test`、`llm chat <id> -m "…" [--stream]`、`small embeddings/rerank` |

--- a/skills/openbkn/references/vega.md
+++ b/skills/openbkn/references/vega.md
@@ -6,32 +6,75 @@
 | `catalog resources <id> [--category table]` | Resources under a catalog. |
 | `catalog health <ids...>` | Health-status for one or more catalogs. |
 | `connector-type list` / `connector-type get <type>` | Available connector types. |
-| `sql --resource-type <t> --query "<sql>"` / `sql -d <json>` | Run SQL (MySQL/MariaDB/PostgreSQL) or OpenSearch DSL directly against a data source. See below. |
+| `sql --query "<sql>"` / `sql -d <json>` | Run SQL (MySQL/MariaDB/PostgreSQL) or OpenSearch DSL directly against a data source. Table = `{{<resource-id>}}`; `--resource-type` optional. See [§ vega sql](#vega-sql--run-sql--dsl-against-a-data-source). |
 | `resource …` | Vega-backend resources (mirror of top-level `resource`). |
 | `dataset build <resource-id> --mode batch\|streaming [--embedding-fields a,b] [--build-key-fields k] [--embedding-model <id>] [--model-dimensions <n>] [--wait]` | Create an index BuildTask. **Index build lives on the resource (one resource = one table); there is no KN-level build.** `batch` requires `--build-key-fields` (else `400 build_key_fields is required for batch mode`). |
 | `dataset build-status <resource-id> <task-id>` | BuildTask state + progress. |
 
-## SQL / DSL against a data source
+## `vega sql` — run SQL / DSL against a data source
 
-`POST /api/vega-backend/v1/resources/query` — vega-backend connects directly to
-MySQL/MariaDB/PostgreSQL (SQL) or OpenSearch (DSL); no Trino.
+`POST /api/vega-backend/v1/resources/query`. vega-backend connects **directly**
+to the data source (no Trino): SQL on MySQL/MariaDB/PostgreSQL, DSL on
+OpenSearch. Dialect translation is done server-side with sqlglot.
+
+### The placeholder rule (most important)
+
+In the `FROM`, reference the table as a **Vega resource id** wrapped in
+`{{ }}` — `{{<resource-id>}}` or `{{.<resource-id>}}`, both accepted. This is
+how the backend knows **which Catalog connector** to open. The id is a Vega
+resource id (looks like `d7nicrcjto2s73d9g67g`), **not** the physical table
+name. Get it with:
 
 ```bash
-# simple: --resource-type + --query (SQL quoted; reference the resource as {{<id>}})
-openbkn vega sql --resource-type mysql --query "SELECT * FROM {{<resource-id>}} LIMIT 5"
-
-# advanced: full JSON body (stream_size, query_timeout, query_id, OpenSearch DSL object)
-openbkn vega sql -d '{"resource_type":"mysql","query":"SELECT ...","stream_size":1000}'
+openbkn resource find --name <table> --exact     # → resource id
+openbkn resource get <resource-id>               # confirm it
 ```
 
-- **Always use a `{{<resource-id>}}` placeholder** for the table — it tells the
-  backend which Catalog connector to use. Bare SQL may fail with
-  `connector config is incomplete`. The `<resource-id>` is a Vega resource id
-  (`vega resource get` / `resource find --name <table> --exact`).
-- `--resource-type` values come from `vega connector-type list` (mysql, mariadb,
-  postgresql, opensearch, …).
-- `-d` wins over `--query`/`--resource-type` when both are given.
-- The data source must first be a registered Catalog + Resource (see below).
+Bare table names (no placeholder) usually fail with
+`connector config is incomplete` — the backend falls back to a global default
+connector that isn't configured. **Always use the placeholder.**
+
+### Usage
+
+```bash
+# Simple — only --query is required; resource_type is inferred from the placeholder
+openbkn vega sql --query "SELECT * FROM {{d7nicrcjto2s73d9g67g}} LIMIT 10"
+
+# With a WHERE / projection (standard SQL, the source's dialect)
+openbkn vega sql --query "SELECT id, name FROM {{<res-id>}} WHERE status = 'active' ORDER BY id DESC LIMIT 50"
+
+# Override the inferred type, larger stream batch
+openbkn vega sql --resource-type postgresql --stream-size 5000 \
+  --query "SELECT count(*) FROM {{<res-id>}}"
+
+# OpenSearch DSL — query is a JSON object, not a SQL string → use --data
+openbkn vega sql -d '{"query":{"match":{"name":"web-pod"}},"resource_type":"opensearch"}'
+
+# Advanced — full body (any field below)
+openbkn vega sql -d '{"query":"SELECT ...","stream_size":1000,"query_timeout":120}'
+```
+
+### Parameters
+
+| Flag / field | Required | Default | Notes |
+| --- | :---: | --- | --- |
+| `--query` / body `query` | ✅ (unless `-d` carries it) | — | SQL string, **or** an OpenSearch DSL object (object → must use `-d`). Reference the table as `{{<resource-id>}}`. |
+| `--resource-type` / `resource_type` | optional | inferred from the placeholder's catalog connector | One of `vega connector-type list` (e.g. `mysql`, `mariadb`, `postgresql`, `opensearch`). Pass only to override. |
+| `--stream-size` / `stream_size` | optional | server default (≈10000) | Streaming batch size, 100–10000. |
+| `--query-timeout` / `query_timeout` | optional | 60 | Seconds, 1–3600. |
+| `query_id` (body only) | optional | — | Cursor session id for paged streaming. |
+| `-d` / `--data` | — | — | Full JSON body. **Wins over** `--query`/`--resource-type`/etc. when both given. |
+
+### Gotchas
+
+- **Always `LIMIT`** large tables — results stream back in full otherwise.
+- SQL dialect is the **source's** (MySQL vs PostgreSQL quoting/functions differ);
+  sqlglot translates common forms but not everything.
+- The data source must already be a registered **Catalog + Resource** (see
+  below) — `vega sql` queries an existing resource, it doesn't create one.
+- `connector config is incomplete` → missing/incorrect `{{<resource-id>}}`
+  placeholder, or the resource's catalog connector isn't healthy
+  (`vega catalog health <id>`).
 
 ## catalog → resource → index
 

--- a/skills/openbkn/references/vega.md
+++ b/skills/openbkn/references/vega.md
@@ -6,9 +6,32 @@
 | `catalog resources <id> [--category table]` | Resources under a catalog. |
 | `catalog health <ids...>` | Health-status for one or more catalogs. |
 | `connector-type list` / `connector-type get <type>` | Available connector types. |
+| `sql --resource-type <t> --query "<sql>"` / `sql -d <json>` | Run SQL (MySQL/MariaDB/PostgreSQL) or OpenSearch DSL directly against a data source. See below. |
 | `resource …` | Vega-backend resources (mirror of top-level `resource`). |
 | `dataset build <resource-id> --mode batch\|streaming [--embedding-fields a,b] [--build-key-fields k] [--embedding-model <id>] [--model-dimensions <n>] [--wait]` | Create an index BuildTask. **Index build lives on the resource (one resource = one table); there is no KN-level build.** `batch` requires `--build-key-fields` (else `400 build_key_fields is required for batch mode`). |
 | `dataset build-status <resource-id> <task-id>` | BuildTask state + progress. |
+
+## SQL / DSL against a data source
+
+`POST /api/vega-backend/v1/resources/query` — vega-backend connects directly to
+MySQL/MariaDB/PostgreSQL (SQL) or OpenSearch (DSL); no Trino.
+
+```bash
+# simple: --resource-type + --query (SQL quoted; reference the resource as {{<id>}})
+openbkn vega sql --resource-type mysql --query "SELECT * FROM {{<resource-id>}} LIMIT 5"
+
+# advanced: full JSON body (stream_size, query_timeout, query_id, OpenSearch DSL object)
+openbkn vega sql -d '{"resource_type":"mysql","query":"SELECT ...","stream_size":1000}'
+```
+
+- **Always use a `{{<resource-id>}}` placeholder** for the table — it tells the
+  backend which Catalog connector to use. Bare SQL may fail with
+  `connector config is incomplete`. The `<resource-id>` is a Vega resource id
+  (`vega resource get` / `resource find --name <table> --exact`).
+- `--resource-type` values come from `vega connector-type list` (mysql, mariadb,
+  postgresql, opensearch, …).
+- `-d` wins over `--query`/`--resource-type` when both are given.
+- The data source must first be a registered Catalog + Resource (see below).
 
 ## catalog → resource → index
 

--- a/src/api/vega.ts
+++ b/src/api/vega.ts
@@ -69,6 +69,29 @@ export async function getBuildTask(ctx: RequestContext, taskId: string): Promise
   return BuildTask.parse(res);
 }
 
+export interface SqlQueryRequest {
+  /** SQL string (MySQL/MariaDB/PostgreSQL) or an OpenSearch DSL object. */
+  query: string | Record<string, unknown>;
+  /** Source type, e.g. mysql | mariadb | postgresql | opensearch (see connector-type list). */
+  resource_type: string;
+  /** Streaming batch size (100–10000, default server-side). */
+  stream_size?: number;
+  /** Query timeout in seconds (1–3600). */
+  query_timeout?: number;
+  /** Cursor session id for paged streaming. */
+  query_id?: string;
+}
+
+/**
+ * Run SQL (or an OpenSearch DSL) directly against a data source. vega-backend
+ * connects through the resource's Catalog connector — reference the resource in
+ * the SQL with a `{{<resource-id>}}` placeholder so the backend knows which
+ * connector to use. `POST /api/vega-backend/v1/resources/query`.
+ */
+export function runSql(ctx: RequestContext, body: SqlQueryRequest): Promise<unknown> {
+  return request(ctx, `${VEGA_BASE}/resources/query`, { method: "POST", body });
+}
+
 export interface ListCatalogsOptions {
   limit?: number;
   offset?: number;

--- a/src/api/vega.ts
+++ b/src/api/vega.ts
@@ -72,8 +72,12 @@ export async function getBuildTask(ctx: RequestContext, taskId: string): Promise
 export interface SqlQueryRequest {
   /** SQL string (MySQL/MariaDB/PostgreSQL) or an OpenSearch DSL object. */
   query: string | Record<string, unknown>;
-  /** Source type, e.g. mysql | mariadb | postgresql | opensearch (see connector-type list). */
-  resource_type: string;
+  /**
+   * Source type (mysql | mariadb | postgresql | opensearch …). Optional — when
+   * the query carries a `{{<resource-id>}}` placeholder the backend infers the
+   * type from that resource's Catalog connector. Pass it only to override.
+   */
+  resource_type?: string;
   /** Streaming batch size (100–10000, default server-side). */
   stream_size?: number;
   /** Query timeout in seconds (1–3600). */

--- a/src/commands/vega.ts
+++ b/src/commands/vega.ts
@@ -1,9 +1,13 @@
 /** `openbkn vega …` — Catalog reads + index BuildTask. */
 import { Command } from "commander";
+import type { SqlQueryRequest } from "../api/vega.js";
 import { group } from "../help/grouped-help.js";
 import { DEFAULT_LIST_LIMIT } from "../types.js";
+import { InputError } from "../utils/errors.js";
 import { printJson } from "../utils/output.js";
 import { clientFrom, csv, outputOptions } from "./_shared.js";
+
+const int = (v: string) => Number.parseInt(v, 10);
 
 export function vegaCommand(): Command {
   const vega = new Command("vega").description(
@@ -102,6 +106,42 @@ export function vegaCommand(): Command {
     .description("Get a connector type")
     .action(async (type: string, _opts, cmd: Command) => {
       printJson(await clientFrom(cmd).vega.connectorType(type), outputOptions(cmd));
+    });
+
+  vega
+    .command("sql")
+    .description("Run SQL / OpenSearch DSL directly against a vega-backend data source")
+    .option("--resource-type <type>", "source type: mysql | mariadb | postgresql | opensearch | …")
+    .option(
+      "--query <sql>",
+      "SQL string; reference a resource with a {{<resource-id>}} placeholder",
+    )
+    .option("--stream-size <n>", "streaming batch size (100–10000)", int)
+    .option("--query-timeout <s>", "query timeout in seconds (1–3600)", int)
+    .option(
+      "-d, --data <json>",
+      "full request body as JSON (advanced; wins over --query/--resource-type)",
+    )
+    .action(async (opts, cmd: Command) => {
+      let body: SqlQueryRequest;
+      if (opts.data) {
+        try {
+          body = JSON.parse(opts.data);
+        } catch {
+          throw new InputError("--data must be valid JSON");
+        }
+      } else {
+        if (!opts.resourceType || !opts.query) {
+          throw new InputError("Provide --resource-type and --query, or a full body with --data.");
+        }
+        body = {
+          query: opts.query,
+          resource_type: opts.resourceType,
+          ...(opts.streamSize !== undefined ? { stream_size: opts.streamSize } : {}),
+          ...(opts.queryTimeout !== undefined ? { query_timeout: opts.queryTimeout } : {}),
+        };
+      }
+      printJson(await clientFrom(cmd).vega.sql(body), outputOptions(cmd));
     });
 
   const resource = vega.command("resource").description("Vega-backend resources");

--- a/src/commands/vega.ts
+++ b/src/commands/vega.ts
@@ -111,7 +111,10 @@ export function vegaCommand(): Command {
   vega
     .command("sql")
     .description("Run SQL / OpenSearch DSL directly against a vega-backend data source")
-    .option("--resource-type <type>", "source type: mysql | mariadb | postgresql | opensearch | …")
+    .option(
+      "--resource-type <type>",
+      "source type (mysql | postgresql | opensearch | …); optional — inferred from the {{<id>}} placeholder",
+    )
     .option(
       "--query <sql>",
       "SQL string; reference a resource with a {{<resource-id>}} placeholder",
@@ -131,12 +134,14 @@ export function vegaCommand(): Command {
           throw new InputError("--data must be valid JSON");
         }
       } else {
-        if (!opts.resourceType || !opts.query) {
-          throw new InputError("Provide --resource-type and --query, or a full body with --data.");
+        if (!opts.query) {
+          throw new InputError("Provide --query (and optionally --resource-type), or --data.");
         }
         body = {
           query: opts.query,
-          resource_type: opts.resourceType,
+          // Optional — the backend infers the type from the {{<id>}} placeholder's
+          // catalog connector when omitted.
+          ...(opts.resourceType ? { resource_type: opts.resourceType } : {}),
           ...(opts.streamSize !== undefined ? { stream_size: opts.streamSize } : {}),
           ...(opts.queryTimeout !== undefined ? { query_timeout: opts.queryTimeout } : {}),
         };

--- a/src/resources/vega.ts
+++ b/src/resources/vega.ts
@@ -3,6 +3,7 @@ import {
   type CreateBuildTaskRequest,
   type CreateCatalogRequest,
   type ListCatalogsOptions,
+  type SqlQueryRequest,
   catalogHealthStatus,
   createBuildTask,
   createCatalog,
@@ -14,6 +15,7 @@ import {
   listCatalogResources,
   listCatalogs,
   listConnectorTypes,
+  runSql,
 } from "../api/vega.js";
 /**
  * Vega resource surface — the exported SDK API for Catalog + index builds.
@@ -34,6 +36,9 @@ export function vega(ctx: RequestContext) {
     catalogHealth: (ids: string[]) => catalogHealthStatus(ctx, ids),
     connectorTypes: () => listConnectorTypes(ctx),
     connectorType: (type: string) => getConnectorType(ctx, type),
+
+    /** Run SQL / OpenSearch DSL directly against a data source. */
+    sql: (body: SqlQueryRequest) => runSql(ctx, body),
 
     /** Build a resource's index. With `wait`, polls until terminal. */
     build: async (

--- a/test/unit/vega.test.ts
+++ b/test/unit/vega.test.ts
@@ -6,6 +6,7 @@ import {
   getCatalog,
   listCatalogResources,
   listConnectorTypes,
+  runSql,
 } from "../../src/api/vega.js";
 import type { RequestContext } from "../../src/types.js";
 
@@ -83,6 +84,24 @@ describe("createBuildTask", () => {
     const body = JSON.parse(firstCall(f)[1].body as string);
     expect(body.embedding_fields).toBe("name,description");
     expect(body.build_key_fields).toBe("skill_id");
+  });
+});
+
+describe("runSql", () => {
+  it("POSTs query + resource_type to /resources/query", async () => {
+    const f = mockFetch({ rows: [] });
+    await runSql(ctx, {
+      query: "SELECT * FROM {{r-1}} LIMIT 5",
+      resource_type: "mysql",
+      stream_size: 1000,
+    });
+    const call = firstCall(f);
+    expect(new URL(call[0]).pathname).toBe("/api/vega-backend/v1/resources/query");
+    expect(call[1].method).toBe("POST");
+    const body = JSON.parse(call[1].body as string);
+    expect(body.query).toBe("SELECT * FROM {{r-1}} LIMIT 5");
+    expect(body.resource_type).toBe("mysql");
+    expect(body.stream_size).toBe(1000);
   });
 });
 


### PR DESCRIPTION
## What

Restores the legacy `kweaver vega sql` command, which was never ported to openbkn — there was no way to run SQL from the CLI.

```bash
# simple
openbkn vega sql --resource-type mysql --query "SELECT * FROM {{<resource-id>}} LIMIT 5"
# advanced (full body: stream_size / query_timeout / OpenSearch DSL)
openbkn vega sql -d '{"resource_type":"mysql","query":"SELECT ...","stream_size":1000}'
```

- `POST /api/vega-backend/v1/resources/query` — vega-backend connects directly to MySQL/MariaDB/PostgreSQL (SQL) or OpenSearch (DSL); no Trino.
- Reference the table with a `{{<resource-id>}}` placeholder so the backend selects the right Catalog connector (bare SQL may fail with `connector config is incomplete`).
- `-d` JSON wins over `--query`/`--resource-type`.
- SDK: `vega.sql(body)` + `runSql` in `api/vega.ts`.
- Skill docs (vega.md / SKILL.md) updated.

## Why it was missing
The live equivalence manifest lists `vega query execute|sql` in a form the parser didn't expand into checkable paths, so the gap slipped past 196/196.

## Verification
- `npm run ci`: 156 passed (added `runSql` test).
- `BKN_EQUIV_LIVE=1`: 196/196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)