### PR TITLE
feat(trace): add phase one SDK trace context

### DIFF
--- a/TRACE.md
+++ b/TRACE.md
@@ -1,0 +1,79 @@
+# bkn-sdk / openbkn CLI Trace Contract
+
+> Status: phase-one module contract  
+> Contract version: `bkn.trace.schema.version=1.0.0`  
+> Reference: `bkn-docs/docs/foundry/bkn-trace/design/阶段一：OpenBKN 可观测记录规范与 Trace Context 基线.md`
+
+## Module
+
+- module name: `sdk-cli`
+- owner: OpenBKN SDK
+- service identity: SDK / CLI caller
+- runtime: TypeScript / Node.js
+- repository path: `bkn-sdk`
+- contract version: `1.0.0`
+
+## Entry Operations
+
+| operation | trigger | required context | emitted spans | emitted events |
+| --- | --- | --- | --- | --- |
+| `sdk.request` | SDK consumer calls an OpenBKN API | optional caller trace context | none in phase one | none in phase one |
+| `sdk.openbkn.call` | SDK HTTP request to OpenBKN | `traceparent`, `bkn-request-id` | none in phase one | none in phase one |
+| `cli.command` | `openbkn` command invocation | optional caller trace context | none in phase one | none in phase one |
+| `cli.trace.validate_fixture` | fixture validation command or equivalent | local request context | none in phase one | validation result output |
+
+## Inbound Context
+
+- accepted options: `ClientOptions.trace.requestId`, `ClientOptions.trace.traceparent`, `ClientOptions.trace.baggage`
+- request id parsing: valid `req_<id>` is preserved; invalid or missing values generate `req_<uuid>`
+- traceparent parsing: valid W3C version `00` is preserved; invalid, all-zero trace id, or all-zero span id generate a new internal traceparent
+- baggage policy: allowlist-only; only `bkn.account.type` and `bkn.runtime.env` propagate
+
+## Outbound Calls
+
+| target | protocol | propagated fields | baggage policy | timeout | retry |
+| --- | --- | --- | --- | --- | --- |
+| OpenBKN APIs | HTTP | `traceparent`, `bkn-request-id`, `x-request-id` | allowlist-only baggage | existing request timeout | existing refresh/retry policy |
+| Raw call passthrough | HTTP | generated context plus explicit caller headers | allowlist-only generated baggage; caller extra headers can override deliberately | `RawCallOptions.timeoutMs` | existing refresh/retry policy |
+
+## Logs
+
+SDK/CLI phase one does not add persistent logs by default. If commands emit diagnostic output, they must not include token, authorization, cookie, full prompt, full SQL, full request body, full response body, or PII.
+
+## Spans
+
+SDK/CLI does not start OpenTelemetry spans in phase one. It injects trace context into outbound HTTP requests so server-side spans, logs, and events can join by `trace_id` and `bkn.request.id`.
+
+## Events
+
+No BKN Trace event envelope is emitted by SDK/CLI in phase one. Fixture validation output acts as the local contract proof until the SDK exposes `openbkn trace contract validate`.
+
+## Sensitive Data Rules
+
+- never log: token, authorization, cookie, full local config, full request body, full response body, prompt, SQL, PII
+- hash only: future prompt, SQL, tool args, tool result
+- controlled reference: future large object and evidence refs
+- baggage allowlist: `bkn.account.type`, `bkn.runtime.env`
+
+## Sampling
+
+- default: generated traceparent uses sampled flag `01`
+- forced sampling: command failures and validation failures should be treated as forced-sampled by downstream trace collectors when available
+- not sampled behavior: request id still propagates
+
+## Fixtures And Tests
+
+| fixture or test | path | purpose | expected result |
+| --- | --- | --- | --- |
+| unit | `test/unit/trace-context.test.ts` | generated request id, valid traceparent propagation, baggage filtering | pass |
+| unit | `test/unit/headers.test.ts` | auth header safety plus generated trace headers | pass |
+| contract fixture | `bkn-docs/docs/foundry/bkn-trace/examples/openbkn-modules/sdk-cli/fixtures/positive.json` | request id injection shape | pass |
+| contract fixture | `bkn-docs/docs/foundry/bkn-trace/examples/openbkn-modules/sdk-cli/fixtures/propagation.json` | outbound context propagation shape | pass |
+| contract fixture | `bkn-docs/docs/foundry/bkn-trace/examples/openbkn-modules/sdk-cli/fixtures/sampling.json` | validation failure forced-sampled shape | pass |
+| contract fixture | `bkn-docs/docs/foundry/bkn-trace/examples/openbkn-modules/sdk-cli/fixtures/negative_baggage.json` | forbidden baggage key rejection | fail |
+
+## Known Gaps
+
+- SDK/CLI does not yet expose `openbkn trace contract validate`; bkn-docs currently provides the executable validator.
+- SDK/CLI does not yet emit local BKN Trace event envelopes.
+- Raw call explicit headers can intentionally override generated trace context; this is preserved for operator debugging.

