### PR TITLE
feat(trace): add evidence event emit helper

### DIFF
--- a/TRACE.md
+++ b/TRACE.md
@@ -1,8 +1,8 @@
 # bkn-sdk / openbkn CLI Trace Contract
 
-> Status: phase-one module contract  
-> Contract version: `bkn.trace.schema.version=1.0.0`  
-> Reference: `bkn-docs/docs/foundry/bkn-trace/design/阶段一：OpenBKN 可观测记录规范与 Trace Context 基线.md`
+> Status: phase-two helper baseline  
+> Contract version: `bkn.trace.schema.version=1.0.0` for phase-one fixture validation; `2.0.0` for evidence event emission  
+> Reference: `bkn-docs/docs/foundry/bkn-trace/design/阶段一：OpenBKN 可观测记录规范与 Trace Context 基线.md`, `bkn-docs/docs/foundry/bkn-trace/design/阶段二：证据引用采集与 BKN Trace 核心能力开发计划.md`
 
 ## Module
 
@@ -11,7 +11,7 @@
 - service identity: SDK / CLI caller
 - runtime: TypeScript / Node.js
 - repository path: `bkn-sdk`
-- contract version: `1.0.0`
+- contract version: `1.0.0` for trace context / fixture validation, `2.0.0` for evidence ingestion
 
 ## Entry Operations
 
@@ -21,6 +21,7 @@
 | `sdk.openbkn.call` | SDK HTTP request to OpenBKN | `traceparent`, `bkn-request-id` | none in phase one | none in phase one |
 | `cli.command` | `openbkn` command invocation | optional caller trace context | none in phase one | none in phase one |
 | `cli.trace.validate_fixture` | fixture validation command or equivalent | local request context | none in phase one | validation result output |
+| `cli.trace.evidence.emit` | `openbkn trace evidence emit <file>` | evidence batch trace context | none | server-side `claim.created` / `evidence.refs.created` / `business.refs.resolved` ingestion |
 
 ## Inbound Context
 
@@ -34,6 +35,7 @@
 | target | protocol | propagated fields | baggage policy | timeout | retry |
 | --- | --- | --- | --- | --- | --- |
 | OpenBKN APIs | HTTP | `traceparent`, `bkn-request-id`, `x-request-id` | allowlist-only baggage | existing request timeout | existing refresh/retry policy |
+| BKN Trace evidence ingestion | HTTP | `traceparent`, `bkn-request-id`, `x-request-id`; evidence batch carries its own `trace` and `events` | allowlist-only baggage | existing request timeout | existing refresh/retry policy |
 | Raw call passthrough | HTTP | generated context plus explicit caller headers | allowlist-only generated baggage; caller extra headers can override deliberately | `RawCallOptions.timeoutMs` | existing refresh/retry policy |
 
 ## Logs
@@ -46,7 +48,12 @@ SDK/CLI does not start OpenTelemetry spans in phase one. It injects trace contex
 
 ## Events
 
-No BKN Trace event envelope is emitted by SDK/CLI in phase one. Fixture validation output acts as the local contract proof until the SDK exposes `openbkn trace contract validate`.
+SDK/CLI now exposes a phase-two submit helper for event batches:
+
+- SDK: `client.trace.emitEvidenceEvents(body)`
+- CLI: `openbkn trace evidence emit <file>`
+
+The SDK does not synthesize evidence events automatically. Callers must provide a `2.0.0` batch containing `trace` and `events`, and the server validates `claim.created`, `evidence.refs.created`, and `business.refs.resolved`.
 
 ## Sensitive Data Rules
 
@@ -66,6 +73,7 @@ No BKN Trace event envelope is emitted by SDK/CLI in phase one. Fixture validati
 | fixture or test | path | purpose | expected result |
 | --- | --- | --- | --- |
 | unit | `test/unit/trace-context.test.ts` | generated request id, valid traceparent propagation, baggage filtering | pass |
+| unit | `test/unit/trace.test.ts` | phase-two evidence emit endpoint path, method, body, response | pass |
 | unit | `test/unit/headers.test.ts` | auth header safety plus generated trace headers | pass |
 | contract fixture | `fixtures/bkn-trace/positive.json` | request id injection shape | pass |
 | contract fixture | `fixtures/bkn-trace/propagation.json` | outbound context propagation shape | pass |
