### PR TITLE
fix(cli): let list commands page past backend default limits

### DIFF
--- a/skills/openbkn/references/dataflow.md
+++ b/skills/openbkn/references/dataflow.md
@@ -2,7 +2,7 @@
 
 | Command | Notes |
 |---------|-------|
-| `list` / `runs <dagId> [--since]` / `logs <dagId> <instanceId>` | DAGs / run history / step logs. |
+| `list` / `runs <dagId> [--since] [--limit n] [--page n]` / `logs <dagId> <instanceId>` | DAGs / run history / step logs. `runs` backend defaults to 20; pass `--limit` to page further. |
 | `run <dagId> --url <remote> --name <file>` | Trigger with a remote file. |
 | `create --body <json>` | Create a DAG from a full document (title + steps required). |
 | `templates` | List bundled dataset/bkn/dataflow templates. |

--- a/skills/openbkn/references/toolbox.md
+++ b/skills/openbkn/references/toolbox.md
@@ -8,5 +8,5 @@
 | `toolbox export <id> -o box.adp [--type toolbox|mcp|operator]` | Export config (impex, raw bytes). |
 | `toolbox import <file> [--type …]` | Import an exported `.adp` (multipart). |
 | `tool upload <openapi-file> --toolbox <id> [--metadata-type openapi]` | Upload a tool spec. |
-| `tool list --toolbox <id>` / `tool set-status …` | List / enable-disable. |
+| `tool list --toolbox <id> [--limit n] [--page n] [--all]` / `tool set-status …` | List / enable-disable. `tool list` backend defaults to 10; `--all` returns every tool. |
 | `tool execute|debug <tool-id> --toolbox <id> [--header/--query/--path/--body JSON]` | Invoke (debug bypasses the enabled gate). |

--- a/skills/openbkn/references/vega.md
+++ b/skills/openbkn/references/vega.md
@@ -3,7 +3,7 @@
 | Command | Notes |
 |---------|-------|
 | `catalog list [--limit] [--offset]` / `catalog get <id>` | Catalogs. |