--- a/TRACE.md
+++ b/TRACE.md
@@ -67,13 +67,13 @@ No BKN Trace event envelope is emitted by SDK/CLI in phase one. Fixture validati
 | --- | --- | --- | --- |
 | unit | `test/unit/trace-context.test.ts` | generated request id, valid traceparent propagation, baggage filtering | pass |
 | unit | `test/unit/headers.test.ts` | auth header safety plus generated trace headers | pass |
-| contract fixture | `bkn-docs/docs/foundry/bkn-trace/examples/openbkn-modules/sdk-cli/fixtures/positive.json` | request id injection shape | pass |
-| contract fixture | `bkn-docs/docs/foundry/bkn-trace/examples/openbkn-modules/sdk-cli/fixtures/propagation.json` | outbound context propagation shape | pass |
-| contract fixture | `bkn-docs/docs/foundry/bkn-trace/examples/openbkn-modules/sdk-cli/fixtures/sampling.json` | validation failure forced-sampled shape | pass |
-| contract fixture | `bkn-docs/docs/foundry/bkn-trace/examples/openbkn-modules/sdk-cli/fixtures/negative_baggage.json` | forbidden baggage key rejection | fail |
+| contract fixture | `fixtures/bkn-trace/positive.json` | request id injection shape | pass |
+| contract fixture | `fixtures/bkn-trace/propagation.json` | outbound context propagation shape | pass |
+| contract fixture | `fixtures/bkn-trace/sampling.json` | validation failure forced-sampled shape | pass |
+| contract fixture | `fixtures/bkn-trace/negative_baggage.json` | forbidden baggage key rejection | fail |
 
 ## Known Gaps
 
-- SDK/CLI does not yet expose `openbkn trace contract validate`; bkn-docs currently provides the executable validator.
+- SDK/CLI exposes `openbkn trace validate-fixture`; bkn-docs remains the source of the shared fixture contract and Python reference validator.
 - SDK/CLI does not yet emit local BKN Trace event envelopes.
 - Raw call explicit headers can intentionally override generated trace context; this is preserved for operator debugging.

--- a/fixtures/bkn-trace/negative_baggage.json
+++ b/fixtures/bkn-trace/negative_baggage.json
@@ -1,0 +1,45 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "sdk_cli_negative_baggage_request_id",
+  "fixture_type": "negative",
+  "scenario": "sdk_cli_request_id_in_baggage",
+  "expected_result": "fail",
+  "trace": {
+    "trace_id": "75040000000000000000000000000004",
+    "bkn.request.id": "req_sdk_cli_0004",
+    "traceparent": "00-75040000000000000000000000000004-7504000000000001-01",
+    "sampling.decision": "sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7504000000000001",
+      "parent_span_id": null,
+      "name": "bkn-sdk.request",
+      "kind": "internal",
+      "bkn.module.name": "sdk-cli",
+      "bkn.operation.name": "sdk.request",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:43:00.000000000Z",
+      "duration_ms": 6
+    }
+  ],
+  "logs": [
+    {
+      "level": "info",
+      "message": "sdk request completed",
+      "trace_id": "75040000000000000000000000000004",
+      "span_id": "7504000000000001",
+      "bkn.request.id": "req_sdk_cli_0004",
+      "bkn.module.name": "sdk-cli",
+      "bkn.operation.name": "sdk.request",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:43:00.006000000Z",
+      "bkn.trace.schema.version": "1.0.0"
+    }
+  ],
+  "events": [],
+  "baggage": {
+    "bkn.account.type": "app",
+    "bkn.request.id": "req_sdk_cli_0004"
+  }
+}

--- a/fixtures/bkn-trace/positive.json
+++ b/fixtures/bkn-trace/positive.json
@@ -1,0 +1,46 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "sdk_cli_positive_request_injection",
+  "fixture_type": "positive",
+  "scenario": "sdk_cli_injects_request_context",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "75010000000000000000000000000001",
+    "bkn.request.id": "req_sdk_cli_0001",
+    "traceparent": "00-75010000000000000000000000000001-7501000000000001-01",
+    "sampling.decision": "sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7501000000000001",
+      "parent_span_id": null,
+      "name": "bkn-cli.command",
+      "kind": "internal",
+      "bkn.module.name": "sdk-cli",
+      "bkn.operation.name": "cli.command",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:40:00.000000000Z",
+      "duration_ms": 29
+    }
+  ],
+  "logs": [
+    {
+      "level": "info",
+      "message": "cli command completed",
+      "trace_id": "75010000000000000000000000000001",
+      "span_id": "7501000000000001",
+      "bkn.request.id": "req_sdk_cli_0001",
+      "bkn.module.name": "sdk-cli",
+      "bkn.operation.name": "cli.command",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:40:00.029000000Z",
+      "bkn.trace.schema.version": "1.0.0",
+      "command.name": "trace.validate_fixture"
+    }
+  ],
+  "events": [],
+  "baggage": {
+    "bkn.account.type": "user",
+    "bkn.runtime.env": "test"
+  }
+}

