### PR TITLE
ci(claude-review): 评审通过即放行 + 评论触发复评 + effort high

### DIFF
--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -1,16 +1,24 @@
 name: Claude Code Review
 
-# 由 Claude 对 PR 做代码评审：开启、重开、从 draft 转 ready，以及每次推送新提交时各跑一次。
+# 由 Claude 对 PR 做代码评审：开启、重开、从 draft 转 ready、每次推送新提交，
+# 以及 PR 发起者留下评论/行内回复时，各跑一次。
 #
 # 覆盖每次推送而非只审首版，是因为评审之后追加的提交往往是「按意见快速改一下」，
 # 恰恰最容易引入新问题；只审首版会让这部分完全不过审。
 # 连续推送的浪费由下面的 concurrency 收敛：新一次运行会取消尚未完成的上一次。
 #
+# 也在评论事件上复评：评审提出的「待确认」项在澄清前不予批准（见下方 prompt），
+# 作者可以不改代码、只回帖来回应，因此必须让回帖也能触发一次复评，否则 approve
+# 永远补不上。为避免自我循环，评论事件由下方 job 的 if 过滤掉 bot 自己的评论，
+# 并限定发起者为 OWNER/MEMBER/COLLABORATOR——评论事件在 base 仓上下文携带
+# secret 运行，限定关联方可挡掉 fork 陌生人触发的 pwn-request。
+#
 # 需要对任意 PR 重新评审时，手动触发 workflow_dispatch 并填 PR 编号。
 #
-# 只对代码路径生效。纯文档改动（*.md）不进评审，既省额度也避免噪声。
+# pull_request 触发只对代码路径生效。纯文档改动（*.md）不进评审，既省额度也避免噪声。
 # 注意：GitHub Actions 不允许同一事件同时使用 paths 与 paths-ignore，因此这里
 # 只写 include 列表——未列出的路径自动跳过——并用 ! 前缀排除列表内的文档文件。
+# 评论事件不支持 paths 过滤，靠 job if 与 Claude 自身判断相关性。
 
 on:
   pull_request:
