### PR TITLE
fix(license): remove stale Apache SDK exclusion

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -28,8 +28,9 @@ This license does not apply to:
       kweaver-ai/kweaver-core, which remain licensed solely under the
       Apache License, Version 2.0, with their original copyright
       notices preserved; nor
-  (b) OpenBKN components expressly licensed under the plain Apache
-      License, Version 2.0 (e.g., BKN SDK / CLI and BKN Skill).
+  (b) OpenBKN components or individual files expressly designated as
+      licensed under the plain Apache License, Version 2.0, in their
+      own license notice or source header.
 See the NOTICE file for the per-component breakdown.
 
 ================================================================


### PR DESCRIPTION
## Summary
- remove the stale SDK/CLI/Skill Apache-2.0 example from the OpenBKN License exclusion
- make the exclusion depend on an explicit per-component or per-file Apache-2.0 designation

## Verification
- git diff --check
- confirmed the old contradictory phrase is absent
- confirmed the commit changes only LICENSE