--- a/fixtures/bkn-trace/propagation.json
+++ b/fixtures/bkn-trace/propagation.json
@@ -1,0 +1,57 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "sdk_cli_propagation_http_call",
+  "fixture_type": "propagation",
+  "scenario": "sdk_cli_propagates_trace_context_to_openbkn",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "75020000000000000000000000000002",
+    "bkn.request.id": "req_sdk_cli_0002",
+    "traceparent": "00-75020000000000000000000000000002-7502000000000001-01",
+    "sampling.decision": "sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7502000000000001",
+      "parent_span_id": null,
+      "name": "bkn-sdk.request",
+      "kind": "internal",
+      "bkn.module.name": "sdk-cli",
+      "bkn.operation.name": "sdk.request",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:41:00.000000000Z",
+      "duration_ms": 55
+    },
+    {
+      "span_id": "7502000000000002",
+      "parent_span_id": "7502000000000001",
+      "name": "bkn-sdk.http.call",
+      "kind": "client",
+      "bkn.module.name": "sdk-cli",
+      "bkn.operation.name": "sdk.openbkn.call",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:41:00.004000000Z",
+      "duration_ms": 51
+    }
+  ],
+  "logs": [
+    {
+      "level": "info",
+      "message": "openbkn request completed",
+      "trace_id": "75020000000000000000000000000002",
+      "span_id": "7502000000000002",
+      "bkn.request.id": "req_sdk_cli_0002",
+      "bkn.module.name": "sdk-cli",
+      "bkn.operation.name": "sdk.openbkn.call",
+      "bkn.status": "ok",
+      "bkn.timestamp": "2026-07-21T06:41:00.055000000Z",
+      "bkn.trace.schema.version": "1.0.0",
+      "bkn.tool.name": "context.search_schema"
+    }
+  ],
+  "events": [],
+  "baggage": {
+    "bkn.account.type": "app",
+    "bkn.runtime.env": "test"
+  }
+}

--- a/fixtures/bkn-trace/sampling.json
+++ b/fixtures/bkn-trace/sampling.json
@@ -1,0 +1,51 @@
+{
+  "bkn.trace.schema.version": "1.0.0",
+  "fixture_id": "sdk_cli_sampling_validation_failure",
+  "fixture_type": "sampling",
+  "scenario": "sdk_cli_fixture_validation_failure_forced_sampled",
+  "expected_result": "pass",
+  "trace": {
+    "trace_id": "75030000000000000000000000000003",
+    "bkn.request.id": "req_sdk_cli_0003",
+    "traceparent": "00-75030000000000000000000000000003-7503000000000001-01",
+    "sampling.decision": "forced_sampled"
+  },
+  "spans": [
+    {
+      "span_id": "7503000000000001",
+      "parent_span_id": null,
+      "name": "bkn-cli.command",
+      "kind": "internal",
+      "bkn.module.name": "sdk-cli",
+      "bkn.operation.name": "cli.trace.validate_fixture",
+      "bkn.status": "error",
+      "bkn.timestamp": "2026-07-21T06:42:00.000000000Z",
+      "duration_ms": 17,
+      "error.category": "validation",
+      "error.code": "BKN_TRACE_FIXTURE_INVALID",
+      "error.retryable": false
+    }
+  ],
+  "logs": [
+    {
+      "level": "error",
+      "message": "fixture validation failed",
+      "trace_id": "75030000000000000000000000000003",
+      "span_id": "7503000000000001",
+      "bkn.request.id": "req_sdk_cli_0003",
+      "bkn.module.name": "sdk-cli",
+      "bkn.operation.name": "cli.trace.validate_fixture",
+      "bkn.status": "error",
+      "bkn.timestamp": "2026-07-21T06:42:00.017000000Z",
+      "bkn.trace.schema.version": "1.0.0",
+      "error.category": "validation",
+      "error.code": "BKN_TRACE_FIXTURE_INVALID",
+      "error.retryable": false
+    }
+  ],
+  "events": [],
+  "baggage": {
+    "bkn.account.type": "user",
+    "bkn.runtime.env": "test"
+  }
+}

--- a/src/api/headers.ts
+++ b/src/api/headers.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 OpenBKN. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See the LICENSE file in the project root.
 
+import { serializeBaggage } from "../trace-context.js";
 /** Build request headers with auth + business domain injected. */
 import type { RequestContext } from "../types.js";
 
