### PR TITLE
docs: add agent contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Description
+<!-- A clear and concise description of the bug -->
+
+## Steps to reproduce
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+<!-- What you expected to happen -->
+
+## Actual behavior
+<!-- What actually happened -->
+
+## Environment
+- OS: [e.g. Windows 10 / macOS 14 / Ubuntu 22.04]
+- Browser: [e.g. Chrome 120 / Edge 119 / Firefox 118] (if applicable)
+- Version: [e.g. v1.0.0]
+
+## Acceptance Criteria (Definition of Done)
+
+- [ ] Reproduction steps no longer trigger the bug
+- [ ] Regression test added covering this bug
+- [ ] CI green
+
+## Boundaries / Risk
+<!-- Risky operations involved in the fix (delete/modify data / schema migration / config / permissions) require human confirmation before an Agent executes them -->
+
+## Additional context
+<!-- Screenshots, logs, links to reproduce, etc. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Feature summary
+<!-- Describe the feature you want in a clear and concise way -->
+
+## Problem / use case
+<!-- What problem does this solve? In what scenarios would you use it? -->
+
+## Proposed solution (optional)
+<!-- How do you think this could be implemented? -->
+
+## Acceptance Criteria (Definition of Done)
+
+- [ ] Specific, verifiable completion conditions
+- [ ] Test coverage
+- [ ] CI green
+- [ ] For UI / interaction work: design mockup link attached (Figma / etc.)
+
+## Boundaries / Risk
+
+<!-- What not to touch; risky operations require human confirmation before an Agent executes them -->
+
+## Additional context
+<!-- References, mockups, screenshots, etc. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+# Pull Request
+
+## What Changed
+
+Brief description of changes:
+
+- [ ] Feature/module 1
+- [ ] Feature/module 2
+- [ ] Docs/doc 1
+
+---
+
+## Why
+
+- Related Issue: [Issue #123](link-to-issue)
+- Related Feature: [Feature Name](link-to-feature)
+- Background:
+
+---
+
+## How
+
+- Key implementation points:
+- Breaking changes (API, config, database, etc.):
+
+---
+
+## Testing
+
+- [ ] Unit tests passed locally
+- [ ] Integration tests passed locally
+- [ ] Verified in test environment
+
+Test notes:
+
+---
+
+## Risk & Rollback
+
+- Potential risks:
+- Rollback plan:
+
+---
+
+## Additional Notes
+
+- Screenshots, logs, documentation links, etc.:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,45 @@
-# AGENTS.md — @openbkn/bkn-sdk
+# AGENTS.md
+
+Entry point for AI agents (Claude Code / Codex / others) working in this repo.
+Read this first, then load the rules under [`rules/`](rules/). Before working in any subdirectory, locate and read every `AGENTS.md` from the repository root through that target directory; rules in the more specific (deeper) file take precedence.
+
+## Read before doing anything
+
+| Topic | File |
+| --- | --- |
+| How we collaborate (humans + Agents) | [rules/WORKFLOW.md](rules/WORKFLOW.md) |
+| Contribution guide (branches, commits, style) | [rules/CONTRIBUTING.md](rules/CONTRIBUTING.md) |
+| Architecture & module boundaries | [rules/ARCHITECTURE.md](rules/ARCHITECTURE.md) |
+| API / HTTP / error conventions | [rules/DEVELOPMENT.md](rules/DEVELOPMENT.md) |
+| Testing conventions | [rules/TESTING.md](rules/TESTING.md) |
+| Module owners (review routing) | [.github/CODEOWNERS](.github/CODEOWNERS) |
+| Issue templates (bug / feature / task) | [.github/ISSUE_TEMPLATE/](.github/ISSUE_TEMPLATE/) |
+| Pull request template | [.github/pull_request_template.md](.github/pull_request_template.md) |
+
+## Hard rules for Agents
+
+- **Review before external writes**: Unless the requester explicitly directs otherwise, after making and verifying code changes, present the working-tree diff for review first. Do **not** commit, push, create or update a PR, or post Issue/PR comments before the requester approves.
+- **Language**: Communicate with users in Chinese by default. Use another language only when the requester explicitly asks for it or the artifact itself requires it.
+- **Clarify material ambiguity**: Before editing, ask for direction when an ambiguity would materially change scope, behavior, risk, or the intended solution; otherwise proceed with a stated, reasonable assumption.
+- **Bug regression coverage**: For bug fixes, add or update a focused regression test that demonstrates the reported failure whenever it is practical.
+- **Verification handoff**: After implementing a change, report relevant edge cases and any remaining test-coverage gaps along with the commands run.
+- **Issue / PR templates**: Before creating an Issue, select the matching template under [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/) and preserve its structure when filling in all applicable sections. Before creating or updating a PR, read and fully complete [`.github/pull_request_template.md`](.github/pull_request_template.md). Do not delete required sections; mark non-applicable items explicitly with a brief reason.
+- **Only pick up Issues labeled `agent-ready`** (acceptance criteria complete + independently doable) that are unassigned. Self-assign to lock.
+- **Acceptance criteria**: a human approves them (label `ac-approved`) before an Issue becomes `agent-ready`. You may *draft* them for human approval.
+- **Risky operations** (deploy, delete/modify data, schema migration, prod config, secrets/permissions, major dependency bumps, cross-service breaking changes): do **not** execute. Post the three-part confirmation (what / blast radius / rollback), apply label `awaiting-confirmation`, and wait for an Owner to apply `owner-confirmed`.
+- **You may never**: approve or merge a PR, bypass or skip CI, or act without the confirmation above. Code review and the merge gates are human-only.
+- **Open PRs with `Closes #<issue>`** and write back progress as Issue/PR comments. Label your PRs `by-agent`.
+- **Stuck / off-track / tests won't pass** → comment the blocker, return the Issue to triage, clear your assignee, label `needs-human`.
+
+## Commits & branches
+
+- Conventional Commits: `type(scope): subject` (`feat` / `fix` / `chore` / `refactor` / `docs` / `test`; scope = service name).
+- Branch from the Issue's "Create a branch"; one PR per Issue, kept small.
+- Branch names must use a valid type prefix and at most two path segments after it: `<type>/<description>`, `<type>/<issue-number>-<description>`, or `<type>/<module>/<description>`; segments start with lowercase letters or digits and may contain `-`, `.`, or `_`.
+
+---
+
+## bkn-sdk-specific guidance
 
 Unified TypeScript SDK + CLI for the **BKN** (Business Knowledge Network) platform. One toolkit, two audiences: end-users/agents (knowledge, agents, search, chat) and platform operators (org, user, role, model, audit). Backend-only; no web UI. Published to npm under `@openbkn`.
 
@@ -58,7 +99,6 @@ Dependency direction is one-way: `commands → resources → api → auth/config
 - Default list `limit` = **30**; query/preview `limit` = **50**; `--limit` always overrides.
 - Global `--json` for machine-readable output where supported.
 - This is a **rewrite**, not a port: reference the legacy user/agent-SDK and operator-CLI predecessors, but slim and unify — do not copy verbatim. Python SDK is dropped.
-- Branch names must use a valid type prefix and at most two path segments after it: `<type>/<description>`, `<type>/<issue-number>-<description>`, or `<type>/<module>/<description>`; segments start with lowercase letters or digits and may contain `-`, `.`, or `_`.
 
 ## Domains
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ Dependency direction is one-way: `commands → resources → api → auth/config
 - Default list `limit` = **30**; query/preview `limit` = **50**; `--limit` always overrides.
 - Global `--json` for machine-readable output where supported.
 - This is a **rewrite**, not a port: reference the legacy user/agent-SDK and operator-CLI predecessors, but slim and unify — do not copy verbatim. Python SDK is dropped.
+- Branch names must use a valid type prefix and at most two path segments after it: `<type>/<description>`, `<type>/<issue-number>-<description>`, or `<type>/<module>/<description>`; segments start with lowercase letters or digits and may contain `-`, `.`, or `_`.
 
 ## Domains
 


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Added branch naming guidance for agents
- [x] Added bug and feature Issue templates
- [x] Added a Pull Request template

---

## Why

- Related Issue: N/A
- Related Feature: Repository collaboration standards
- Background: Standardize contribution metadata and provide agents with a CI-compatible branch naming convention.

---

## How

- Key implementation points: Add GitHub templates and a concise naming rule to the repository harness.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally — N/A (documentation-only change)
- [x] Integration tests passed locally — N/A (documentation-only change)
- [x] Verified in test environment — `git diff --check` passed

Test notes: No runtime behavior changed.

---

## Risk & Rollback

- Potential risks: Template wording may need refinement based on contributor feedback.
- Rollback plan: Revert commit `60b6a4a`.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: N/A.