### PR TITLE
feat(bkn-trace): add typed graph api commands

### DIFF
--- a/src/api/trace.ts
+++ b/src/api/trace.ts
@@ -336,6 +336,6 @@ function queryWithLimit(
   query: Record<string, string> | undefined,
   opts: TraceQueryOptions,
 ): Record<string, string | number> | undefined {
-  if (opts.limit === undefined) return query;
+  if (opts.limit === undefined || !Number.isFinite(opts.limit)) return query;
   return { ...(query ?? {}), limit: opts.limit };
 }

--- a/src/api/trace.ts
+++ b/src/api/trace.ts
@@ -12,6 +12,7 @@ import { request } from "./http.js";
 
 const SEARCH = "/api/agent-observability/v1/traces/_search";
 const EVIDENCE_EVENTS = "/api/agent-observability/v1/evidence/events";
+const TRACES = "/api/agent-observability/v1/traces";
 
 interface SearchHits {
   hits?: { hits?: Array<{ _source?: Record<string, unknown> }> };
@@ -69,6 +70,101 @@ export interface EvidenceIngestResponse {
   claim_count: number;
   evidence_ref_count: number;
   business_ref_count: number;
+}
+
+export interface VisibilitySummary {
+  authorized_ref_count: number;
+  redacted_ref_count: number;
+  hidden_ref_count: number;
+  omitted_ref_count: number;
+  unresolved_ref_count: number;
+  unauthorized_ref_count?: number;
+}
+
+export interface GraphPage {
+  node_count: number;
+  edge_count: number;
+  truncated?: boolean;
+  next_cursor?: string | null;
+}
+
+export interface TraceGraphNode {
+  span_id: string;
+  parent_span_id?: string;
+  name: string;
+  kind: string;
+  service_name?: string;
+  status: string;
+  error_message?: string;
+  start_nano: number;
+  end_nano: number;
+  duration_nano: number;
+}
+
+export interface TraceGraphEdge {
+  id: string;
+  parent_span_id: string;
+  child_span_id: string;
+  edge_type: string;
+}
+
+export interface TraceGraphResponse {
+  trace_id: string;
+  status: string;
+  duration_nano: number;
+  partial: boolean;
+  partial_reason: string[];
+  page: GraphPage;
+  data: {
+    nodes: TraceGraphNode[];
+    edges: TraceGraphEdge[];
+  };
+}
+
+export interface EvidenceChainResponse {
+  trace_id: string;
+  "bkn.request.id": string;
+  partial: boolean;
+  partial_reason: string[];
+  visibility_summary: VisibilitySummary;
+  page: GraphPage;
+  data: {
+    claims: Array<Record<string, unknown>>;
+    evidence_refs: Array<Record<string, unknown>>;
+    business_refs: Array<Record<string, unknown>>;
+  };
+}
+
+export interface BusinessGraphResponse {
+  trace_id: string;
+  "bkn.request.id": string;
+  partial: boolean;
+  partial_reason: string[];
+  visibility_summary: VisibilitySummary;
+  page: GraphPage;
+  data: {
+    nodes: Array<Record<string, unknown>>;
+    edges: Array<Record<string, unknown>>;
+  };
+}
+
+export interface SnapshotPreviewResponse {
+  trace_id: string;
+  "bkn.request.id": string;
+  partial: boolean;
+  partial_reason: string[];
+  visibility_summary: VisibilitySummary;
+  snapshot_ref: {
+    snapshot_id: string;
+    mode: "preview" | string;
+    uri?: string;
+  };
+  manifest: Record<string, unknown>;
+}
+
+export type TraceScope = string | { traceId: string } | { requestId: string };
+export interface TraceQueryOptions {
+  limit?: number;
 }
 
 function isoToNanos(iso: string): string | undefined {
@@ -141,6 +237,43 @@ export function emitEvidenceEvents(
   return request<EvidenceIngestResponse>(ctx, EVIDENCE_EVENTS, { method: "POST", body });
 }
 
+export function getTraceGraph(ctx: RequestContext, traceId: string): Promise<TraceGraphResponse> {
+  return request<TraceGraphResponse>(ctx, `${TRACES}/${encodeURIComponent(traceId)}/trace-graph`);
+}
+
+export function getEvidenceChain(
+  ctx: RequestContext,
+  scope: TraceScope,
+  opts: TraceQueryOptions = {},
+): Promise<EvidenceChainResponse> {
+  const target = traceTarget(scope, "evidence-chain");
+  return request<EvidenceChainResponse>(ctx, target.path, {
+    query: queryWithLimit(target.query, opts),
+  });
+}
+
+export function getBusinessGraph(
+  ctx: RequestContext,
+  scope: TraceScope,
+  opts: TraceQueryOptions = {},
+): Promise<BusinessGraphResponse> {
+  const target = traceTarget(scope, "business-graph");
+  return request<BusinessGraphResponse>(ctx, target.path, {
+    query: queryWithLimit(target.query, opts),
+  });
+}
+
+export function getSnapshotPreview(
+  ctx: RequestContext,
+  scope: TraceScope,
+  opts: TraceQueryOptions = {},
+): Promise<SnapshotPreviewResponse> {
+  const target = traceTarget(scope, "snapshot-preview");
+  return request<SnapshotPreviewResponse>(ctx, target.path, {
+    query: queryWithLimit(target.query, opts),
+  });
+}
+
 /**
  * Fetch all span `_source` docs for a conversation.
  * Hop 1: aggregate trace ids for the conversation. Hop 2: fetch their spans.
@@ -180,4 +313,29 @@ export async function getSpansByConversation(
       },
     })) ?? {};
   return (spans.hits?.hits ?? []).map((h) => h._source ?? {});
+}
+
+function traceTarget(
+  scope: TraceScope,
+  subresource: "evidence-chain" | "business-graph" | "snapshot-preview",
+): { path: string; query?: Record<string, string> } {
+  if (typeof scope === "string") {
+    return { path: `${TRACES}/${encodeURIComponent(scope)}/${subresource}` };
+  }
+  if ("traceId" in scope) {
+    return { path: `${TRACES}/${encodeURIComponent(scope.traceId)}/${subresource}` };
+  }
+  const requestPath =
+    subresource === "evidence-chain"
+      ? `${TRACES}/by-request`
+      : `${TRACES}/by-request/${subresource}`;
+  return { path: requestPath, query: { request_id: scope.requestId } };
+}
+
+function queryWithLimit(
+  query: Record<string, string> | undefined,
+  opts: TraceQueryOptions,
+): Record<string, string | number> | undefined {
+  if (opts.limit === undefined) return query;
+  return { ...(query ?? {}), limit: opts.limit };
 }

--- a/src/commands/trace.ts
+++ b/src/commands/trace.ts
@@ -8,6 +8,7 @@ import { renderReportMarkdown } from "../bkn-trace/diagnose.js";
 import { validateFixturePath } from "../bkn-trace/fixture-validate.js";
 import { validateSchemaFile } from "../bkn-trace/schema-validate.js";
 import { group } from "../help/grouped-help.js";
+import { InputError } from "../utils/errors.js";
 import { printJson } from "../utils/output.js";
 import { clientFrom, outputOptions, readBody } from "./_shared.js";
 
@@ -15,6 +16,55 @@ export function traceCommand(): Command {
   const cmd = new Command("trace").description(
     "BKN Trace — fetch spans, diagnose (symbolic + LLM rubric), scan, eval-set, schema validate",
   );
+
+  cmd
+    .command("graph <trace-id>")
+    .description("Fetch normalized trace graph by trace id")
+    .action(async (traceId: string, _opts, cmd: Command) => {
+      printJson(await clientFrom(cmd).trace.graph(traceId), outputOptions(cmd));
+    });
+
+  cmd
+    .command("evidence-chain [trace-id]")
+    .description("Fetch BKN Trace evidence chain by trace id or --request-id")
+    .option("--request-id <id>", "BKN request id scope")
+    .option("--limit <n>", "maximum evidence trace batches", (v) => Number.parseInt(v, 10))
+    .action(async (traceId: string | undefined, opts, cmd: Command) => {
+      printJson(
+        await clientFrom(cmd).trace.evidenceChain(traceScope(traceId, opts.requestId), {
+          limit: opts.limit,
+        }),
+        outputOptions(cmd),
+      );
+    });
+
+  cmd
+    .command("business-graph [trace-id]")
+    .description("Fetch BKN Trace business semantic graph by trace id or --request-id")
+    .option("--request-id <id>", "BKN request id scope")
+    .option("--limit <n>", "maximum evidence trace batches", (v) => Number.parseInt(v, 10))
+    .action(async (traceId: string | undefined, opts, cmd: Command) => {
+      printJson(
+        await clientFrom(cmd).trace.businessGraph(traceScope(traceId, opts.requestId), {
+          limit: opts.limit,
+        }),
+        outputOptions(cmd),
+      );
+    });
+
+  cmd
+    .command("snapshot-preview [trace-id]")
+    .description("Fetch metadata-only evidence snapshot preview by trace id or --request-id")
+    .option("--request-id <id>", "BKN request id scope")
+    .option("--limit <n>", "maximum evidence trace batches", (v) => Number.parseInt(v, 10))
+    .action(async (traceId: string | undefined, opts, cmd: Command) => {
+      printJson(
+        await clientFrom(cmd).trace.snapshotPreview(traceScope(traceId, opts.requestId), {
+          limit: opts.limit,
+        }),
+        outputOptions(cmd),
+      );
+    });
 
   cmd
     .command("get <conversation-id>")
@@ -128,4 +178,13 @@ export function traceCommand(): Command {
     });
 
   return group(cmd, "TRACE AI");
+}
+
+function traceScope(traceId: string | undefined, requestId: string | undefined) {
+  if (traceId && requestId) {
+    throw new InputError("Provide either trace id or --request-id, not both.");
+  }
+  if (requestId) return { requestId };
+  if (traceId) return traceId;
+  throw new InputError("Provide a trace id or --request-id.");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,10 +32,20 @@ export { vega } from "./resources/vega.js";
 export * as auth from "./resources/auth.js";
 
 export type {
+  BusinessGraphResponse,
   EvidenceEvent,
+  EvidenceChainResponse,
   EvidenceIngestRequest,
   EvidenceIngestResponse,
   EvidenceTraceContext,
+  GraphPage,
+  SnapshotPreviewResponse,
+  TraceGraphEdge,
+  TraceGraphNode,
+  TraceQueryOptions,
+  TraceGraphResponse,
+  TraceScope,
+  VisibilitySummary,
 } from "./api/trace.js";
 
 // Vega build types are part of the public contract.

--- a/src/resources/trace.ts
+++ b/src/resources/trace.ts
@@ -5,9 +5,15 @@
 import { fetchAgentInfo, sendChat } from "../api/agent-chat.js";
 import {
   type EvidenceIngestRequest,
+  type TraceQueryOptions,
+  type TraceScope,
   emitEvidenceEvents,
+  getBusinessGraph,
+  getEvidenceChain,
   getRawSpansByConversation,
+  getSnapshotPreview,
   getSpansByConversation,
+  getTraceGraph,
   traceSearch,
 } from "../api/trace.js";
 import { claudeAvailable, judgeJson } from "../bkn-trace/claude-judge.js";
@@ -93,6 +99,17 @@ export function trace(ctx: RequestContext) {
     search: (body: unknown) => traceSearch(ctx, body),
     /** Submit BKN Trace phase-two claim/evidence/business events. */
     emitEvidenceEvents: (body: EvidenceIngestRequest) => emitEvidenceEvents(ctx, body),
+    /** Normalized trace tree/status graph by trace id. */
+    graph: (traceId: string) => getTraceGraph(ctx, traceId),
+    /** Claim -> evidence/business refs graph by trace id or BKN request id. */
+    evidenceChain: (scope: TraceScope, opts?: TraceQueryOptions) =>
+      getEvidenceChain(ctx, scope, opts),
+    /** Business semantic graph by trace id or BKN request id. */
+    businessGraph: (scope: TraceScope, opts?: TraceQueryOptions) =>
+      getBusinessGraph(ctx, scope, opts),
+    /** Metadata-only evidence snapshot preview by trace id or BKN request id. */
+    snapshotPreview: (scope: TraceScope, opts?: TraceQueryOptions) =>
+      getSnapshotPreview(ctx, scope, opts),
     /** All span source docs for a conversation. */
     spans: (conversationId: string, opts?: { maxTraceIds?: number; maxSpans?: number }) =>
       getSpansByConversation(ctx, conversationId, opts),

--- a/test/unit/trace.test.ts
+++ b/test/unit/trace.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { emitEvidenceEvents, getSpansByConversation, traceSearch } from "../../src/api/trace.js";
+import {
+  emitEvidenceEvents,
+  getBusinessGraph,
+  getEvidenceChain,
+  getSnapshotPreview,
+  getSpansByConversation,
+  getTraceGraph,
+  traceSearch,
+} from "../../src/api/trace.js";
 import type { RequestContext } from "../../src/types.js";
 
 const ctx: RequestContext = {
@@ -88,6 +96,54 @@ describe("emitEvidenceEvents", () => {
     expect(c[1].method).toBe("POST");
     expect(JSON.parse(c[1].body as string).events[0].event_type).toBe("claim.created");
     expect(result.accepted_event_count).toBe(1);
+  });
+});
+
+describe("typed BKN Trace graph APIs", () => {
+  it("GETs trace graph by trace id", async () => {
+    const f = mockFetchSeq([{ trace_id: "trace_1", status: "ok", data: { nodes: [], edges: [] } }]);
+    const result = await getTraceGraph(ctx, "trace_1");
+    const c = calls(f)[0];
+    if (!c) throw new Error("no call");
+    expect(new URL(c[0]).pathname).toBe("/api/agent-observability/v1/traces/trace_1/trace-graph");
+    expect(c[1].method).toBe("GET");
+    expect(result.trace_id).toBe("trace_1");
+  });
+
+  it("GETs evidence chain and business graph with optional limit", async () => {
+    const f = mockFetchSeq([
+      { trace_id: "trace_1", data: { claims: [], evidence_refs: [], business_refs: [] } },
+      { trace_id: "trace_1", data: { nodes: [], edges: [] } },
+    ]);
+    await getEvidenceChain(ctx, "trace_1", { limit: 50 });
+    await getBusinessGraph(ctx, "trace_1", { limit: 50 });
+    const [evidenceCall, graphCall] = calls(f);
+    if (!evidenceCall || !graphCall) throw new Error("missing calls");
+    const evidenceURL = new URL(evidenceCall[0]);
+    const graphURL = new URL(graphCall[0]);
+    expect(evidenceURL.pathname).toBe("/api/agent-observability/v1/traces/trace_1/evidence-chain");
+    expect(evidenceURL.searchParams.get("limit")).toBe("50");
+    expect(graphURL.pathname).toBe("/api/agent-observability/v1/traces/trace_1/business-graph");
+    expect(graphURL.searchParams.get("limit")).toBe("50");
+  });
+
+  it("GETs request scoped evidence chain and snapshot preview", async () => {
+    const f = mockFetchSeq([
+      { "bkn.request.id": "req_1", data: { claims: [], evidence_refs: [], business_refs: [] } },
+      { "bkn.request.id": "req_1", snapshot_ref: { mode: "preview" }, manifest: {} },
+    ]);
+    await getEvidenceChain(ctx, { requestId: "req_1" });
+    await getSnapshotPreview(ctx, { requestId: "req_1" });
+    const [evidenceCall, snapshotCall] = calls(f);
+    if (!evidenceCall || !snapshotCall) throw new Error("missing calls");
+    const evidenceURL = new URL(evidenceCall[0]);
+    const snapshotURL = new URL(snapshotCall[0]);
+    expect(evidenceURL.pathname).toBe("/api/agent-observability/v1/traces/by-request");
+    expect(evidenceURL.searchParams.get("request_id")).toBe("req_1");
+    expect(snapshotURL.pathname).toBe(
+      "/api/agent-observability/v1/traces/by-request/snapshot-preview",
+    );
+    expect(snapshotURL.searchParams.get("request_id")).toBe("req_1");
   });
 });
 

--- a/test/unit/trace.test.ts
+++ b/test/unit/trace.test.ts
@@ -130,20 +130,37 @@ describe("typed BKN Trace graph APIs", () => {
   it("GETs request scoped evidence chain and snapshot preview", async () => {
     const f = mockFetchSeq([
       { "bkn.request.id": "req_1", data: { claims: [], evidence_refs: [], business_refs: [] } },
+      { "bkn.request.id": "req_1", data: { nodes: [], edges: [] } },
       { "bkn.request.id": "req_1", snapshot_ref: { mode: "preview" }, manifest: {} },
     ]);
     await getEvidenceChain(ctx, { requestId: "req_1" });
+    await getBusinessGraph(ctx, { requestId: "req_1" });
     await getSnapshotPreview(ctx, { requestId: "req_1" });
-    const [evidenceCall, snapshotCall] = calls(f);
-    if (!evidenceCall || !snapshotCall) throw new Error("missing calls");
+    const [evidenceCall, graphCall, snapshotCall] = calls(f);
+    if (!evidenceCall || !graphCall || !snapshotCall) throw new Error("missing calls");
     const evidenceURL = new URL(evidenceCall[0]);
+    const graphURL = new URL(graphCall[0]);
     const snapshotURL = new URL(snapshotCall[0]);
     expect(evidenceURL.pathname).toBe("/api/agent-observability/v1/traces/by-request");
     expect(evidenceURL.searchParams.get("request_id")).toBe("req_1");
+    expect(graphURL.pathname).toBe("/api/agent-observability/v1/traces/by-request/business-graph");
+    expect(graphURL.searchParams.get("request_id")).toBe("req_1");
     expect(snapshotURL.pathname).toBe(
       "/api/agent-observability/v1/traces/by-request/snapshot-preview",
     );
     expect(snapshotURL.searchParams.get("request_id")).toBe("req_1");
+  });
+
+  it("does not serialize a NaN limit", async () => {
+    const f = mockFetchSeq([
+      { trace_id: "trace_1", data: { claims: [], evidence_refs: [], business_refs: [] } },
+    ]);
+
+    await getEvidenceChain(ctx, "trace_1", { limit: Number.NaN });
+
+    const c = calls(f)[0];
+    if (!c) throw new Error("no call");
+    expect(new URL(c[0]).searchParams.has("limit")).toBe(false);
   });
 });
 


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Add typed BKN Trace graph API methods for trace graph, evidence chain, business graph, and snapshot preview.
- [x] Expose graph APIs through the trace resource namespace and public SDK type exports.
- [x] Add CLI commands: trace graph, trace evidence-chain, trace business-graph, trace snapshot-preview.

---

## Why

- Related Issue: BKN Trace phase three C4 SDK / CLI support.
- Related Feature: BKN Trace core service and Studio consumption boundary.
- Background: Stage three APIs should be consumed through stable typed SDK/CLI surfaces instead of raw OpenSearch queries.

---

## How

- Key implementation points:
  - Add response contracts for TraceGraphResponse, EvidenceChainResponse, BusinessGraphResponse, SnapshotPreviewResponse, GraphPage, VisibilitySummary, and TraceScope.
  - Support trace-id scoped and request-id scoped graph queries with optional limit query parameter.
  - Route CLI commands through resources -> api, preserving existing command layering.
- Breaking changes (API, config, database, etc.): None. Pure additive SDK/CLI surface.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- npm run lint
- npm test -- test/unit/trace.test.ts
- npm test
- git diff --check
- Sandbox npm test hit expected 127.0.0.1 listen EPERM in tls.test.ts; rerun with local listen permission passed.

---

## Risk & Rollback

- Potential risks: Backend deployments without these BKN Trace endpoints will return normal HTTP errors when the new methods are called.
- Rollback plan: Revert this additive SDK/CLI commit.

---

## Additional Notes

- Aligns SDK/CLI with bkn-foundry Trace Graph API work in openbkn-ai/bkn-foundry#435 and existing Evidence Chain / Business Graph / Snapshot Preview service contracts.