@@ -8,6 +9,7 @@ export function buildHeaders(
   ctx: RequestContext,
   extra?: Record<string, string>,
 ): Record<string, string> {
+  const baggage = serializeBaggage(ctx.trace?.baggage);
   // Only `authorization` carries the token. A custom header would survive a
   // cross-origin redirect that strips `authorization`, handing the bearer to
   // the redirect target (the download routes follow redirects); bkn-safe
@@ -15,6 +17,14 @@ export function buildHeaders(
   return {
     authorization: `Bearer ${ctx.token}`,
     "x-business-domain": ctx.businessDomain,
+    ...(ctx.trace
+      ? {
+          "bkn-request-id": ctx.trace.requestId,
+          "x-request-id": ctx.trace.requestId,
+          traceparent: ctx.trace.traceparent,
+        }
+      : {}),
+    ...(baggage ? { baggage } : {}),
     ...extra,
   };
 }

--- a/src/bkn-trace/fixture-validate.ts
+++ b/src/bkn-trace/fixture-validate.ts
@@ -1,0 +1,306 @@
+// Copyright (c) 2026 OpenBKN. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the project root.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const CONTRACT_VERSION = "1.0.0";
+const TRACEPARENT_RE = /^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}$/;
+const REQUEST_ID_RE = /^req_[0-9A-Za-z_.-]+$/;
+const RFC3339_NANO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/;
+const ALLOWED_BAGGAGE = new Set(["bkn.account.type", "bkn.runtime.env"]);
+const REQUIRED_LOG_FIELDS = [
+  "trace_id",
+  "span_id",
+  "bkn.request.id",
+  "bkn.module.name",
+  "bkn.operation.name",
+  "bkn.status",
+  "bkn.timestamp",
+  "bkn.trace.schema.version",
+];
+const REQUIRED_SPAN_FIELDS = [
+  "span_id",
+  "name",
+  "bkn.module.name",
+  "bkn.operation.name",
+  "bkn.status",
+  "bkn.timestamp",
+];
+const REQUIRED_EVENT_FIELDS = [
+  "trace_id",
+  "span_id",
+  "bkn.request.id",
+  "bkn.operation.name",
+  "event_id",
+  "event_type",
+  "bkn.trace.schema.version",
+  "observed_at",
+  "emitted_at",
+  "producer_module",
+  "payload",
+];
+const SENSITIVE_PATTERNS = [
+  /authorization/i,
+  /bearer\s+[A-Za-z0-9._-]+/i,
+  /access[_-]?token/i,
+  /api[_-]?key/i,
+  /cookie/i,
+  /\bselect\s+.+\s+from\b/is,
+  /prompt\s*[:=]/i,
+  /https?:\/\/[^\s"']+/i,
+  /[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}/,
+];
+
+export interface FixtureValidationError {
+  code: string;
+  path: string;
+  message: string;
+}
+
+export interface FixtureValidationResult {
+  fixtureId: string;
+  result: "pass" | "fail";
+  contractVersion: string | null;
+  errors: FixtureValidationError[];
+  warnings: string[];
+  expectedResult: "pass" | "fail" | null;
+  expectationMatched: boolean;
+}
+
+export interface FixturePathValidationResult {
+  ok: boolean;
+  results: FixtureValidationResult[];
+}
+
+function err(code: string, path: string, message: string): FixtureValidationError {
+  return { code, path, message };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function jsonFiles(path: string): string[] {
+  const stat = statSync(path);
+  if (stat.isFile()) return [path];
+  return readdirSync(path)
+    .filter((name) => name.endsWith(".json"))
+    .sort()
+    .map((name) => join(path, name));
+}
+
+function validTraceparent(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  const match = TRACEPARENT_RE.exec(value);
+  if (!match) return false;
+  const [, traceId, spanId] = match;
+  return traceId !== "0".repeat(32) && spanId !== "0".repeat(16);
+}
+
+function checkRequired(
+  item: Record<string, unknown>,
+  fields: string[],
+  basePath: string,
+  errors: FixtureValidationError[],
+): void {
+  for (const field of fields) {
+    if (item[field] === undefined || item[field] === "") {
+      errors.push(
+        err(
+          "BKN_TRACE_REQUIRED_FIELD_MISSING",
+          `${basePath}.${field}`,
+          `missing required field ${field}`,
+        ),
+      );
+    }
+  }
+}
+
+function checkTimestamp(value: unknown, path: string, errors: FixtureValidationError[]): void {
+  if (typeof value !== "string" || !RFC3339_NANO_RE.test(value)) {
+    errors.push(err("BKN_TRACE_INVALID_TIMESTAMP", path, "timestamp must be UTC RFC3339Nano"));
+  }
+}
+
+function checkSensitive(value: unknown, path: string, errors: FixtureValidationError[]): void {
+  if (Array.isArray(value)) {
+    value.forEach((child, index) => checkSensitive(child, `${path}[${index}]`, errors));
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, child] of Object.entries(value))
+      checkSensitive(child, `${path}.${key}`, errors);
+    return;
+  }
+  if (typeof value !== "string") return;
+  if (SENSITIVE_PATTERNS.some((pattern) => pattern.test(value))) {
+    errors.push(
+      err(
+        "BKN_TRACE_SENSITIVE_VALUE_LEAKED",
+        path,
+        "sensitive value must be redacted, hashed, or referenced",
+      ),
+    );
+  }
+}
+
+export function validateFixture(data: unknown): FixtureValidationResult {
+  const root = asRecord(data);
+  const errors: FixtureValidationError[] = [];
+  const fixtureId = typeof root.fixture_id === "string" ? root.fixture_id : "<unknown>";
+  const contractVersion =
+    typeof root["bkn.trace.schema.version"] === "string" ? root["bkn.trace.schema.version"] : null;
+
+  if (!contractVersion) {
+    errors.push(
+      err(
+        "BKN_TRACE_SCHEMA_VERSION_MISSING",
+        "$.bkn.trace.schema.version",
+        "missing contract version",
+      ),
+    );
+  } else if (contractVersion !== CONTRACT_VERSION) {
+    errors.push(
+      err(
+        "BKN_TRACE_SCHEMA_VERSION_UNSUPPORTED",
+        "$.bkn.trace.schema.version",
+        `unsupported contract version ${contractVersion}`,
+      ),
+    );
+  }
+
+  const trace = asRecord(root.trace);
+  const traceId = trace.trace_id;
+  const requestId = trace["bkn.request.id"];
+  if (typeof traceId !== "string" || !/^[0-9a-f]{32}$/.test(traceId)) {
+    errors.push(
+      err("BKN_TRACE_REQUIRED_FIELD_MISSING", "$.trace.trace_id", "missing valid trace id"),
+    );
+  }
+  if (typeof requestId !== "string" || !REQUEST_ID_RE.test(requestId)) {
+    errors.push(
+      err(
+        "BKN_TRACE_REQUIRED_FIELD_MISSING",
+        "$.trace.bkn.request.id",
+        "missing valid bkn.request.id",
+      ),
+    );
+  }
+  if (!validTraceparent(trace.traceparent)) {
+    errors.push(err("BKN_TRACE_INVALID_TRACEPARENT", "$.trace.traceparent", "invalid traceparent"));
+  }
+
+  const spans = Array.isArray(root.spans) ? root.spans : [];
+  const spanIds = new Set<string>();
+  spans.forEach((item, index) => {
+    const span = asRecord(item);
+    checkRequired(span, REQUIRED_SPAN_FIELDS, `$.spans[${index}]`, errors);
+    checkTimestamp(span["bkn.timestamp"], `$.spans[${index}].bkn.timestamp`, errors);
+    if (typeof span.span_id === "string") spanIds.add(span.span_id);
+    const parent = span.parent_span_id;
+    if (parent !== null && parent !== undefined && !spanIds.has(String(parent))) {
+      errors.push(
+        err(
+          "BKN_TRACE_ORPHAN_SPAN",
+          `$.spans[${index}].parent_span_id`,
+          "parent span must appear before child span or be represented as a link",
+        ),
+      );
+    }
+  });
+  if (spans.length === 0) {
+    errors.push(err("BKN_TRACE_REQUIRED_FIELD_MISSING", "$.spans", "at least one span required"));
+  }
+
+  const logs = Array.isArray(root.logs) ? root.logs : [];
+  logs.forEach((item, index) => {
+    const log = asRecord(item);
+    checkRequired(log, REQUIRED_LOG_FIELDS, `$.logs[${index}]`, errors);
+    checkTimestamp(log["bkn.timestamp"], `$.logs[${index}].bkn.timestamp`, errors);
+    if (log.trace_id !== traceId || log["bkn.request.id"] !== requestId) {
+      errors.push(
+        err("BKN_TRACE_JOIN_FAILED", `$.logs[${index}]`, "log cannot join trace/request"),
+      );
+    }
+    if (!spanIds.has(String(log.span_id))) {
+      errors.push(
+        err("BKN_TRACE_JOIN_FAILED", `$.logs[${index}].span_id`, "log span_id not found"),
+      );
+    }
+  });
+
+  const events = Array.isArray(root.events) ? root.events : [];
+  events.forEach((item, index) => {
+    const event = asRecord(item);
+    checkRequired(event, REQUIRED_EVENT_FIELDS, `$.events[${index}]`, errors);
+    checkTimestamp(event.observed_at, `$.events[${index}].observed_at`, errors);
+    checkTimestamp(event.emitted_at, `$.events[${index}].emitted_at`, errors);
+    if (event.trace_id !== traceId || event["bkn.request.id"] !== requestId) {
+      errors.push(
+        err("BKN_TRACE_JOIN_FAILED", `$.events[${index}]`, "event cannot join trace/request"),
+      );
+    }
+    if (!spanIds.has(String(event.span_id))) {
+      errors.push(
+        err("BKN_TRACE_JOIN_FAILED", `$.events[${index}].span_id`, "event span_id not found"),
+      );
+    }
+  });
+
+  const baggage = asRecord(root.baggage);
+  for (const key of Object.keys(baggage)) {
+    if (!ALLOWED_BAGGAGE.has(key)) {
+      errors.push(
+        err(
+          "BKN_TRACE_BAGGAGE_FORBIDDEN_FIELD",
+          `$.baggage.${key}`,
+          `baggage field ${key} is forbidden`,
+        ),
+      );
+    }
+  }
+
+  checkSensitive(root, "$", errors);
+  const result: "pass" | "fail" = errors.length > 0 ? "fail" : "pass";
+  const expectedResult =
+    root.expected_result === "pass" || root.expected_result === "fail"
+      ? root.expected_result
+      : null;
+  return {
+    fixtureId,
+    result,
+    contractVersion,
+    errors,
+    warnings: [],
+    expectedResult,
+    expectationMatched: expectedResult === null ? result === "pass" : expectedResult === result,
+  };
+}
+
+export function validateFixturePath(path: string): FixturePathValidationResult {
+  const results = jsonFiles(path).map((file) => {
+    try {
+      return validateFixture(JSON.parse(readFileSync(file, "utf8")));
+    } catch (e) {
+      return {
+        fixtureId: file,
+        result: "fail" as const,
+        contractVersion: null,
+        errors: [
+          err(
+            "BKN_TRACE_FIXTURE_PARSE_FAILED",
+            "$",
+            `failed to parse JSON: ${e instanceof Error ? e.message : String(e)}`,
+          ),
+        ],
+        warnings: [],
+        expectedResult: null,
+        expectationMatched: false,
+      };
+    }
+  });
+  return { ok: results.every((r) => r.expectationMatched), results };
+}