-| `catalog resources <id> [--category table]` | Resources under a catalog. |
+| `catalog resources <id> [--category table] [--limit n] [--offset n]` | Resources under a catalog. Backend defaults to 20; `--limit -1` fetches all. |
 | `catalog health <ids...>` | Health-status for one or more catalogs. |
 | `connector-type list` / `connector-type get <type>` | Available connector types. |
 | `sql --query "<sql>"` / `sql -d <json>` | Run SQL (MySQL/MariaDB/PostgreSQL) or OpenSearch DSL directly against a data source. Table = `{{<resource-id>}}`; `--resource-type` optional. See [§ vega sql](#vega-sql--run-sql--dsl-against-a-data-source). |

--- a/src/api/dataflow.ts
+++ b/src/api/dataflow.ts
@@ -72,6 +72,8 @@ export async function executeDataflow(
 
 export interface ListRunsOptions {
   since?: string;
+  page?: number;
+  limit?: number;
 }
 
 export function listDataflowRuns(
@@ -79,8 +81,14 @@ export function listDataflowRuns(
   dagId: string,
   opts: ListRunsOptions = {},
 ): Promise<unknown> {
+  // Backend (listDagInstanceV2) defaults to limit=20 when unset; pass an explicit
+  // limit to page past the first 20 runs.
   return request(ctx, `${BASE}/dag/${encodeURIComponent(dagId)}/results`, {
-    query: { since: opts.since || undefined },
+    query: {
+      since: opts.since || undefined,
+      page: opts.page,
+      limit: opts.limit && opts.limit > 0 ? opts.limit : undefined,
+    },
   });
 }
 

--- a/src/api/resources.ts
+++ b/src/api/resources.ts
@@ -84,7 +84,13 @@ export function listResources(
       category: opts.category || undefined,
       status: opts.status || undefined,
       database: opts.database || undefined,
-      limit: opts.limit && opts.limit > 0 ? opts.limit : undefined,
+      // Same `/resources` endpoint as `catalogResources`: limit=-1 (NO_LIMIT)
+      // fetches every row; any other non-positive/invalid value falls back to
+      // the backend default.
+      limit:
+        Number.isFinite(opts.limit) && (opts.limit! > 0 || opts.limit === -1)
+          ? opts.limit
+          : undefined,
       offset: opts.offset,
       sort: opts.sort,
       direction: opts.direction,

--- a/src/api/toolboxes.ts
+++ b/src/api/toolboxes.ts
@@ -117,7 +117,7 @@ export function listTools(
   return request(ctx, `${PATH}/${encodeURIComponent(boxId)}/tools/list`, {
     query: {
       page: opts.page,
-      page_size: opts.pageSize,
+      page_size: Number.isFinite(opts.pageSize) && opts.pageSize! > 0 ? opts.pageSize : undefined,
       all: opts.all ? "true" : undefined,
     },
   });

--- a/src/api/toolboxes.ts
+++ b/src/api/toolboxes.ts
@@ -101,9 +101,26 @@ export function listToolboxes(
   });
 }
 
-/** List tools inside a toolbox. */
-export function listTools(ctx: RequestContext, boxId: string): Promise<unknown> {
-  return request(ctx, `${PATH}/${encodeURIComponent(boxId)}/tools/list`);
+export interface ListToolsOptions {
+  page?: number;
+  pageSize?: number;
+  all?: boolean;
+}
+
+/** List tools inside a toolbox. Backend defaults to page_size=10 (max 100); pass
+ *  `all: true` to return every tool regardless of page size. */
+export function listTools(
+  ctx: RequestContext,
+  boxId: string,
+  opts: ListToolsOptions = {},
+): Promise<unknown> {
+  return request(ctx, `${PATH}/${encodeURIComponent(boxId)}/tools/list`, {
+    query: {
+      page: opts.page,
+      page_size: opts.pageSize,
+      all: opts.all ? "true" : undefined,
+    },
+  });
 }
 
 export interface CreateToolboxOptions {

--- a/src/api/vega.ts
+++ b/src/api/vega.ts
@@ -308,7 +308,8 @@ export function listCatalogResources(
     query: {
       catalog_id: id,
       category: category || undefined,
-      limit: limit !== undefined && limit !== 0 ? limit : undefined,
+      // limit=-1 (NO_LIMIT) fetches all; NaN / 0 fall back to the backend default.
+      limit: Number.isFinite(limit) && (limit! > 0 || limit === -1) ? limit : undefined,
       offset: offset || undefined,
     },
   });

--- a/src/api/vega.ts
+++ b/src/api/vega.ts
@@ -297,11 +297,20 @@ export function listCatalogResources(
   ctx: RequestContext,
   id: string,
   category?: string,
+  limit?: number,
+  offset?: number,
 ): Promise<unknown> {
   // The backend has no `/catalogs/:id/resources` route — resources are listed
-  // via `/resources?catalog_id=…` (same endpoint as `resource list`).
+  // via `/resources?catalog_id=…` (same endpoint as `resource list`). Without an
+  // explicit `limit` the backend defaults to DEFAULT_LIMIT=20 (range [1,1000]);
+  // pass limit=-1 (NO_LIMIT) to fetch every resource.
   return request(ctx, `${VEGA_BASE}/resources`, {
-    query: { catalog_id: id, category: category || undefined },
+    query: {
+      catalog_id: id,
+      category: category || undefined,
+      limit: limit !== undefined && limit !== 0 ? limit : undefined,
+      offset: offset || undefined,
+    },
   });
 }
 

--- a/src/commands/dataflow.ts
+++ b/src/commands/dataflow.ts
@@ -25,7 +25,7 @@ export function dataflowCommand(): Command {
     .description("List run records for one dataflow")
     .option("--since <date>", "filter runs since a date")
     .option("--limit <n>", "page size (backend default 20)", int)
-    .option("--page <n>", "page (0-based)", int, 0)
+    .option("--page <n>", "page (0-based; backend default 0)", int)
     .action(async (dagId: string, opts, cmd: Command) => {
       printJson(
         await clientFrom(cmd).dataflows.runs(dagId, {

--- a/src/commands/dataflow.ts
+++ b/src/commands/dataflow.ts
@@ -24,9 +24,15 @@ export function dataflowCommand(): Command {
     .command("runs <dagId>")
     .description("List run records for one dataflow")
     .option("--since <date>", "filter runs since a date")
+    .option("--limit <n>", "page size (backend default 20)", int)
+    .option("--page <n>", "page (0-based)", int, 0)
     .action(async (dagId: string, opts, cmd: Command) => {
       printJson(
-        await clientFrom(cmd).dataflows.runs(dagId, { since: opts.since }),
+        await clientFrom(cmd).dataflows.runs(dagId, {
+          since: opts.since,
+          page: opts.page,
+          limit: opts.limit,
+        }),
         outputOptions(cmd),
       );
     });

--- a/src/commands/toolbox.ts
+++ b/src/commands/toolbox.ts
@@ -100,7 +100,7 @@ export function toolCommand(): Command {
     .description("List tools in a toolbox")
     .requiredOption("--toolbox <box-id>", "toolbox id")
     .option("--limit <n>", "page size (backend default 10, max 100)", int)
-    .option("--page <n>", "page (1-based)", int, 1)
+    .option("--page <n>", "page (1-based; backend default 1)", int)
     .option("--all", "return every tool, ignoring page size")
     .action(async (opts, cmd: Command) => {
       printJson(

--- a/src/commands/toolbox.ts
+++ b/src/commands/toolbox.ts
@@ -99,8 +99,18 @@ export function toolCommand(): Command {
     .command("list")
     .description("List tools in a toolbox")
     .requiredOption("--toolbox <box-id>", "toolbox id")
+    .option("--limit <n>", "page size (backend default 10, max 100)", int)
+    .option("--page <n>", "page (1-based)", int, 1)
+    .option("--all", "return every tool, ignoring page size")
     .action(async (opts, cmd: Command) => {
-      printJson(await clientFrom(cmd).toolboxes.tools(opts.toolbox), outputOptions(cmd));
+      printJson(
+        await clientFrom(cmd).toolboxes.tools(opts.toolbox, {
+          page: opts.page,
+          pageSize: opts.limit,
+          all: opts.all,
+        }),
+        outputOptions(cmd),
+      );
     });
 
   cmd

--- a/src/commands/vega.ts
+++ b/src/commands/vega.ts
@@ -72,8 +72,13 @@ export function vegaCommand(): Command {
     .command("resources <id>")
     .description("List resources under a catalog")
     .option("--category <c>", "filter by category (e.g. table)")
+    .option("--limit <n>", "page size (backend default 20, max 1000; -1 = all)", int)
+    .option("--offset <n>", "page offset", int, 0)
     .action(async (id: string, opts, cmd: Command) => {
-      printJson(await clientFrom(cmd).vega.catalogResources(id, opts.category), outputOptions(cmd));
+      printJson(
+        await clientFrom(cmd).vega.catalogResources(id, opts.category, opts.limit, opts.offset),
+        outputOptions(cmd),
+      );
     });
   catalog
     .command("health <ids...>")

--- a/src/resources/toolboxes.ts
+++ b/src/resources/toolboxes.ts
@@ -8,6 +8,7 @@ import {
   type CreateToolboxOptions,
   type ImpexType,
   type ListToolboxesOptions,
+  type ListToolsOptions,
   type ToolInvokeEnvelope,
   createToolbox,
   debugTool,
@@ -26,7 +27,7 @@ import type { RequestContext } from "../types.js";
 export function toolboxes(ctx: RequestContext) {
   return {
     list: (opts?: ListToolboxesOptions) => listToolboxes(ctx, opts),
-    tools: (boxId: string) => listTools(ctx, boxId),
+    tools: (boxId: string, opts?: ListToolsOptions) => listTools(ctx, boxId, opts),
     create: (opts: CreateToolboxOptions) => createToolbox(ctx, opts),
     delete: (boxId: string) => deleteToolbox(ctx, boxId),
     publish: (boxId: string) => setToolboxStatus(ctx, boxId, "published"),

--- a/src/resources/vega.ts
+++ b/src/resources/vega.ts
@@ -49,7 +49,8 @@ export function vega(ctx: RequestContext) {
     deleteCatalog: (id: string) => deleteCatalog(ctx, id),
     testCatalogConnection: (id: string) => testCatalogConnection(ctx, id),
     discoverCatalog: (id: string, wait = false) => discoverCatalog(ctx, id, wait),
-    catalogResources: (id: string, category?: string) => listCatalogResources(ctx, id, category),
+    catalogResources: (id: string, category?: string, limit?: number, offset?: number) =>
+      listCatalogResources(ctx, id, category, limit, offset),
     catalogHealth: (ids: string[]) => catalogHealthStatus(ctx, ids),
     connectorTypes: () => listConnectorTypes(ctx),
     connectorType: (type: string) => getConnectorType(ctx, type),

--- a/test/unit/dataflow.test.ts
+++ b/test/unit/dataflow.test.ts
@@ -37,8 +37,15 @@ describe("dataflow read endpoints (automation v2)", () => {
     await listDataflowRuns(ctx, "dag 1");
     const u = url(f);
     expect(u.pathname).toBe("/api/automation/v2/dag/dag%201/results");
-    // No explicit limit → backend default (20) applies.
+    // No explicit limit/page → backend defaults (limit=20, page=0) apply.
     expect(u.searchParams.has("limit")).toBe(false);
+    expect(u.searchParams.has("page")).toBe(false);
+  });
+
+  it("runs drops a NaN limit (never sends limit=NaN)", async () => {
+    const f = mockFetch();
+    await listDataflowRuns(ctx, "d1", { limit: Number.NaN });
+    expect(url(f).searchParams.has("limit")).toBe(false);
   });
 
   it("runs forwards page/limit to page past the default 20", async () => {

--- a/test/unit/dataflow.test.ts
+++ b/test/unit/dataflow.test.ts
@@ -35,7 +35,18 @@ describe("dataflow read endpoints (automation v2)", () => {
   it("runs hits /dag/{id}/results", async () => {
     const f = mockFetch();
     await listDataflowRuns(ctx, "dag 1");
-    expect(url(f).pathname).toBe("/api/automation/v2/dag/dag%201/results");
+    const u = url(f);
+    expect(u.pathname).toBe("/api/automation/v2/dag/dag%201/results");
+    // No explicit limit → backend default (20) applies.
+    expect(u.searchParams.has("limit")).toBe(false);
+  });
+
+  it("runs forwards page/limit to page past the default 20", async () => {
+    const f = mockFetch();
+    await listDataflowRuns(ctx, "d1", { page: 2, limit: 100 });
+    const u = url(f);
+    expect(u.searchParams.get("page")).toBe("2");
+    expect(u.searchParams.get("limit")).toBe("100");
   });
 
   it("logs hits /dag/{id}/result/{instance} with paging", async () => {

--- a/test/unit/resources.test.ts
+++ b/test/unit/resources.test.ts
@@ -62,6 +62,18 @@ describe("listResources", () => {
     expect(url.searchParams.get("sort")).toBe("name");
     expect(url.searchParams.get("direction")).toBe("asc");
   });
+
+  it("forwards limit=-1 (NO_LIMIT) to fetch every row", async () => {
+    const f = mockFetch();
+    await listResources(ctx, { datasourceId: "ds-1", limit: -1 });
+    expect(new URL(firstCall(f)[0]).searchParams.get("limit")).toBe("-1");
+  });
+
+  it("drops non-finite / zero limit so the backend default applies", async () => {
+    const f = mockFetch();
+    await listResources(ctx, { limit: Number.NaN });
+    expect(new URL(firstCall(f)[0]).searchParams.has("limit")).toBe(false);
+  });
 });
 
 describe("updateResource/configureResourceIndex", () => {

--- a/test/unit/toolboxes.test.ts
+++ b/test/unit/toolboxes.test.ts
@@ -36,9 +36,16 @@ describe("toolbox endpoints (tool-box)", () => {
     await listTools(ctx, "box 1");
     const u = url(f);
     expect(u.pathname).toBe("/api/agent-operator-integration/v1/tool-box/box%201/tools/list");
-    // No explicit page_size → backend default (10) applies.
+    // No explicit page/page_size → backend defaults (page=1, page_size=10) apply.
+    expect(u.searchParams.has("page")).toBe(false);
     expect(u.searchParams.has("page_size")).toBe(false);
     expect(u.searchParams.has("all")).toBe(false);
+  });
+
+  it("tools list drops a NaN/zero page_size (never sends page_size=NaN)", async () => {
+    const f = mockFetch();
+    await listTools(ctx, "b1", { pageSize: Number.NaN });
+    expect(url(f).searchParams.has("page_size")).toBe(false);
   });
 
   it("tools list forwards all=true to bypass the default page size", async () => {

--- a/test/unit/toolboxes.test.ts
+++ b/test/unit/toolboxes.test.ts
@@ -34,6 +34,18 @@ describe("toolbox endpoints (tool-box)", () => {
   it("tools list hits /tool-box/{id}/tools/list", async () => {
     const f = mockFetch();
     await listTools(ctx, "box 1");
-    expect(url(f).pathname).toBe("/api/agent-operator-integration/v1/tool-box/box%201/tools/list");
+    const u = url(f);
+    expect(u.pathname).toBe("/api/agent-operator-integration/v1/tool-box/box%201/tools/list");
+    // No explicit page_size → backend default (10) applies.
+    expect(u.searchParams.has("page_size")).toBe(false);
+    expect(u.searchParams.has("all")).toBe(false);
+  });
+
+  it("tools list forwards all=true to bypass the default page size", async () => {
+    const f = mockFetch();
+    await listTools(ctx, "b1", { all: true, pageSize: 50 });
+    const u = url(f);
+    expect(u.searchParams.get("all")).toBe("true");
+    expect(u.searchParams.get("page_size")).toBe("50");
   });
 });

--- a/test/unit/vega.test.ts
+++ b/test/unit/vega.test.ts
@@ -61,6 +61,12 @@ describe("vega uses the vega-backend base path", () => {
     expect(u.searchParams.get("offset")).toBe("40");
   });
 
+  it("catalogResources drops a NaN limit (never sends limit=NaN)", async () => {
+    const f = mockFetch();
+    await listCatalogResources(ctx, "c-1", undefined, Number.NaN);
+    expect(new URL(firstCall(f)[0]).searchParams.has("limit")).toBe(false);
+  });
+
   it("catalogHealthStatus joins ids", async () => {
     const f = mockFetch();
     await catalogHealthStatus(ctx, ["a", "b"]);

--- a/test/unit/vega.test.ts
+++ b/test/unit/vega.test.ts
@@ -49,6 +49,16 @@ describe("vega uses the vega-backend base path", () => {
     expect(u.pathname).toBe("/api/vega-backend/v1/resources");
     expect(u.searchParams.get("catalog_id")).toBe("c-1");
     expect(u.searchParams.get("category")).toBe("table");
+    // No explicit limit → backend applies its own default (DEFAULT_LIMIT=20).
+    expect(u.searchParams.has("limit")).toBe(false);
+  });
+
+  it("catalogResources forwards limit/offset (limit=-1 fetches all)", async () => {
+    const f = mockFetch();
+    await listCatalogResources(ctx, "c-1", undefined, -1, 40);
+    const u = new URL(firstCall(f)[0]);
+    expect(u.searchParams.get("limit")).toBe("-1");
+    expect(u.searchParams.get("offset")).toBe("40");
   });
 
   it("catalogHealthStatus joins ids", async () => {


### PR DESCRIPTION
## Problem

`openbkn vega catalog resources <id>` only ever returned 20 rows. Root cause: the command sends `GET /resources?catalog_id=…` with **no** `limit`, so the vega backend applies its own `DEFAULT_LIMIT=20` and silently truncates. `--full` only controls column display, not row count — there was no way to page past the default.

Audited every list command against the kweaver backend handlers. Found **two more** of the same class where the CLI cannot override the backend default page size:

| Command | Backend default | Source |
|---|---|---|
| `vega catalog resources <id>` | 20 | `DEFAULT_LIMIT` (vega-backend) |
| `dataflow runs <dagId>` | 20 | `listDagInstanceV2` |
| `tool list --toolbox <id>` | 10 | `QueryToolListReq.PageSize` |

Verified OK (already pageable or not paginated): `vega catalog list`, `resource list`, `skill list/market`, `agent list/personal/template`, `model list`, `toolbox list`, KN schema lists (`limit=-1` = all), `dataflow list` (`limit=-1`), `bkn resources` (unpaginated), instance/action/metric queries (body passthrough), semantic/trace search (own size params), context-loader MCP listings.

## Fix

Forward pagination through the api + resource + command layers:

- `vega catalog resources` → `--limit` / `--offset` (`--limit -1` fetches all via backend `NO_LIMIT`).
- `dataflow runs` → `--limit` / `--page`.
- `tool list` → `--limit` / `--page` / `--all` (`all=true` bypasses page size).

Default behavior is unchanged (no `limit` sent → backend default), so this is additive.

## Tests

Unit tests for each: the default request omits the limit param, and the new flags are forwarded. `npm run ci` green (lint + 199 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)