@@ -75,5 +83,5 @@ No BKN Trace event envelope is emitted by SDK/CLI in phase one. Fixture validati
 ## Known Gaps
 
 - SDK/CLI exposes `openbkn trace validate-fixture`; bkn-docs remains the source of the shared fixture contract and Python reference validator.
-- SDK/CLI does not yet emit local BKN Trace event envelopes.
+- SDK/CLI can submit phase-two evidence event batches, but does not yet generate claim/evidence/business events automatically from ordinary SDK calls.
 - Raw call explicit headers can intentionally override generated trace context; this is preserved for operator debugging.

--- a/src/api/trace.ts
+++ b/src/api/trace.ts
@@ -11,6 +11,7 @@ import type { RequestContext } from "../types.js";
 import { request } from "./http.js";
 
 const SEARCH = "/api/agent-observability/v1/traces/_search";
+const EVIDENCE_EVENTS = "/api/agent-observability/v1/evidence/events";
 
 interface SearchHits {
   hits?: { hits?: Array<{ _source?: Record<string, unknown> }> };
@@ -28,6 +29,46 @@ export interface RawSpan {
   status?: { code?: string };
   attributes?: Record<string, unknown>;
   events?: Array<{ name?: string; time?: string; attributes?: Record<string, unknown> }>;
+}
+
+export interface EvidenceTraceContext {
+  trace_id: string;
+  traceparent: string;
+  "bkn.request.id": string;
+  "bkn.tenant.id"?: string;
+  business_domain?: string;
+  "bkn.account.id": string;
+  "bkn.account.type": string;
+}
+
+export interface EvidenceEvent {
+  event_id: string;
+  event_type: string;
+  "bkn.trace.schema.version": string;
+  observed_at: string;
+  emitted_at: string;
+  producer_module: string;
+  trace_id: string;
+  span_id: string;
+  "bkn.request.id": string;
+  "bkn.operation.name": string;
+  payload: Record<string, unknown>;
+}
+
+export interface EvidenceIngestRequest {
+  "bkn.trace.schema.version": "2.0.0";
+  trace: EvidenceTraceContext;
+  events: EvidenceEvent[];
+}
+
+export interface EvidenceIngestResponse {
+  trace_id: string;
+  "bkn.request.id": string;
+  "bkn.trace.schema.version": string;
+  accepted_event_count: number;
+  claim_count: number;
+  evidence_ref_count: number;
+  business_ref_count: number;
 }
 
 function isoToNanos(iso: string): string | undefined {
@@ -90,6 +131,14 @@ export async function getRawSpansByConversation(
 /** Raw OpenSearch-style trace search (body passthrough). */
 export function traceSearch(ctx: RequestContext, body: unknown): Promise<unknown> {
   return request(ctx, SEARCH, { method: "POST", body });
+}
+
+/** Submit BKN Trace phase-two claim/evidence/business events. */
+export function emitEvidenceEvents(
+  ctx: RequestContext,
+  body: EvidenceIngestRequest,
+): Promise<EvidenceIngestResponse> {
+  return request<EvidenceIngestResponse>(ctx, EVIDENCE_EVENTS, { method: "POST", body });
 }
 
 /**

--- a/src/commands/trace.ts
+++ b/src/commands/trace.ts
@@ -116,5 +116,16 @@ export function traceCommand(): Command {
       if (!result.ok) process.exitCode = 1;
     });
 
+  const evidence = cmd
+    .command("evidence")
+    .description("Submit BKN Trace phase-two evidence events");
+  evidence
+    .command("emit <file>")
+    .description("Submit a phase-two evidence event batch JSON file")
+    .action(async (file: string, _opts, cmd: Command) => {
+      const body = JSON.parse(readFileSync(file, "utf8"));
+      printJson(await clientFrom(cmd).trace.emitEvidenceEvents(body), outputOptions(cmd));
+    });
+
   return group(cmd, "TRACE AI");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,13 @@ export { vega } from "./resources/vega.js";
 // Auth is store-backed (pre-token), so it is a standalone namespace.
 export * as auth from "./resources/auth.js";
 
+export type {
+  EvidenceEvent,
+  EvidenceIngestRequest,
+  EvidenceIngestResponse,
+  EvidenceTraceContext,
+} from "./api/trace.js";
+
 // Vega build types are part of the public contract.
 export type {
   BuildMode,

--- a/src/resources/trace.ts
+++ b/src/resources/trace.ts
@@ -3,7 +3,13 @@
 
 /** Trace resource surface (data fetch + symbolic/rubric diagnose + eval-set). */
 import { fetchAgentInfo, sendChat } from "../api/agent-chat.js";
-import { getRawSpansByConversation, getSpansByConversation, traceSearch } from "../api/trace.js";
+import {
+  type EvidenceIngestRequest,
+  emitEvidenceEvents,
+  getRawSpansByConversation,
+  getSpansByConversation,
+  traceSearch,
+} from "../api/trace.js";
 import { claudeAvailable, judgeJson } from "../bkn-trace/claude-judge.js";
 import {
   BUILTIN_RULES,
@@ -85,6 +91,8 @@ export function trace(ctx: RequestContext) {
   return {
     /** Raw trace search (OpenSearch-style body). */
     search: (body: unknown) => traceSearch(ctx, body),
+    /** Submit BKN Trace phase-two claim/evidence/business events. */
+    emitEvidenceEvents: (body: EvidenceIngestRequest) => emitEvidenceEvents(ctx, body),
     /** All span source docs for a conversation. */
     spans: (conversationId: string, opts?: { maxTraceIds?: number; maxSpans?: number }) =>
       getSpansByConversation(ctx, conversationId, opts),

--- a/test/unit/trace.test.ts
+++ b/test/unit/trace.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getSpansByConversation, traceSearch } from "../../src/api/trace.js";
+import { emitEvidenceEvents, getSpansByConversation, traceSearch } from "../../src/api/trace.js";
 import type { RequestContext } from "../../src/types.js";
 
 const ctx: RequestContext = {
@@ -33,6 +33,61 @@ describe("traceSearch", () => {
     if (!c) throw new Error("no call");
     expect(new URL(c[0]).pathname).toBe("/api/agent-observability/v1/traces/_search");
     expect(c[1].method).toBe("POST");
+  });
+});
+
+describe("emitEvidenceEvents", () => {
+  it("POSTs a phase-two evidence event batch", async () => {
+    const f = mockFetchSeq([
+      {
+        trace_id: "8c0d0000000000000000000000000001",
+        "bkn.request.id": "req_phase2_001",
+        "bkn.trace.schema.version": "2.0.0",
+        accepted_event_count: 1,
+        claim_count: 1,
+        evidence_ref_count: 0,
+        business_ref_count: 0,
+      },
+    ]);
+    const result = await emitEvidenceEvents(ctx, {
+      "bkn.trace.schema.version": "2.0.0",
+      trace: {
+        trace_id: "8c0d0000000000000000000000000001",
+        traceparent: "00-8c0d0000000000000000000000000001-1f12000000000001-01",
+        "bkn.request.id": "req_phase2_001",
+        business_domain: "bd_demo",
+        "bkn.account.id": "acct_demo",
+        "bkn.account.type": "app",
+      },
+      events: [
+        {
+          event_id: "evt_claim",
+          event_type: "claim.created",
+          "bkn.trace.schema.version": "2.0.0",
+          observed_at: "2026-07-22T04:00:00.000000000Z",
+          emitted_at: "2026-07-22T04:00:00.001000000Z",
+          producer_module: "third-party-agent",
+          trace_id: "8c0d0000000000000000000000000001",
+          span_id: "1f12000000000001",
+          "bkn.request.id": "req_phase2_001",
+          "bkn.operation.name": "agent.answer",
+          payload: {
+            claim_id: "claim_001",
+            claim_type: "answer",
+            claim_hash: "sha256:claim",
+            visibility: "visible",
+            version_status: "versioned",
+          },
+        },
+      ],
+    });
+
+    const c = calls(f)[0];
+    if (!c) throw new Error("no call");
+    expect(new URL(c[0]).pathname).toBe("/api/agent-observability/v1/evidence/events");
+    expect(c[1].method).toBe("POST");
+    expect(JSON.parse(c[1].body as string).events[0].event_type).toBe("claim.created");
+    expect(result.accepted_event_count).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- add typed phase-two evidence ingest request/response types
- add SDK resource helper `client.trace.emitEvidenceEvents(body)`
- add CLI command `openbkn trace evidence emit <file>`
- update SDK trace contract notes

## Tests
- `npm run lint`
- `npm test`
- targeted: `npm test -- --run test/unit/trace.test.ts test/unit/fixture-validate.test.ts test/unit/trace-context.test.ts`

Refs openbkn-ai/bkn-foundry#270