--- a/src/commands/trace.ts
+++ b/src/commands/trace.ts
@@ -5,6 +5,7 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { Command } from "commander";
 import { renderReportMarkdown } from "../bkn-trace/diagnose.js";
+import { validateFixturePath } from "../bkn-trace/fixture-validate.js";
 import { validateSchemaFile } from "../bkn-trace/schema-validate.js";
 import { group } from "../help/grouped-help.js";
 import { printJson } from "../utils/output.js";
@@ -104,6 +105,15 @@ export function traceCommand(): Command {
       const result = validateSchemaFile(file, opts.kind);
       printJson(result, outputOptions(cmd));
       if (!result.valid) process.exitCode = 1;
+    });
+
+  cmd
+    .command("validate-fixture <path>")
+    .description("Validate BKN Trace phase-one fixture JSON files")
+    .action(async (path: string, _opts, cmd: Command) => {
+      const result = validateFixturePath(path);
+      printJson(result, outputOptions(cmd));
+      if (!result.ok) process.exitCode = 1;
     });
 
   return group(cmd, "TRACE AI");

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -1,11 +1,7 @@
 // Copyright (c) 2026 OpenBKN. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See the LICENSE file in the project root.
 
-/**
- * Resolve a full RequestContext from explicit options → env → store.
- * Order: caller options win, then env vars, then the active platform/user
- * in `~/.bkn/`.
- */
+import { createTraceContext } from "../trace-context.js";
 import { type ClientOptions, DEFAULT_BUSINESS_DOMAIN, type RequestContext } from "../types.js";
 import { InputError } from "../utils/errors.js";
 import {
@@ -16,6 +12,12 @@ import {
   usersOfPlatform,
   writeToken,
 } from "./store.js";
+
+/**
+ * Resolve a full RequestContext from explicit options → env → store.
+ * Order: caller options win, then env vars, then the active platform/user
+ * in `~/.bkn/`.
+ */
 
 /** Resolve `--user` to a user id, or explain what is saved instead. */
 function resolveUserId(baseUrl: string, userOrName: string): string {
@@ -84,6 +86,7 @@ export function resolveContext(opts: ClientOptions = {}): RequestContext {
       readPlatformConfig(normalized).businessDomain ??
       DEFAULT_BUSINESS_DOMAIN,
     insecure,
+    trace: createTraceContext(opts.trace),
     ...(refresh ? { refresh } : {}),
   };
 }

--- a/src/resources/trace.ts
+++ b/src/resources/trace.ts
@@ -20,6 +20,7 @@ import {
   buildCasesFromQueries,
   runEvalSet,
 } from "../bkn-trace/eval-set.js";
+import { validateFixturePath } from "../bkn-trace/fixture-validate.js";
 import type { RequestContext } from "../types.js";
 
 async function semanticJudge(
@@ -127,6 +128,8 @@ export function trace(ctx: RequestContext) {
     },
     /** Build eval cases from a loosely-shaped queries object/array. */
     evalSetBuild: (raw: unknown): EvalCase[] => buildCasesFromQueries(raw),
+    /** Validate BKN Trace phase-one fixture files or directories. */
+    validateFixture: (path: string) => validateFixturePath(path),
     /**
      * Run an eval set against an agent: each case's query is sent to the agent,
      * the resulting trace is fetched, and assertions are checked. `llm` enables

--- a/src/trace-context.ts
+++ b/src/trace-context.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 OpenBKN. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the project root.
+
+import { randomBytes, randomUUID } from "node:crypto";
+import type { TraceContext, TraceContextOptions } from "./types.js";
+
+const TRACEPARENT_RE = /^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}$/;
+const REQUEST_ID_RE = /^req_[0-9A-Za-z_.-]+$/;
+const ALLOWED_BAGGAGE = new Set(["bkn.account.type", "bkn.runtime.env"]);
+
+export function isValidRequestId(value: string | undefined): value is string {
+  return typeof value === "string" && REQUEST_ID_RE.test(value);
+}
+
+export function isValidTraceparent(value: string | undefined): value is string {
+  if (typeof value !== "string") return false;
+  const match = TRACEPARENT_RE.exec(value);
+  if (!match) return false;
+  const [, traceId, spanId] = match;
+  return traceId !== "0".repeat(32) && spanId !== "0".repeat(16);
+}
+
+export function createTraceContext(opts: TraceContextOptions = {}): TraceContext {
+  const requestId = isValidRequestId(opts.requestId) ? opts.requestId : `req_${randomUUID()}`;
+  const traceparent = isValidTraceparent(opts.traceparent) ? opts.traceparent : newTraceparent();
+  const baggage = filterBaggage(opts.baggage);
+  return {
+    requestId,
+    traceparent,
+    ...(Object.keys(baggage).length > 0 ? { baggage } : {}),
+  };
+}
+
+export function filterBaggage(baggage: Record<string, string> | undefined): Record<string, string> {
+  const filtered: Record<string, string> = {};
+  for (const [key, value] of Object.entries(baggage ?? {})) {
+    if (ALLOWED_BAGGAGE.has(key) && value !== "") filtered[key] = value;
+  }
+  return filtered;
+}
+
+export function serializeBaggage(baggage: Record<string, string> | undefined): string | undefined {
+  const filtered = filterBaggage(baggage);
+  const entries = Object.entries(filtered);
+  if (entries.length === 0) return undefined;
+  return entries.map(([key, value]) => `${key}=${encodeURIComponent(value)}`).join(",");
+}
+
+function newTraceparent(): string {
+  return `00-${randomHex(16)}-${randomHex(8)}-01`;
+}
+
+function randomHex(bytes: number): string {
+  let value = randomBytes(bytes).toString("hex");
+  while (/^0+$/.test(value)) value = randomBytes(bytes).toString("hex");
+  return value;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,8 @@ export interface ClientOptions {
   businessDomain?: string;
   /** Skip TLS verification (dev / self-signed only). */
   insecure?: boolean;
+  /** Optional BKN Trace phase-one context for request correlation. */
+  trace?: TraceContextOptions;
 }
 
 /** Fully resolved request context — every field is known. */
@@ -27,6 +29,8 @@ export interface RequestContext {
   token: string;
   businessDomain: string;
   insecure: boolean;
+  /** Stable per-client BKN Trace context propagated on outbound requests. */
+  trace?: TraceContext;
   /**
    * Stored-credential refresh: on a 401, swap the refresh token for a fresh
    * access token, persist it, and retry once. Absent for explicit `--token`/env.
@@ -36,6 +40,21 @@ export interface RequestContext {
     clientId?: string;
     persist: (tokens: RefreshableTokens) => void;
   };
+}
+
+export interface TraceContextOptions {
+  /** OpenBKN request id. Generated as `req_<uuid>` when omitted or invalid. */
+  requestId?: string;
+  /** W3C Trace Context header. Generated when omitted or invalid. */
+  traceparent?: string;
+  /** Baggage values are allowlisted before propagation. */
+  baggage?: Record<string, string>;
+}
+
+export interface TraceContext {
+  requestId: string;
+  traceparent: string;
+  baggage?: Record<string, string>;
 }
 
 export const DEFAULT_BUSINESS_DOMAIN = "bd_public";

--- a/test/unit/fixture-validate.test.ts
+++ b/test/unit/fixture-validate.test.ts
@@ -1,0 +1,133 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { validateFixturePath } from "../../src/bkn-trace/fixture-validate.js";
+
+const temps: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "bkn-trace-fixture-"));
+  temps.push(dir);
+  return dir;
+}
+
+function writeFixture(name: string, fixture: unknown): string {
+  const dir = tempDir();
+  const file = join(dir, name);
+  writeFileSync(file, JSON.stringify(fixture, null, 2));
+  return file;
+}
+
+function baseFixture(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const fixture = {
+    "bkn.trace.schema.version": "1.0.0",
+    fixture_id: "fixture_positive",
+    fixture_type: "positive",
+    scenario: "minimal",
+    expected_result: "pass",
+    trace: {
+      trace_id: "11111111111111111111111111111111",
+      "bkn.request.id": "req_fixture_001",
+      traceparent: "00-11111111111111111111111111111111-2222222222222222-01",
+    },
+    spans: [
+      {
+        span_id: "2222222222222222",
+        parent_span_id: null,
+        name: "sdk-cli.request",
+        "bkn.module.name": "sdk-cli",
+        "bkn.operation.name": "sdk.request",
+        "bkn.status": "ok",
+        "bkn.timestamp": "2026-07-21T07:00:00.000000000Z",
+      },
+    ],
+    logs: [
+      {
+        level: "info",
+        message: "request completed",
+        trace_id: "11111111111111111111111111111111",
+        span_id: "2222222222222222",
+        "bkn.request.id": "req_fixture_001",
+        "bkn.module.name": "sdk-cli",
+        "bkn.operation.name": "sdk.request",
+        "bkn.status": "ok",
+        "bkn.timestamp": "2026-07-21T07:00:00.001000000Z",
+        "bkn.trace.schema.version": "1.0.0",
+      },
+    ],
+    events: [],
+    baggage: { "bkn.account.type": "app" },
+  };
+  return { ...fixture, ...overrides };
+}
+
+afterEach(() => {
+  for (const dir of temps.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("validateFixturePath", () => {
+  it("passes a positive fixture when the actual validation passes", () => {
+    const file = writeFixture("positive.json", baseFixture());
+    const result = validateFixturePath(file);
+    expect(result.ok).toBe(true);
+    expect(result.results[0]).toMatchObject({ fixtureId: "fixture_positive", result: "pass" });
+  });
+
+  it("passes a negative fixture when the actual validation fails", () => {
+    const file = writeFixture(
+      "negative.json",
+      baseFixture({
+        fixture_id: "fixture_negative_baggage",
+        fixture_type: "negative",
+        expected_result: "fail",
+        baggage: { "bkn.account.id": "forbidden" },
+      }),
+    );
+    const result = validateFixturePath(file);
+    expect(result.ok).toBe(true);
+    expect(result.results[0]?.result).toBe("fail");
+    expect(result.results[0]?.errors[0]?.code).toBe("BKN_TRACE_BAGGAGE_FORBIDDEN_FIELD");
+  });
+
+  it("fails the command result when a negative fixture unexpectedly passes", () => {
+    const file = writeFixture(
+      "negative.json",
+      baseFixture({
+        fixture_id: "fixture_negative_wrong",
+        fixture_type: "negative",
+        expected_result: "fail",
+      }),
+    );
+    const result = validateFixturePath(file);
+    expect(result.ok).toBe(false);
+    expect(result.results[0]?.expectationMatched).toBe(false);
+  });
+
+  it("validates every JSON fixture in a directory", () => {
+    const dir = tempDir();
+    writeFileSync(join(dir, "a.json"), JSON.stringify(baseFixture()));
+    writeFileSync(
+      join(dir, "b.json"),
+      JSON.stringify(
+        baseFixture({
+          fixture_id: "fixture_sensitive",
+          fixture_type: "negative",
+          expected_result: "fail",
+          logs: [
+            {
+              ...(baseFixture().logs as Record<string, unknown>[])[0],
+              message: "executed select token from secret_table",
+            },
+          ],
+        }),
+      ),
+    );
+    const result = validateFixturePath(dir);
+    expect(result.ok).toBe(true);
+    expect(result.results.map((r) => r.fixtureId).sort()).toEqual([
+      "fixture_positive",
+      "fixture_sensitive",
+    ]);
+  });
+});

--- a/test/unit/trace-context.test.ts
+++ b/test/unit/trace-context.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { buildHeaders } from "../../src/api/headers.js";
+import { resolveContext } from "../../src/config/resolve.js";
+import type { RequestContext } from "../../src/types.js";
+
+const ctx: RequestContext = {
+  baseUrl: "https://demo.example.com",
+  token: "SECRET",
+  businessDomain: "bd_public",
+  insecure: false,
+  trace: {
+    requestId: "req_test_001",
+    traceparent: "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
+    baggage: {
+      "bkn.account.type": "app",
+      "bkn.account.id": "forbidden",
+      "bkn.runtime.env": "test",
+    },
+  },
+};
+
+describe("BKN Trace context headers", () => {
+  it("injects request id and traceparent while filtering forbidden baggage", () => {
+    const headers = buildHeaders(ctx);
+    expect(headers["bkn-request-id"]).toBe("req_test_001");
+    expect(headers.traceparent).toBe("00-1234567890abcdef1234567890abcdef-1234567890abcdef-01");
+    expect(headers.baggage).toBe("bkn.account.type=app,bkn.runtime.env=test");
+  });
+
+  it("lets explicit safe extra headers override generated trace context", () => {
+    const headers = buildHeaders(ctx, {
+      "bkn-request-id": "req_override_002",
+      traceparent: "00-fedcba0987654321fedcba0987654321-fedcba0987654321-01",
+    });
+    expect(headers["bkn-request-id"]).toBe("req_override_002");
+    expect(headers.traceparent).toBe("00-fedcba0987654321fedcba0987654321-fedcba0987654321-01");
+  });
+});
+
+describe("resolveContext trace defaults", () => {
+  it("generates a stable request id and traceparent for a client context", () => {
+    const resolved = resolveContext({ baseUrl: "https://demo.example.com", token: "SECRET" });
+    expect(resolved.trace?.requestId).toMatch(/^req_[0-9A-Za-z_.-]+$/);
+    expect(resolved.trace?.traceparent).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-01$/);
+    expect(buildHeaders(resolved)["bkn-request-id"]).toBe(resolved.trace?.requestId);
+  });
+
+  it("accepts a caller supplied request id and valid traceparent", () => {
+    const resolved = resolveContext({
+      baseUrl: "https://demo.example.com",
+      token: "SECRET",
+      trace: {
+        requestId: "req_external_003",
+        traceparent: "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+      },
+    });
+    expect(resolved.trace?.requestId).toBe("req_external_003");
+    expect(resolved.trace?.traceparent).toBe(
+      "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+    );
+  });
+});


### PR DESCRIPTION
## 背景

接入 BKN Trace 阶段一，确保 SDK/CLI 作为 OpenBKN 内外部调用入口时能统一注入 request id、传播 traceparent，并提供 fixture 校验命令。

## 变更

- 增加 SDK `TRACE.md`。
- 增加 `fixtures/bkn-trace/*.json`。
- SDK/CLI 注入 `bkn-request-id`。
- 透传合法 `traceparent`。
- baggage 只允许 allowlist 字段。
- 增加 CLI fixture validator：`trace validate-fixture`。

## 验证

- `npm run lint`
- `npm test`
- `npm run build`
- `node dist/cli.js trace validate-fixture fixtures/bkn-trace --json`
- `python3 /path/to/bkn-docs/docs/foundry/bkn-trace/validation/validate_phase1_fixture.py fixtures/bkn-trace --pretty`

## GWT 覆盖

- GWT-01 无上游上下文
- GWT-02 可信上游 Trace Context
- GWT-04 非法 traceparent
- GWT-05 baggage 违规
- GWT-14 版本兼容
- GWT-16 第三方 Agent 调用 OpenBKN 后生成业务结论

## Known gaps

- 进入主线后继续补 SDK helper 与第三方/BYO Agent 可运行 demo。