@@ -22,6 +30,10 @@ on:
       - 'package.json'
       - 'tsconfig.json'
       - '!**/*.md'
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -30,32 +42,60 @@ on:
         type: string
 
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number || inputs.pr_number }}
+  # 按事件类别分组，别把评论事件和 PR 推送混在一组。concurrency 在 run 排队时求值，
+  # 早于 job if，所以隔离只能靠分组，if 拦不住取消。
+  #
+  # push（含 opened/synchronize/…）落 -push 组、cancel-in-progress 生效：连续推送时
+  # 新 run 取消未完成的旧 run，省额度。
+  #
+  # 评论事件（issue_comment / pull_request_review_comment）每条按 comment.id 各自成组。
+  # 否则 claude-code-action（track_progress）在评论触发的复评跑到一半时以 bot 身份贴
+  # tracking comment，那条 comment 又触发 issue_comment、排进同一 -comment 组，
+  # cancel-in-progress 在 job if 过滤掉 bot 评论之前就把正在跑的复评取消了——评论触发的
+  # 复评每次贴进度评论那刻自杀（作者回帖复评后放行因此永远补不上 approve）。
+  # 按 comment.id 分组后每条评论各自独立、互不取消，bot 的进度评论也顶不掉正在跑的复评。
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}-${{ (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') && format('comment-{0}', github.event.comment.id) || 'push' }}
   cancel-in-progress: true
 
 jobs:
   review:
-    # fork 发起的 PR 拿不到 secrets，直接跳过避免红叉
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    # 逐事件放行：
+    #   - workflow_dispatch：手动，总放行。
+    #   - pull_request：只同仓 PR（fork 拿不到 secret，跳过避免红叉）。
+    #   - 评论/行内回复：必须挂在 PR 上、非 bot 自己发的、且发起者为
+    #     OWNER/MEMBER/COLLABORATOR，挡掉自我循环与 fork 陌生人的 pwn-request。
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_review_comment' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       github.event.sender.login != 'github-actions[bot]' &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       github.event.sender.login != 'github-actions[bot]' &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
+      checks: read
+      statuses: read
       id-token: write
     env:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # pull_request 事件下 checkout 会自动落到 PR 的 merge ref；
-          # workflow_dispatch 下只会拿到默认分支，需要下一步显式切到 PR 分支，
-          # 因此这里放开深度以便 gh pr checkout 能建立分支。
-          fetch-depth: ${{ github.event_name == 'workflow_dispatch' && 0 || 1 }}
+          # pull_request 事件下 checkout 会自动落到 PR 的 merge ref；其它事件
+          # （手动触发、评论、行内回复）只会拿到默认分支，需要下一步显式切到
+          # PR 分支，因此这里放开深度以便 gh pr checkout 能建立分支。
+          fetch-depth: ${{ github.event_name == 'pull_request' && 1 || 0 }}
 
-      - name: Checkout PR branch (manual trigger)
-        if: github.event_name == 'workflow_dispatch'
+      - name: Checkout PR branch (non-PR events)
+        if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -96,18 +136,45 @@ jobs:
             评审要求：
             - 用中文。
             - 具体问题用 inline comment 贴到对应行，说明「问题是什么 + 怎么改」。
-            - 顶层 comment 只写整体判断和阻塞项清单，不要复述 diff。
+            - 顶层 comment 只写整体判断、阻塞项清单、待确认项清单，不要复述 diff。
             - 不确定的推测标注为「待确认」，不要当成缺陷断言。
             - 没问题就说没问题，不要为了凑数提格式化/命名类的琐碎意见
               （biome 已覆盖格式）。
 
+            这次可能是复评（作者推了新提交或回复了评论）。先把现状摸清再下结论：
+            - `gh pr view "$PR_NUMBER" --json reviewDecision,reviewRequests,comments`
+              以及 `gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/comments"`
+              读回你之前留下的 inline 评论与其下的回复，弄清哪些「待确认」项
+              PR 发起者已经回应、哪些还悬着。
+            - `gh pr checks "$PR_NUMBER"` 看必需检查当前状态。
+
+            按下面的优先级落成一次 PR review（不是普通评论），三选一：
+
+            1. 有阻塞项（确定的缺陷）→ `gh pr review "$PR_NUMBER" --request-changes
+               --body "<阻塞清单>"`。
+            2. 无阻塞项，但仍有待确认项没有被澄清 → 不要 approve。用
+               `gh pr review "$PR_NUMBER" --comment --body "<未澄清项清单>"` 留言等回应。
+               逐条判断发起者的回应是否真正澄清了该疑点：
+               - 回应正面、切题、能打消疑虑 → 该条视为已澄清。
+               - 回应缺失、答非所问、回避，或仍留有实质疑点 → 该条仍未澄清，
+                 在留言里点名说明还差什么、请补充；别默认「回了就算清」。
+               - 回应本身暴露出新的确定缺陷 → 归到第 1 类。
+               判断要讲理、就事论事，不要为难：回应只要合理对上了疑点就放行，
+               不必追求完美措辞，也不要凭「可能」反复追问同一条。
+            3. 无阻塞项、所有待确认项都已被你判定为澄清、且必需检查没有失败也没有
+               还在跑 → `gh pr review "$PR_NUMBER" --approve --body "<一句放行理由>"`。
+               必需检查只要有失败或仍 pending，就退回第 2 类留言说明在等 CI，先不批。
+
+            批准以 github-actions[bot] 身份提交，只表态、不合并。人工仍需自行 merge。
+
           # 大 PR 只给 gh pr diff 不够：Claude 需要进文件看上下文、比对 commit，
-          # 会伸手 Read/Grep/git diff 等工具。补齐只读检视工具并放宽轮次上限，
-          # 避免评审因 permission denial 撞满轮次、评论冻在「进行中」。
+          # 会伸手 Read/Grep/git diff 等工具。补齐只读检视工具与 PR review/checks/api
+          # 并放宽轮次上限，避免评审因 permission denial 撞满轮次、评论冻在「进行中」。
           claude_args: |
             --model claude-opus-4-8
+            --effort high
             --max-turns 60
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,LS,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Grep,Glob,LS,Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*)"
 
       - name: Warn when credential missing
         if: env.CLAUDE_CODE_OAUTH_TOKEN == ''


### PR DESCRIPTION
## 做什么

参照 bkn-studio 的 `automation-claude-review.yml`，把本仓 Claude 评审从「只贴评论」升级为**评审通过即 approve 的放行门**。

## 改动

- **审核过=放行**：评审落成一次真正的 PR review，三选一——有确定缺陷 `--request-changes`；有「待确认」项未澄清 `--comment`（不 approve）；无阻塞 + 待确认全澄清 + 必需检查不失败不 pending `--approve`。以 `github-actions[bot]` 身份表态，不合并，人工仍自行 merge。
- **评论触发复评**：新增 `issue_comment` / `pull_request_review_comment` 事件。作者不改代码、只回帖澄清「待确认」项即可触发复评补 approve。
- **并发隔离**：concurrency 按事件类分组——push 组 `cancel-in-progress`；评论按 `comment.id` 各自成组，避免 bot 进度评论触发的 `issue_comment` 把正在跑的复评取消掉。
- **权限收敛**：job `if` 过滤 bot 自评论 + 限 `OWNER/MEMBER/COLLABORATOR`，挡 fork 陌生人 pwn-request。
- **effort high**：`claude_args` 加 `--effort high`；补 `checks/statuses` 读权限与 `gh pr review/checks/api` 工具。

paths 与评审重点（正确性/安全/兼容性/测试）保留本仓原样。

🤖 Generated with [Claude Code](https://claude.com/claude-code)