### PR TITLE
feat(trace): 完成第三方 Agent 业务 Interaction E2E

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 # Build output
 dist/
 build/
+.tmp-example/
 *.tsbuildinfo
 
 # Test / coverage

--- a/TRACE.md
+++ b/TRACE.md
@@ -1,87 +1,82 @@
-# bkn-sdk / openbkn CLI Trace Contract
+# bkn-sdk / openbkn CLI BKN Trace 接入规范
 
-> Status: phase-two helper baseline  
-> Contract version: `bkn.trace.schema.version=1.0.0` for phase-one fixture validation; `2.0.0` for evidence event emission  
-> Reference: `bkn-docs/docs/foundry/bkn-trace/design/阶段一：OpenBKN 可观测记录规范与 Trace Context 基线.md`, `bkn-docs/docs/foundry/bkn-trace/design/阶段二：证据引用采集与 BKN Trace 核心能力开发计划.md`
+> 状态：BKN Trace 2.1 业务事件接入基线
+> 默认写入版本：`bkn.trace.schema.version=2.1.0`
+> 兼容读取/校验：`1.0.0`、`2.0.0`、`2.1.0`
 
-## Module
+## 模块身份
 
-- module name: `sdk-cli`
-- owner: OpenBKN SDK
-- service identity: SDK / CLI caller
-- runtime: TypeScript / Node.js
-- repository path: `bkn-sdk`
-- contract version: `1.0.0` for trace context / fixture validation, `2.0.0` for evidence ingestion
+- 模块：`sdk-cli`
+- 观测对象：使用 SDK/CLI 调用 OpenBKN 的第三方 Agent 和 AI 应用
+- 职责：传播统一 Trace Context，并显式记录业务事实、结论、证据、业务引用和 Action 生命周期
+- 非职责：SDK 不根据普通 HTTP 返回内容猜测或自动生成业务结论
 
-## Entry Operations
+## Trace Context
 
-| operation | trigger | required context | emitted spans | emitted events |
-| --- | --- | --- | --- | --- |
-| `sdk.request` | SDK consumer calls an OpenBKN API | optional caller trace context | none in phase one | none in phase one |
-| `sdk.openbkn.call` | SDK HTTP request to OpenBKN | `traceparent`, `bkn-request-id` | none in phase one | none in phase one |
-| `cli.command` | `openbkn` command invocation | optional caller trace context | none in phase one | none in phase one |
-| `cli.trace.validate_fixture` | fixture validation command or equivalent | local request context | none in phase one | validation result output |
-| `cli.trace.evidence.emit` | `openbkn trace evidence emit <file>` | evidence batch trace context | none | server-side `claim.created` / `evidence.refs.created` / `business.refs.resolved` ingestion |
+调用方可通过 `ClientOptions.trace` 传入 `requestId`、`traceparent` 和 allowlist baggage。缺失或非法的 request id / W3C traceparent 会由 SDK 生成。所有 OpenBKN HTTP 请求传播：
 
-## Inbound Context
+- `traceparent`
+- `bkn-request-id`
+- `x-request-id`
+- baggage allowlist：`bkn.account.type`、`bkn.runtime.env`
 
-- accepted options: `ClientOptions.trace.requestId`, `ClientOptions.trace.traceparent`, `ClientOptions.trace.baggage`
-- request id parsing: valid `req_<id>` is preserved; invalid or missing values generate `req_<uuid>`
-- traceparent parsing: valid W3C version `00` is preserved; invalid, all-zero trace id, or all-zero span id generate a new internal traceparent
-- baggage policy: allowlist-only; only `bkn.account.type` and `bkn.runtime.env` propagate
+SDK 当前不自行启动 OpenTelemetry span；服务端 span、日志和业务事件通过同一 `trace_id` 与 `bkn.request.id` 关联。
 
-## Outbound Calls
+## 业务事件
 
-| target | protocol | propagated fields | baggage policy | timeout | retry |
-| --- | --- | --- | --- | --- | --- |
-| OpenBKN APIs | HTTP | `traceparent`, `bkn-request-id`, `x-request-id` | allowlist-only baggage | existing request timeout | existing refresh/retry policy |
-| BKN Trace evidence ingestion | HTTP | `traceparent`, `bkn-request-id`, `x-request-id`; evidence batch carries its own `trace` and `events` | allowlist-only baggage | existing request timeout | existing refresh/retry policy |
-| Raw call passthrough | HTTP | generated context plus explicit caller headers | allowlist-only generated baggage; caller extra headers can override deliberately | `RawCallOptions.timeoutMs` | existing refresh/retry policy |
+`client.trace.createSession(...)` 或 `new TraceSession(...)` 提供强类型的 2.1 记录入口：
 
-## Logs
+1. `startInteraction`：记录用户/任务意图的 hash 和运行模式。
+2. `observeOperation`：记录检索、知识读取、数据查询、模型调用、工具调用等业务操作事实。
+3. `createClaim`：创建结论，并校验引用的 event/operation 必须属于当前 session。
+4. `createEvidenceRefs`：把结论关联到受控证据引用和版本。
+5. `resolveBusinessRefs`：把结论还原到本体对象、属性、关系、指标、逻辑或行动。
+6. Action API：强制 `recommended → approval_requested → approved|rejected → executed → result_recorded`；未批准不得执行，拒绝后不得继续。
+7. `flush`：批量提交；失败时保留原 event id，可安全重试。
 
-SDK/CLI phase one does not add persistent logs by default. If commands emit diagnostic output, they must not include token, authorization, cookie, full prompt, full SQL, full request body, full response body, or PII.
+底层 `client.trace.emitEvidenceEvents(body)` 保留给框架和高级调用方，但新接入应优先使用 `TraceSession`。
 
-## Spans
+## 第三方 Agent 示例
 
-SDK/CLI does not start OpenTelemetry spans in phase one. It injects trace context into outbound HTTP requests so server-side spans, logs, and events can join by `trace_id` and `bkn.request.id`.
+示例：[examples/bkn-trace-business-agent.ts](examples/bkn-trace-business-agent.ts)
 
-## Events
+Dry-run 只生成不含凭据、原始 prompt、SQL 或行级数据的 2.1 fixture：
 
-SDK/CLI now exposes a phase-two submit helper for event batches:
+```bash
+npx tsup examples/bkn-trace-business-agent.ts --format esm --out-dir .tmp-example
+node .tmp-example/bkn-trace-business-agent.js --dry-run --out /tmp/bkn-trace-sdk-agent.json
+node dist/cli.js trace validate-fixture /tmp/bkn-trace-sdk-agent.json
+```
 
-- SDK: `client.trace.emitEvidenceEvents(body)`
-- CLI: `openbkn trace evidence emit <file>`
+该文件是 contract dry-run 示例，禁止以 live 模式提交硬编码事实。生产 Agent 必须在真实检索、查询、模型、审批和 Action 发生处调用相同 API，并使用真实返回的 refs；完整本地 E2E 脚本负责验证这一生产路径。
 
-The SDK does not synthesize evidence events automatically. Callers must provide a `2.0.0` batch containing `trace` and `events`, and the server validates `claim.created`, `evidence.refs.created`, and `business.refs.resolved`.
+## 查询
 
-## Sensitive Data Rules
+```bash
+openbkn trace graph <trace-id>
+openbkn trace evidence-chain <trace-id>
+openbkn trace business-graph <trace-id>
+openbkn trace snapshot-preview <trace-id>
+openbkn trace evidence-chain --request-id <request-id>
+```
 
-- never log: token, authorization, cookie, full local config, full request body, full response body, prompt, SQL, PII
-- hash only: future prompt, SQL, tool args, tool result
-- controlled reference: future large object and evidence refs
-- baggage allowlist: `bkn.account.type`, `bkn.runtime.env`
+## 敏感数据边界
 
-## Sampling
+- 禁止记录：token、authorization、cookie、完整配置、完整 prompt、完整 SQL、查询参数、请求/响应全文、PII。
+- 只记录 hash：意图、prompt、SQL、工具参数、工具结果、结论正文。
+- 只记录受控引用：业务对象、数据快照、知识网络版本、文档、工具产物、Action task/artifact。
+- `business refs` 必须来自调用方已解析的结构化结果，不得从自然语言中猜测。
 
-- default: generated traceparent uses sampled flag `01`
-- forced sampling: command failures and validation failures should be treated as forced-sampled by downstream trace collectors when available
-- not sampled behavior: request id still propagates
+## 测试门槛
 
-## Fixtures And Tests
+- `test/unit/trace-context.test.ts`：context 生成、传播和 baggage 过滤。
+- `test/unit/trace-session.test.ts`：因果关联、跨 session 拒绝、Action 状态机和重试幂等。
+- `test/unit/fixture-validate.test.ts`：1.0/2.0/2.1 兼容、事件注册、敏感字段负向校验。
+- `test/unit/trace.test.ts`：事件提交与 Trace/Evidence/Business/Snapshot 查询 API。
+- `npm run ci && npm run build` 必须通过；第三方示例 dry-run 必须通过 `trace validate-fixture`。
 
-| fixture or test | path | purpose | expected result |
-| --- | --- | --- | --- |
-| unit | `test/unit/trace-context.test.ts` | generated request id, valid traceparent propagation, baggage filtering | pass |
-| unit | `test/unit/trace.test.ts` | phase-two evidence emit endpoint path, method, body, response | pass |
-| unit | `test/unit/headers.test.ts` | auth header safety plus generated trace headers | pass |
-| contract fixture | `fixtures/bkn-trace/positive.json` | request id injection shape | pass |
-| contract fixture | `fixtures/bkn-trace/propagation.json` | outbound context propagation shape | pass |
-| contract fixture | `fixtures/bkn-trace/sampling.json` | validation failure forced-sampled shape | pass |
-| contract fixture | `fixtures/bkn-trace/negative_baggage.json` | forbidden baggage key rejection | fail |
+## 已知边界
 
-## Known Gaps
-
-- SDK/CLI exposes `openbkn trace validate-fixture`; bkn-docs remains the source of the shared fixture contract and Python reference validator.
-- SDK/CLI can submit phase-two evidence event batches, but does not yet generate claim/evidence/business events automatically from ordinary SDK calls.
-- Raw call explicit headers can intentionally override generated trace context; this is preserved for operator debugging.
+- 普通 SDK API 调用只自动传播 Trace Context，不会自动推断 claim、evidence 或 business refs。
+- 真实业务语义必须由 Agent/应用在事实发生处通过 `TraceSession` 显式记录。
+- 服务端负责跨批次 `event_id` 幂等、权限过滤、图投影、快照和持久化。

--- a/docs/product-specs/bkn-trace.md
+++ b/docs/product-specs/bkn-trace.md
@@ -23,8 +23,11 @@
 - `TraceSession.flush()`：批量提交并支持失败重试。
 - `client.trace.emitArtifact/artifact`：写入和读取受权的用户问题、结果、查询、数据、逻辑和行动制品。
 - `client.trace.requests.list/get/traces`：查询业务运行列表、详情及其关联技术 Trace。
+- `client.trace.interactions.get`：聚合同一轮业务交互中的多个独立 request/trace。
 - `client.trace.emitEvidenceEvents(...)`：兼容底层 2.0/2.1/2.2 批次提交。
 - `client.trace.graph/evidenceChain/businessGraph/snapshotPreview`：查询展示所需数据。
+
+SDK 的所有出站实现必须复用统一 Trace header builder。Context Loader 的 MCP `initialize`、`notifications/initialized` 和 `tools/call` 与普通 REST 请求同样传播 `traceparent`、`bkn-request-id`、`x-request-id`、`bkn-operation-id`、`bkn-attempt`、`bkn-event-observed-at`，以及调用方显式提供的 conversation/interaction；MCP transport 不得因自行组装认证和 session header 而丢失业务关联上下文。operation 与 observed-at 在创建请求上下文时生成一次，重试必须保持稳定。
 
 ## 业务引用合同
 
@@ -54,4 +57,4 @@ field:<resource_id>:<field_id>
 
 ## 完成标准
 
-第三方 Agent 示例必须先持久化受权 Artifact，再由 2.2 事件引用这些制品，形成完整五层业务链并通过 contract validate。普通日志、Span 和核心事件不得包含凭据或未受控原文；真实 E2E 还必须由服务端业务运行查询结果和 Studio 正式菜单页面共同验收。
+第三方 Agent 示例必须先持久化受权 Artifact，再由 2.2 事件引用这些制品，形成完整五层业务链并通过 contract validate。真实验收运行 `npm run test:e2e:trace-business`：同一 interaction 内的 schema 检索、`run_sql` 和证据发布必须形成至少 3 个独立 request/trace，并能读取完整问题、查询、数据、逻辑和结果制品。普通日志、Span 和核心事件不得包含凭据或未受控原文；真实 E2E 还必须由服务端业务运行查询结果和 Studio 正式菜单页面共同验收。

--- a/docs/product-specs/bkn-trace.md
+++ b/docs/product-specs/bkn-trace.md
@@ -27,7 +27,7 @@
 - `client.trace.emitEvidenceEvents(...)`：兼容底层 2.0/2.1/2.2 批次提交。
 - `client.trace.graph/evidenceChain/businessGraph/snapshotPreview`：查询展示所需数据。
 
-SDK 的所有出站实现必须复用统一 Trace header builder。Context Loader 的 MCP `initialize`、`notifications/initialized` 和 `tools/call` 与普通 REST 请求同样传播 `traceparent`、`bkn-request-id`、`x-request-id`、`bkn-operation-id`、`bkn-attempt`、`bkn-event-observed-at`，以及调用方显式提供的 conversation/interaction；MCP transport 不得因自行组装认证和 session header 而丢失业务关联上下文。operation 与 observed-at 在创建请求上下文时生成一次，重试必须保持稳定。
+SDK 的所有出站实现必须复用统一 Trace header builder。Context Loader 的 MCP `initialize`、`notifications/initialized` 和 `tools/call` 与普通 REST 请求同样传播 `traceparent`、`bkn-request-id`、`x-request-id`、`bkn-operation-id`、`bkn-attempt`、`bkn-event-observed-at`，以及调用方显式提供的 conversation/interaction；MCP transport 不得因自行组装认证和 session header 而丢失业务关联上下文。operation 与 observed-at 在每次逻辑调用开始时生成一次，该调用内的初始化和重试必须保持稳定；长生命周期 client 的不同调用不得复用自动生成值。
 
 ## 业务引用合同
 

--- a/docs/product-specs/bkn-trace.md
+++ b/docs/product-specs/bkn-trace.md
@@ -1,23 +1,36 @@
-# BKN Trace (evidence & observability)
+# BKN Trace：SDK 与第三方 Agent
 
-## Goal
+## 目标
 
-Full-chain observability for agent decisions: inspect the evidence chain ("how was this answer derived"), scan traces against rules, diagnose issues, and build eval sets.
+让任意第三方 Agent 或 AI 应用在调用 OpenBKN 时，不仅留下技术调用链，还能留下可解释、可溯源、可复查的业务链：用户意图、业务操作、结论、证据引用、本体业务对象和 Action 结果。
 
-## User-visible behavior
+## 用户可见能力
 
-- `openbkn trace list` — traces (limit 30); `openbkn trace get <id>` — evidence chain / data provenance for one decision.
-- `openbkn trace scan <id>` — run built-in rules over a trace.
-- `openbkn trace diagnose <id>` — diagnose a trace against built-in diagnostic rules.
-- Eval-set tooling: build rubric-based evaluation sets from traces.
+- 按 `trace id` 或 `request id` 查询技术调用链、证据链和业务语义图。
+- 从结论回到产生结论的知识读取、数据查询、模型/工具操作。
+- 从证据回到有版本的知识网络、数据快照和受控产物引用。
+- 从业务引用看到对象、属性、关系、指标、逻辑和行动，而不是只有 span 数量。
+- 查看 Action 推荐、审批、执行与结果；未批准和已拒绝的 Action 不得显示为已执行。
 
-## SDK touchpoints
+## SDK 接口
 
-- `resources/` trace surface over `api/trace.ts`; rule/prompt assets (yaml + `.prompt.md`) ship as bundled data files.
-- Sub-areas mirror the legacy layout: `scan`, `diagnose`, `eval-set`, `exp`.
+- `client.trace.createSession(...)`：创建 BKN Trace 2.1 强类型业务会话。
+- `TraceSession.startInteraction/observeOperation/createClaim`：建立业务因果链。
+- `TraceSession.createEvidenceRefs/resolveBusinessRefs`：建立证据与本体业务语义链。
+- `TraceSession.recommendAction/.../recordActionResult`：记录受约束的 Action 生命周期。
+- `TraceSession.flush()`：批量提交并支持失败重试。
+- `client.trace.emitEvidenceEvents(...)`：兼容底层 2.0/2.1 批次提交。
+- `client.trace.graph/evidenceChain/businessGraph/snapshotPreview`：查询展示所需数据。
 
-## Edge cases
+## CLI 接口
 
-- Built-in rule/prompt files must be packaged into the build output (not just `src/`).
-- Large traces: render the chain incrementally; `--json` emits the structured graph.
-- Diagnose/scan results cite the specific rule that fired.
+- `openbkn trace graph <trace-id>`
+- `openbkn trace evidence-chain [trace-id] [--request-id <id>]`
+- `openbkn trace business-graph [trace-id] [--request-id <id>]`
+- `openbkn trace snapshot-preview [trace-id] [--request-id <id>]`
+- `openbkn trace validate-fixture <path>`
+- `openbkn trace evidence emit <file>`
+
+## 完成标准
+
+第三方 Agent 示例必须产生完整五层业务链，通过 2.1 contract validate，不包含原始 prompt、SQL、行级数据或凭据；真实 E2E 还必须由服务端查询结果和 Studio 正式菜单页面共同验收。

--- a/docs/product-specs/bkn-trace.md
+++ b/docs/product-specs/bkn-trace.md
@@ -6,7 +6,9 @@
 
 ## 用户可见能力
 
-- 按 `trace id` 或 `request id` 查询技术调用链、证据链和业务语义图。
+- 从可筛选、可分页的业务运行列表进入，不要求业务用户理解或手工输入内部 ID。
+- 按用户问题、业务结果、时间、Agent/应用、业务域、知识网络、状态和证据完整度筛选。
+- 从一条 `request id` 下钻其一个或多个 `trace id`，再查看 Span 技术调用链。
 - 从结论回到产生结论的知识读取、数据查询、模型/工具操作。
 - 从证据回到有版本的知识网络、数据快照和受控产物引用。
 - 从业务引用看到对象、属性、关系、指标、逻辑和行动，而不是只有 span 数量。
@@ -14,13 +16,32 @@
 
 ## SDK 接口
 
-- `client.trace.createSession(...)`：创建 BKN Trace 2.1 强类型业务会话。
+- `client.trace.createSession(...)`：创建 BKN Trace 2.1 兼容或 2.2 业务内容制品会话。
 - `TraceSession.startInteraction/observeOperation/createClaim`：建立业务因果链。
 - `TraceSession.createEvidenceRefs/resolveBusinessRefs`：建立证据与本体业务语义链。
 - `TraceSession.recommendAction/.../recordActionResult`：记录受约束的 Action 生命周期。
 - `TraceSession.flush()`：批量提交并支持失败重试。
-- `client.trace.emitEvidenceEvents(...)`：兼容底层 2.0/2.1 批次提交。
+- `client.trace.emitArtifact/artifact`：写入和读取受权的用户问题、结果、查询、数据、逻辑和行动制品。
+- `client.trace.requests.list/get/traces`：查询业务运行列表、详情及其关联技术 Trace。
+- `client.trace.emitEvidenceEvents(...)`：兼容底层 2.0/2.1/2.2 批次提交。
 - `client.trace.graph/evidenceChain/businessGraph/snapshotPreview`：查询展示所需数据。
+
+## 业务引用合同
+
+SDK 在创建 `business.refs.resolved` 或 Action target 时校验全限定引用：
+
+```text
+kn:<kn_id>
+object:<kn_id>:<object_type_id>
+property:<kn_id>:<object_type_id>:<property_id>
+relation:<kn_id>:<relation_type_id>
+action_type:<kn_id>:<action_type_id>
+metric:<kn_id>:<metric_id>
+resource:<resource_id>
+field:<resource_id>:<field_id>
+```
+
+`object` 表示对象类型，不表示对象实例。实例级信息只能使用平台认可的受控 source/evidence 或 opaque artifact ref，不能在通用事件里裸传业务主键。短引用在 SDK 侧直接拒绝，避免把不可唯一定位的事件提交到核心。
 
 ## CLI 接口
 
@@ -33,4 +54,4 @@
 
 ## 完成标准
 
-第三方 Agent 示例必须产生完整五层业务链，通过 2.1 contract validate，不包含原始 prompt、SQL、行级数据或凭据；真实 E2E 还必须由服务端查询结果和 Studio 正式菜单页面共同验收。
+第三方 Agent 示例必须先持久化受权 Artifact，再由 2.2 事件引用这些制品，形成完整五层业务链并通过 contract validate。普通日志、Span 和核心事件不得包含凭据或未受控原文；真实 E2E 还必须由服务端业务运行查询结果和 Studio 正式菜单页面共同验收。

--- a/examples/bkn-trace-business-agent.ts
+++ b/examples/bkn-trace-business-agent.ts
@@ -1,0 +1,223 @@
+import { createHash, randomBytes } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { type EvidenceIngestRequest, TraceSession, createClient } from "../src/index.js";
+
+const dryRun = process.argv.includes("--dry-run");
+const outputArg = process.argv.indexOf("--out");
+const outputPath = outputArg >= 0 ? process.argv[outputArg + 1] : undefined;
+if (!dryRun) {
+  throw new Error(
+    "This contract example is dry-run only; production events must wrap real operations",
+  );
+}
+
+function hash(value: string): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+const client = createClient({
+  baseUrl: process.env.OPENBKN_BASE_URL ?? "http://127.0.0.1",
+  token: process.env.OPENBKN_TOKEN ?? "dry-run-not-sent",
+  businessDomain: process.env.OPENBKN_BUSINESS_DOMAIN ?? "bd_public",
+});
+const traceContext = client.ctx.trace;
+if (!traceContext) throw new Error("BKN Trace context was not initialized");
+
+const traceId = traceContext.traceparent.split("-")[1];
+if (!traceId) throw new Error("Generated traceparent does not contain a trace id");
+
+let captured: EvidenceIngestRequest | undefined;
+const session = new TraceSession({
+  trace: {
+    trace_id: traceId,
+    traceparent: traceContext.traceparent,
+    "bkn.request.id": traceContext.requestId,
+    business_domain: client.ctx.businessDomain,
+    "bkn.account.id": process.env.OPENBKN_ACCOUNT_ID ?? "account_sdk_example",
+    "bkn.account.type": "app",
+  },
+  producerModule: "third-party-business-agent",
+  spanId: randomBytes(8).toString("hex"),
+  emit: async (body) => {
+    captured = body;
+    return {
+      trace_id: body.trace.trace_id,
+      "bkn.request.id": body.trace["bkn.request.id"],
+      "bkn.trace.schema.version": body["bkn.trace.schema.version"],
+      accepted_event_count: body.events.length,
+      claim_count: 1,
+      evidence_ref_count: 2,
+      business_ref_count: 3,
+    };
+  },
+});
+
+const interaction = session.startInteraction({
+  operationName: "supplychain.shortage.assess",
+  intentHash: hash("评估关键物料短缺风险并创建监控任务"),
+  mode: "task",
+  appRef: "app:sdk-business-agent-example",
+});
+const retrieval = session.observeOperation("retrieval.completed", {
+  operationName: "supplychain.knowledge.retrieve",
+  causationEventId: interaction.event_id,
+  payload: {
+    query_hash: hash("关键物料、供应商与库存关系"),
+    candidate_count: 3,
+    truncated: false,
+    version_status: "versioned",
+  },
+});
+const knowledge = session.observeOperation("knowledge.read.observed", {
+  operationName: "supplychain.knowledge.read",
+  causationEventId: retrieval.event_id,
+  payload: {
+    kn_id: "supplychain",
+    read_kind: "object_relation_schema",
+    version_status: "versioned",
+    schema_version: "supplychain:v3",
+    business_refs: ["object-type:material", "object-type:supplier", "relation-type:supplied_by"],
+  },
+});
+const data = session.observeOperation("data.query.observed", {
+  operationName: "supplychain.inventory.aggregate",
+  causationEventId: knowledge.event_id,
+  payload: {
+    query_hash: hash("按物料汇总可用库存和未来七日需求"),
+    query_type: "aggregate",
+    row_count: 2,
+    resource_refs: ["data-view:material-availability:v5"],
+    version_status: "versioned",
+  },
+});
+const model = session.observeOperation("model.call.observed", {
+  operationName: "supplychain.risk.reason",
+  causationEventId: data.event_id,
+  payload: {
+    model_name: "risk-reasoner-v1",
+    model_provider: "openai-compatible",
+    input_token_count: 420,
+    output_token_count: 96,
+    prompt_hash: hash("knowledge-and-data-refs"),
+    output_hash: hash("material-M-1001-shortage-risk"),
+    status: "ok",
+  },
+});
+const claim = session.createClaim({
+  operationName: "supplychain.claim.create",
+  causationEventId: model.event_id,
+  claimId: "claim_material_M_1001_shortage",
+  claimType: "recommendation",
+  claimHash: hash("物料 M-1001 存在七日内短缺风险，建议创建监控任务"),
+  sourceEventIds: [knowledge.event_id, data.event_id, model.event_id],
+  operationIds: [
+    knowledge.operation_id as string,
+    data.operation_id as string,
+    model.operation_id as string,
+  ],
+  versionStatus: "versioned",
+});
+const evidence = session.createEvidenceRefs({
+  operationName: "supplychain.evidence.link",
+  claimId: claim.claim_id as string,
+  refs: [
+    {
+      refId: "evidence:knowledge:supplychain-v3",
+      refType: "knowledge_network",
+      sourceSystem: "bkn",
+      validity: "available",
+      versionStatus: "versioned",
+      visibility: "visible",
+      summaryHash: hash("kn:supplychain:v3"),
+    },
+    {
+      refId: "evidence:data:material-availability-v5",
+      refType: "data_resource",
+      sourceSystem: "vega",
+      validity: "observed",
+      versionStatus: "versioned",
+      visibility: "visible",
+      summaryHash: hash("data-view:material-availability:v5"),
+    },
+  ],
+});
+session.resolveBusinessRefs({
+  operationName: "supplychain.business.resolve",
+  claimId: claim.claim_id as string,
+  causationEventId: evidence.event_id,
+  resolverStatus: "resolved",
+  refs: [
+    {
+      refId: "object:material:M-1001",
+      refType: "object",
+      sourceSystem: "bkn",
+      validity: "available",
+      versionStatus: "versioned",
+      visibility: "visible",
+    },
+    {
+      refId: "property:material:available_quantity",
+      refType: "property",
+      sourceSystem: "bkn",
+      validity: "available",
+      versionStatus: "versioned",
+      visibility: "visible",
+    },
+    {
+      refId: "relation:material:M-1001:supplier:S-2001",
+      refType: "relation",
+      sourceSystem: "bkn",
+      validity: "available",
+      versionStatus: "versioned",
+      visibility: "visible",
+    },
+  ],
+});
+const action = session.recommendAction({
+  operationName: "supplychain.monitor.recommend",
+  claimId: claim.claim_id as string,
+  actionType: "create_shortage_monitor",
+  targetRefs: ["object:material:M-1001"],
+  reasonHash: hash("claim_material_M_1001_shortage"),
+});
+session.requestActionApproval(action, { policyRef: "policy:reversible-monitor-task" });
+session.approveAction(action, {
+  actorRef: "account:example-approver",
+  policyDecisionRef: "policy-decision:allow-monitor-task",
+});
+session.executeAction(action, {
+  status: "ok",
+  invocationRef: "tool:create-shortage-monitor",
+});
+session.recordActionResult(action, {
+  status: "created",
+  resultHash: hash("monitor-task-created"),
+  taskRef: "monitor-task:dry-run-001",
+});
+
+await session.flush();
+
+if (!captured) throw new Error("No BKN Trace event batch was produced");
+const fixture = {
+  fixture_id: "sdk_third_party_business_agent_2_1",
+  "bkn.trace.schema.version": "2.1.0",
+  expected_result: "pass",
+  trace: captured.trace,
+  baggage: { "bkn.account.type": "app" },
+  spans: [
+    {
+      span_id: captured.events[0]?.span_id,
+      parent_span_id: null,
+      name: "third-party-business-agent",
+      "bkn.module.name": "third-party-business-agent",
+      "bkn.operation.name": "supplychain.shortage.assess",
+      "bkn.status": "ok",
+      "bkn.timestamp": captured.events[0]?.observed_at,
+    },
+  ],
+  logs: [],
+  events: captured.events,
+};
+const serialized = `${JSON.stringify(fixture, null, 2)}\n`;
+if (outputPath) writeFileSync(outputPath, serialized);
+else process.stdout.write(serialized);

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lint": "npm run check:deps && biome check . && tsc --noEmit",
     "format": "biome format --write .",
     "test": "vitest run",
+    "test:e2e:trace-business": "npm run build && node test/e2e/bkn-trace-business-interaction.mjs",
     "test:cover": "vitest run --coverage",
     "ci": "npm run lint && npm test",
     "prepublishOnly": "npm run ci && npm run build"

--- a/src/api/context-loader.ts
+++ b/src/api/context-loader.ts
@@ -7,6 +7,7 @@
  * notifications/initialized, then tools/call. Handles plain-JSON and
  * SSE (`data:`) response bodies. Per-process session cache (5 min TTL).
  */
+import { createOperationTraceContext } from "../trace-context.js";
 import type { RequestContext } from "../types.js";
 import { HttpError } from "../utils/errors.js";
 import { authFetch } from "./auth-fetch.js";
@@ -27,6 +28,10 @@ function nextId(): number {
 
 function mcpUrl(ctx: RequestContext): string {
   return `${ctx.baseUrl}${MCP_PATH}`;
+}
+
+function operationContext(ctx: RequestContext): RequestContext {
+  return ctx.trace ? { ...ctx, trace: createOperationTraceContext(ctx.trace) } : ctx;
 }
 
 /**
@@ -130,8 +135,9 @@ export async function callTool(
   name: string,
   args: Record<string, unknown>,
 ): Promise<unknown> {
-  const sessionId = await ensureSession(ctx, knId);
-  const { text } = await post(ctx, knId, sessionId, {
+  const operationCtx = operationContext(ctx);
+  const sessionId = await ensureSession(operationCtx, knId);
+  const { text } = await post(operationCtx, knId, sessionId, {
     jsonrpc: "2.0",
     method: "tools/call",
     params: { name, arguments: args },
@@ -147,8 +153,9 @@ export async function callMethod(
   method: string,
   params: Record<string, unknown> = {},
 ): Promise<unknown> {
-  const sessionId = await ensureSession(ctx, knId);
-  const { text } = await post(ctx, knId, sessionId, {
+  const operationCtx = operationContext(ctx);
+  const sessionId = await ensureSession(operationCtx, knId);
+  const { text } = await post(operationCtx, knId, sessionId, {
     jsonrpc: "2.0",
     method,
     params: Object.keys(params).length > 0 ? params : undefined,

--- a/src/api/context-loader.ts
+++ b/src/api/context-loader.ts
@@ -10,6 +10,7 @@
 import type { RequestContext } from "../types.js";
 import { HttpError } from "../utils/errors.js";
 import { authFetch } from "./auth-fetch.js";
+import { buildHeaders } from "./headers.js";
 import { request } from "./http.js";
 import { tlsFetch } from "./tls.js";
 
@@ -39,15 +40,13 @@ export function mcpInfo(ctx: RequestContext): Promise<unknown> {
 }
 
 function headers(ctx: RequestContext, knId: string, sessionId?: string): Record<string, string> {
-  const h: Record<string, string> = {
+  return buildHeaders(ctx, {
     "content-type": "application/json",
     accept: "application/json, text/event-stream",
     "x-kn-id": knId,
     "mcp-protocol-version": PROTOCOL,
-    authorization: `Bearer ${ctx.token}`,
-  };
-  if (sessionId) h["mcp-session-id"] = sessionId;
-  return h;
+    ...(sessionId ? { "mcp-session-id": sessionId } : {}),
+  });
 }
 
 /** Parse a JSON-RPC response body that may be plain JSON or an SSE stream. */

--- a/src/api/headers.ts
+++ b/src/api/headers.ts
@@ -22,6 +22,8 @@ export function buildHeaders(
           "bkn-request-id": ctx.trace.requestId,
           "x-request-id": ctx.trace.requestId,
           traceparent: ctx.trace.traceparent,
+          ...(ctx.trace.conversationId ? { "bkn-conversation-id": ctx.trace.conversationId } : {}),
+          ...(ctx.trace.interactionId ? { "bkn-interaction-id": ctx.trace.interactionId } : {}),
         }
       : {}),
     ...(baggage ? { baggage } : {}),

--- a/src/api/headers.ts
+++ b/src/api/headers.ts
@@ -24,6 +24,9 @@ export function buildHeaders(
           traceparent: ctx.trace.traceparent,
           ...(ctx.trace.conversationId ? { "bkn-conversation-id": ctx.trace.conversationId } : {}),
           ...(ctx.trace.interactionId ? { "bkn-interaction-id": ctx.trace.interactionId } : {}),
+          ...(ctx.trace.operationId ? { "bkn-operation-id": ctx.trace.operationId } : {}),
+          ...(ctx.trace.attempt ? { "bkn-attempt": String(ctx.trace.attempt) } : {}),
+          ...(ctx.trace.observedAt ? { "bkn-event-observed-at": ctx.trace.observedAt } : {}),
         }
       : {}),
     ...(baggage ? { baggage } : {}),

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -18,6 +18,8 @@ export interface RequestInitEx {
   /** Query params appended to the path. */
   query?: Record<string, string | number | boolean | Array<string | number | boolean> | undefined>;
   headers?: Record<string, string>;
+  /** Redirect policy; credential-bearing writes should use `manual`. */
+  redirect?: "follow" | "error" | "manual";
   /** Per-request timeout; defaults to 30s. */
   timeoutMs?: number;
 }
@@ -50,6 +52,7 @@ export async function request<T = unknown>(
         ...init.headers,
       }),
       body: hasBody ? JSON.stringify(init.body) : undefined,
+      redirect: init.redirect,
       signal: controller.signal,
     });
 

--- a/src/api/trace.ts
+++ b/src/api/trace.ts
@@ -42,9 +42,27 @@ export interface EvidenceTraceContext {
   "bkn.account.type": string;
 }
 
+export type BusinessEvidenceEventType =
+  | "agent.interaction.started"
+  | "retrieval.completed"
+  | "knowledge.read.observed"
+  | "data.query.observed"
+  | "model.call.observed"
+  | "tool.called"
+  | "tool.result.observed"
+  | "claim.created"
+  | "evidence.refs.created"
+  | "business.refs.resolved"
+  | "action.recommended"
+  | "action.approval_requested"
+  | "action.approved"
+  | "action.rejected"
+  | "action.executed"
+  | "action.result_recorded";
+
 export interface EvidenceEvent {
   event_id: string;
-  event_type: string;
+  event_type: BusinessEvidenceEventType | (string & {});
   "bkn.trace.schema.version": string;
   observed_at: string;
   emitted_at: string;
@@ -53,11 +71,16 @@ export interface EvidenceEvent {
   span_id: string;
   "bkn.request.id": string;
   "bkn.operation.name": string;
+  interaction_id?: string;
+  operation_id?: string;
+  causation_event_id?: string;
+  claim_id?: string;
+  attempt?: number;
   payload: Record<string, unknown>;
 }
 
 export interface EvidenceIngestRequest {
-  "bkn.trace.schema.version": "2.0.0";
+  "bkn.trace.schema.version": "2.0.0" | "2.1.0";
   trace: EvidenceTraceContext;
   events: EvidenceEvent[];
 }

--- a/src/api/trace.ts
+++ b/src/api/trace.ts
@@ -391,6 +391,7 @@ export function emitEvidenceEvents(
     method: "POST",
     body,
     headers: evidenceWriteHeaders(ctx),
+    redirect: "manual",
   });
 }
 
@@ -403,6 +404,7 @@ export function emitEvidenceArtifact(
     method: "POST",
     body,
     headers: evidenceWriteHeaders(ctx),
+    redirect: "manual",
   });
 }
 

--- a/src/api/trace.ts
+++ b/src/api/trace.ts
@@ -14,6 +14,7 @@ const SEARCH = "/api/agent-observability/v1/traces/_search";
 const EVIDENCE_EVENTS = "/api/agent-observability/v1/evidence/events";
 const EVIDENCE_ARTIFACTS = "/api/agent-observability/v1/evidence/artifacts";
 const REQUESTS = "/api/agent-observability/v1/requests";
+const INTERACTIONS = "/api/agent-observability/v1/interactions";
 const TRACES = "/api/agent-observability/v1/traces";
 
 interface SearchHits {
@@ -143,6 +144,8 @@ export interface ActionSummary {
 
 export interface RequestSummary {
   request_id: string;
+  conversation_id?: string;
+  interaction_id?: string;
   started_at?: string;
   completed_at?: string;
   initiator?: string;
@@ -164,6 +167,8 @@ export interface RequestSummary {
 export interface TraceExecutionSummary {
   trace_id: string;
   request_id: string;
+  conversation_id?: string;
+  interaction_id?: string;
   started_at?: string;
   completed_at?: string;
   agent_or_app?: string;
@@ -192,9 +197,22 @@ export interface RequestSummaryQuery {
   status?: string;
   agentOrApp?: string;
   businessDomain?: string;
+  conversationId?: string;
+  interactionId?: string;
   knowledgeNetwork?: string;
   evidenceCompleteness?: string;
   keyword?: string;
+}
+
+export interface InteractionSummary {
+  interaction_id: string;
+  conversation_id?: string;
+  started_at?: string;
+  completed_at?: string;
+  status: string;
+  duration_ms?: number;
+  requests: RequestSummary[];
+  traces: TraceExecutionSummary[];
 }
 
 export interface EvidenceIngestResponse {
@@ -369,7 +387,11 @@ export function emitEvidenceEvents(
   ctx: RequestContext,
   body: EvidenceIngestRequest,
 ): Promise<EvidenceIngestResponse> {
-  return request<EvidenceIngestResponse>(ctx, EVIDENCE_EVENTS, { method: "POST", body });
+  return request<EvidenceIngestResponse>(ctx, EVIDENCE_EVENTS, {
+    method: "POST",
+    body,
+    headers: evidenceWriteHeaders(ctx),
+  });
 }
 
 /** Store authorized BKN Trace 2.2 business content separately from core events. */
@@ -380,7 +402,14 @@ export function emitEvidenceArtifact(
   return request<EvidenceArtifactIngestResponse>(ctx, EVIDENCE_ARTIFACTS, {
     method: "POST",
     body,
+    headers: evidenceWriteHeaders(ctx),
   });
+}
+
+function evidenceWriteHeaders(ctx: RequestContext): Record<string, string> | undefined {
+  return ctx.evidenceIngestToken
+    ? { "x-bkn-trace-ingest-token": ctx.evidenceIngestToken }
+    : undefined;
 }
 
 /** Read one authorized BKN Trace 2.2 artifact by opaque id. */
@@ -403,6 +432,13 @@ export function listRequestSummaries(
 
 export function getRequestSummary(ctx: RequestContext, requestId: string): Promise<RequestSummary> {
   return request<RequestSummary>(ctx, `${REQUESTS}/${encodeURIComponent(requestId)}`);
+}
+
+export function getInteractionSummary(
+  ctx: RequestContext,
+  interactionId: string,
+): Promise<InteractionSummary> {
+  return request<InteractionSummary>(ctx, `${INTERACTIONS}/${encodeURIComponent(interactionId)}`);
 }
 
 export function getRequestTraces(
@@ -529,6 +565,8 @@ function summaryQuery(query: RequestSummaryQuery): Record<string, string | numbe
   if (query.status) result.status = query.status;
   if (query.agentOrApp) result.agent_or_app = query.agentOrApp;
   if (query.businessDomain) result.business_domain = query.businessDomain;
+  if (query.conversationId) result.conversation_id = query.conversationId;
+  if (query.interactionId) result.interaction_id = query.interactionId;
   if (query.knowledgeNetwork) result.knowledge_network = query.knowledgeNetwork;
   if (query.evidenceCompleteness) {
     result.evidence_completeness = query.evidenceCompleteness;

--- a/src/api/trace.ts
+++ b/src/api/trace.ts
@@ -12,6 +12,8 @@ import { request } from "./http.js";
 
 const SEARCH = "/api/agent-observability/v1/traces/_search";
 const EVIDENCE_EVENTS = "/api/agent-observability/v1/evidence/events";
+const EVIDENCE_ARTIFACTS = "/api/agent-observability/v1/evidence/artifacts";
+const REQUESTS = "/api/agent-observability/v1/requests";
 const TRACES = "/api/agent-observability/v1/traces";
 
 interface SearchHits {
@@ -36,6 +38,7 @@ export interface EvidenceTraceContext {
   trace_id: string;
   traceparent: string;
   "bkn.request.id": string;
+  "bkn.conversation.id"?: string;
   "bkn.tenant.id"?: string;
   business_domain?: string;
   "bkn.account.id": string;
@@ -47,6 +50,7 @@ export type BusinessEvidenceEventType =
   | "retrieval.completed"
   | "knowledge.read.observed"
   | "data.query.observed"
+  | "logic.execution.observed"
   | "model.call.observed"
   | "tool.called"
   | "tool.result.observed"
@@ -80,9 +84,117 @@ export interface EvidenceEvent {
 }
 
 export interface EvidenceIngestRequest {
-  "bkn.trace.schema.version": "2.0.0" | "2.1.0";
+  "bkn.trace.schema.version": "2.0.0" | "2.1.0" | "2.2.0";
   trace: EvidenceTraceContext;
   events: EvidenceEvent[];
+}
+
+export type EvidenceArtifactType =
+  | "action_input"
+  | "action_result"
+  | "data_result"
+  | "logic_execution"
+  | "query"
+  | "question"
+  | "result";
+
+export interface EvidenceArtifact {
+  artifact_id: string;
+  artifact_type: EvidenceArtifactType;
+  "bkn.request.id": string;
+  trace_id?: string;
+  interaction_id?: string;
+  operation_id?: string;
+  claim_id?: string;
+  source_ref?: string;
+  business_refs?: string[];
+  content_type: string;
+  schema_version: "2.2.0";
+  observed_at: string;
+  as_of?: string;
+  source_version?: string;
+  content_hash: string;
+  content?: unknown;
+  snapshot_ref?: string;
+  "bkn.tenant.id"?: string;
+  business_domain?: string;
+  "bkn.account.id": string;
+  "bkn.account.type": string;
+  initiator?: string;
+  agent_or_app?: string;
+}
+
+export interface EvidenceArtifactIngestResponse {
+  artifact_id: string;
+  artifact_type: EvidenceArtifactType;
+  "bkn.request.id": string;
+  trace_id?: string;
+  content_hash: string;
+  created: boolean;
+}
+
+export interface ActionSummary {
+  recommended: number;
+  approved: number;
+  executed: number;
+  completed: number;
+  last_status?: string;
+}
+
+export interface RequestSummary {
+  request_id: string;
+  started_at?: string;
+  completed_at?: string;
+  initiator?: string;
+  agent_or_app?: string;
+  business_domain?: string;
+  knowledge_networks?: string[];
+  question_preview?: string;
+  result_preview?: string;
+  status: string;
+  evidence_completeness: string;
+  partial_reasons?: string[];
+  business_refs?: string[];
+  action_summary: Partial<ActionSummary>;
+  trace_count: number;
+  duration_ms?: number;
+  error_summary?: string;
+}
+
+export interface TraceExecutionSummary {
+  trace_id: string;
+  request_id: string;
+  started_at?: string;
+  completed_at?: string;
+  agent_or_app?: string;
+  business_domain?: string;
+  root_operation?: string;
+  status: string;
+  span_count: number;
+  duration_ms?: number;
+  error_summary?: string;
+}
+
+export interface SummaryPage<T> {
+  entries: T[];
+  total: number;
+  next_cursor?: string | null;
+  truncated: boolean;
+  partial: boolean;
+  partial_reasons?: string[];
+}
+
+export interface RequestSummaryQuery {
+  limit?: number;
+  cursor?: string;
+  from?: string;
+  to?: string;
+  status?: string;
+  agentOrApp?: string;
+  businessDomain?: string;
+  knowledgeNetwork?: string;
+  evidenceCompleteness?: string;
+  keyword?: string;
 }
 
 export interface EvidenceIngestResponse {
@@ -260,6 +372,51 @@ export function emitEvidenceEvents(
   return request<EvidenceIngestResponse>(ctx, EVIDENCE_EVENTS, { method: "POST", body });
 }
 
+/** Store authorized BKN Trace 2.2 business content separately from core events. */
+export function emitEvidenceArtifact(
+  ctx: RequestContext,
+  body: EvidenceArtifact,
+): Promise<EvidenceArtifactIngestResponse> {
+  return request<EvidenceArtifactIngestResponse>(ctx, EVIDENCE_ARTIFACTS, {
+    method: "POST",
+    body,
+  });
+}
+
+/** Read one authorized BKN Trace 2.2 artifact by opaque id. */
+export function getEvidenceArtifact(
+  ctx: RequestContext,
+  artifactId: string,
+): Promise<EvidenceArtifact> {
+  return request<EvidenceArtifact>(ctx, `${EVIDENCE_ARTIFACTS}/${encodeURIComponent(artifactId)}`);
+}
+
+/** List product-facing business request summaries. */
+export function listRequestSummaries(
+  ctx: RequestContext,
+  query: RequestSummaryQuery = {},
+): Promise<SummaryPage<RequestSummary>> {
+  return request<SummaryPage<RequestSummary>>(ctx, REQUESTS, {
+    query: summaryQuery(query),
+  });
+}
+
+export function getRequestSummary(ctx: RequestContext, requestId: string): Promise<RequestSummary> {
+  return request<RequestSummary>(ctx, `${REQUESTS}/${encodeURIComponent(requestId)}`);
+}
+
+export function getRequestTraces(
+  ctx: RequestContext,
+  requestId: string,
+  query: Pick<RequestSummaryQuery, "cursor" | "limit"> = {},
+): Promise<SummaryPage<TraceExecutionSummary>> {
+  return request<SummaryPage<TraceExecutionSummary>>(
+    ctx,
+    `${REQUESTS}/${encodeURIComponent(requestId)}/traces`,
+    { query: summaryQuery(query) },
+  );
+}
+
 export function getTraceGraph(ctx: RequestContext, traceId: string): Promise<TraceGraphResponse> {
   return request<TraceGraphResponse>(ctx, `${TRACES}/${encodeURIComponent(traceId)}/trace-graph`);
 }
@@ -361,4 +518,21 @@ function queryWithLimit(
 ): Record<string, string | number> | undefined {
   if (opts.limit === undefined || !Number.isFinite(opts.limit)) return query;
   return { ...(query ?? {}), limit: opts.limit };
+}
+
+function summaryQuery(query: RequestSummaryQuery): Record<string, string | number> | undefined {
+  const result: Record<string, string | number> = {};
+  if (query.limit !== undefined && Number.isFinite(query.limit)) result.limit = query.limit;
+  if (query.cursor) result.cursor = query.cursor;
+  if (query.from) result.from = query.from;
+  if (query.to) result.to = query.to;
+  if (query.status) result.status = query.status;
+  if (query.agentOrApp) result.agent_or_app = query.agentOrApp;
+  if (query.businessDomain) result.business_domain = query.businessDomain;
+  if (query.knowledgeNetwork) result.knowledge_network = query.knowledgeNetwork;
+  if (query.evidenceCompleteness) {
+    result.evidence_completeness = query.evidenceCompleteness;
+  }
+  if (query.keyword) result.keyword = query.keyword;
+  return Object.keys(result).length ? result : undefined;
 }

--- a/src/bkn-trace/fixture-validate.ts
+++ b/src/bkn-trace/fixture-validate.ts
@@ -4,7 +4,8 @@
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
-const CONTRACT_VERSION = "1.0.0";
+const CONTRACT_VERSIONS = new Set(["1.0.0", "2.0.0", "2.1.0"]);
+const BUSINESS_CONTRACT_VERSION = "2.1.0";
 const TRACEPARENT_RE = /^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}$/;
 const REQUEST_ID_RE = /^req_[0-9A-Za-z_.-]+$/;
 const RFC3339_NANO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$/;
@@ -51,6 +52,169 @@ const SENSITIVE_PATTERNS = [
   /https?:\/\/[^\s"']+/i,
   /[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}/,
 ];
+const BUSINESS_EVENT_TYPES = new Set([
+  "agent.interaction.started",
+  "retrieval.completed",
+  "knowledge.read.observed",
+  "data.query.observed",
+  "model.call.observed",
+  "tool.called",
+  "tool.result.observed",
+  "claim.created",
+  "evidence.refs.created",
+  "business.refs.resolved",
+  "action.recommended",
+  "action.approval_requested",
+  "action.approved",
+  "action.rejected",
+  "action.executed",
+  "action.result_recorded",
+]);
+const CLAIM_EVENT_TYPES = new Set([
+  "claim.created",
+  "evidence.refs.created",
+  "business.refs.resolved",
+  "action.recommended",
+  "action.approval_requested",
+  "action.approved",
+  "action.rejected",
+  "action.executed",
+  "action.result_recorded",
+]);
+const ACTION_TRANSITIONS: Record<string, Set<string>> = {
+  recommended: new Set(["approval_requested"]),
+  approval_requested: new Set(["approved", "rejected"]),
+  approved: new Set(["executed"]),
+  executed: new Set(["result_recorded"]),
+  rejected: new Set(),
+  result_recorded: new Set(),
+};
+const ACTION_STATE_BY_EVENT: Record<string, string> = {
+  "action.recommended": "recommended",
+  "action.approval_requested": "approval_requested",
+  "action.approved": "approved",
+  "action.rejected": "rejected",
+  "action.executed": "executed",
+  "action.result_recorded": "result_recorded",
+};
+interface FixtureActionState {
+  state: string;
+  claimID: string;
+  operationID: string;
+  lastEventID: string;
+}
+const EVENT_PAYLOAD_FIELDS: Record<string, Set<string>> = {
+  "agent.interaction.started": new Set(["intent_hash", "mode", "agent_id", "app_ref"]),
+  "retrieval.completed": new Set([
+    "query_hash",
+    "candidate_count",
+    "truncated",
+    "version_status",
+    "source_refs",
+  ]),
+  "knowledge.read.observed": new Set([
+    "kn_id",
+    "read_kind",
+    "version_status",
+    "schema_version",
+    "business_refs",
+  ]),
+  "data.query.observed": new Set([
+    "query_hash",
+    "query_type",
+    "row_count",
+    "truncated",
+    "as_of",
+    "version_status",
+    "resource_refs",
+    "field_refs",
+  ]),
+  "model.call.observed": new Set([
+    "model_name",
+    "model_provider",
+    "status",
+    "input_token_count",
+    "output_token_count",
+    "prompt_hash",
+    "output_hash",
+    "error_category",
+    "error_hash",
+  ]),
+  "tool.called": new Set(["tool_id", "tool_name", "args_hash", "visibility", "version_status"]),
+  "tool.result.observed": new Set([
+    "tool_id",
+    "tool_name",
+    "status",
+    "result_hash",
+    "result_length",
+    "result_count",
+    "error_hash",
+    "error_category",
+    "visibility",
+    "version_status",
+  ]),
+  "claim.created": new Set([
+    "claim_id",
+    "claim_type",
+    "claim_hash",
+    "source_event_ids",
+    "operation_ids",
+    "visibility",
+    "version_status",
+  ]),
+  "evidence.refs.created": new Set(["claim_id", "evidence_refs"]),
+  "business.refs.resolved": new Set(["claim_id", "resolver_status", "business_refs"]),
+  "action.recommended": new Set([
+    "action_instance_id",
+    "action_type",
+    "target_refs",
+    "reason_hash",
+    "status",
+  ]),
+  "action.approval_requested": new Set(["action_instance_id", "policy_ref", "status"]),
+  "action.approved": new Set(["action_instance_id", "actor_ref", "policy_decision_ref", "status"]),
+  "action.rejected": new Set(["action_instance_id", "actor_ref", "policy_decision_ref", "status"]),
+  "action.executed": new Set([
+    "action_instance_id",
+    "invocation_ref",
+    "tool_ref",
+    "status",
+    "error_category",
+    "error_hash",
+  ]),
+  "action.result_recorded": new Set([
+    "action_instance_id",
+    "result_hash",
+    "artifact_ref",
+    "task_ref",
+    "status",
+  ]),
+};
+const REFERENCE_FIELDS = new Set([
+  "ref_id",
+  "ref_type",
+  "source_system",
+  "validity",
+  "version_status",
+  "visibility",
+  "summary_hash",
+]);
+const FORBIDDEN_RAW_KEYS = new Set([
+  "authorization",
+  "cookie",
+  "access_token",
+  "refresh_token",
+  "id_token",
+  "api_key",
+  "password",
+  "private_key",
+  "prompt",
+  "user_question",
+  "approval_comment",
+  "sql",
+  "query_params",
+  "rows",
+]);
 
 export interface FixtureValidationError {
   code: string;
@@ -131,8 +295,27 @@ function checkSensitive(value: unknown, path: string, errors: FixtureValidationE
     return;
   }
   if (value && typeof value === "object") {
-    for (const [key, child] of Object.entries(value))
+    for (const [key, child] of Object.entries(value)) {
+      if (FORBIDDEN_RAW_KEYS.has(key.toLowerCase())) {
+        errors.push(
+          err(
+            "BKN_TRACE_SENSITIVE_VALUE_LEAKED",
+            `${path}.${key}`,
+            "raw sensitive field is forbidden",
+          ),
+        );
+      }
+      if (
+        key.endsWith("_hash") &&
+        child !== "" &&
+        (typeof child !== "string" || !/^sha256:[0-9a-f]{64}$/.test(child))
+      ) {
+        errors.push(
+          err("BKN_TRACE_REQUIRED_FIELD_MISSING", `${path}.${key}`, `${key} must be a sha256 hash`),
+        );
+      }
       checkSensitive(child, `${path}.${key}`, errors);
+    }
     return;
   }
   if (typeof value !== "string") return;
@@ -162,7 +345,7 @@ export function validateFixture(data: unknown): FixtureValidationResult {
         "missing contract version",
       ),
     );
-  } else if (contractVersion !== CONTRACT_VERSION) {
+  } else if (!CONTRACT_VERSIONS.has(contractVersion)) {
     errors.push(
       err(
         "BKN_TRACE_SCHEMA_VERSION_UNSUPPORTED",
@@ -233,8 +416,14 @@ export function validateFixture(data: unknown): FixtureValidationResult {
   });
 
   const events = Array.isArray(root.events) ? root.events : [];
+  const eventIds = new Set<string>();
+  const knownEventIds = new Set<string>();
+  const knownOperationIds = new Set<string>();
+  const knownClaimIds = new Set<string>();
+  const actionStates = new Map<string, FixtureActionState>();
   events.forEach((item, index) => {
     const event = asRecord(item);
+    const eventPath = `$.events[${index}]`;
     checkRequired(event, REQUIRED_EVENT_FIELDS, `$.events[${index}]`, errors);
     checkTimestamp(event.observed_at, `$.events[${index}].observed_at`, errors);
     checkTimestamp(event.emitted_at, `$.events[${index}].emitted_at`, errors);
@@ -248,7 +437,42 @@ export function validateFixture(data: unknown): FixtureValidationResult {
         err("BKN_TRACE_JOIN_FAILED", `$.events[${index}].span_id`, "event span_id not found"),
       );
     }
+    if (typeof event.event_id === "string") {
+      if (eventIds.has(event.event_id)) {
+        errors.push(
+          err("BKN_TRACE_EVENT_ID_CONFLICT", `${eventPath}.event_id`, "duplicate event_id"),
+        );
+      }
+      eventIds.add(event.event_id);
+    }
+    if (contractVersion !== BUSINESS_CONTRACT_VERSION) return;
+    if (event["bkn.trace.schema.version"] !== contractVersion) {
+      errors.push(
+        err(
+          "BKN_TRACE_SCHEMA_VERSION_UNSUPPORTED",
+          `${eventPath}.bkn.trace.schema.version`,
+          "event contract version must match the fixture envelope",
+        ),
+      );
+    }
+    validateBusinessEvent(
+      event,
+      eventPath,
+      knownEventIds,
+      knownOperationIds,
+      knownClaimIds,
+      actionStates,
+      errors,
+    );
+    if (typeof event.event_id === "string") knownEventIds.add(event.event_id);
+    if (typeof event.operation_id === "string") knownOperationIds.add(event.operation_id);
+    if (event.event_type === "claim.created" && typeof event.claim_id === "string") {
+      knownClaimIds.add(event.claim_id);
+    }
   });
+  if (contractVersion !== "1.0.0" && events.length === 0) {
+    errors.push(err("BKN_TRACE_REQUIRED_FIELD_MISSING", "$.events", "at least one event required"));
+  }
 
   const baggage = asRecord(root.baggage);
   for (const key of Object.keys(baggage)) {
@@ -278,6 +502,302 @@ export function validateFixture(data: unknown): FixtureValidationResult {
     expectedResult,
     expectationMatched: expectedResult === null ? result === "pass" : expectedResult === result,
   };
+}
+
+function validateBusinessEvent(
+  event: Record<string, unknown>,
+  path: string,
+  knownEventIds: Set<string>,
+  knownOperationIds: Set<string>,
+  knownClaimIds: Set<string>,
+  actionStates: Map<string, FixtureActionState>,
+  errors: FixtureValidationError[],
+): void {
+  const eventType = typeof event.event_type === "string" ? event.event_type : "";
+  if (!BUSINESS_EVENT_TYPES.has(eventType)) {
+    errors.push(
+      err(
+        "BKN_TRACE_EVENT_TYPE_UNSUPPORTED",
+        `${path}.event_type`,
+        `unsupported event ${eventType}`,
+      ),
+    );
+    return;
+  }
+  checkRequired(event, ["interaction_id"], path, errors);
+  if (eventType !== "agent.interaction.started" && eventType !== "claim.created") {
+    checkRequired(event, ["operation_id"], path, errors);
+  }
+  if (eventType !== "agent.interaction.started") {
+    checkRequired(event, ["causation_event_id"], path, errors);
+    if (
+      typeof event.causation_event_id === "string" &&
+      !knownEventIds.has(event.causation_event_id)
+    ) {
+      errors.push(
+        err(
+          "BKN_TRACE_CAUSATION_INVALID",
+          `${path}.causation_event_id`,
+          "causation_event_id must reference an earlier event",
+        ),
+      );
+    }
+  }
+  if (CLAIM_EVENT_TYPES.has(eventType)) {
+    checkRequired(event, ["claim_id"], path, errors);
+    if (
+      eventType !== "claim.created" &&
+      typeof event.claim_id === "string" &&
+      !knownClaimIds.has(event.claim_id)
+    ) {
+      errors.push(
+        err(
+          "BKN_TRACE_UNKNOWN_CLAIM_ID",
+          `${path}.claim_id`,
+          "event must reference an earlier claim",
+        ),
+      );
+    }
+  }
+  const payload = asRecord(event.payload);
+  checkAllowedKeys(
+    payload,
+    EVENT_PAYLOAD_FIELDS[eventType] ?? new Set(),
+    `${path}.payload`,
+    errors,
+  );
+  if (eventType === "agent.interaction.started") {
+    checkRequired(payload, ["intent_hash", "mode"], `${path}.payload`, errors);
+    checkOneOf(payload, ["agent_id", "app_ref"], `${path}.payload`, errors);
+  }
+  if (eventType === "retrieval.completed") {
+    checkRequired(
+      payload,
+      ["query_hash", "candidate_count", "truncated"],
+      `${path}.payload`,
+      errors,
+    );
+  }
+  if (eventType === "knowledge.read.observed") {
+    checkRequired(payload, ["kn_id", "read_kind", "version_status"], `${path}.payload`, errors);
+  }
+  if (eventType === "data.query.observed") {
+    checkRequired(payload, ["query_hash", "query_type", "row_count"], `${path}.payload`, errors);
+  }
+  if (eventType === "model.call.observed") {
+    checkRequired(
+      payload,
+      [
+        "model_name",
+        "model_provider",
+        "status",
+        "input_token_count",
+        "output_token_count",
+        "prompt_hash",
+        "output_hash",
+      ],
+      `${path}.payload`,
+      errors,
+    );
+    if (payload.status === "error") {
+      checkRequired(payload, ["error_category", "error_hash"], `${path}.payload`, errors);
+    }
+  }
+  if (eventType === "claim.created") {
+    checkRequired(
+      payload,
+      [
+        "claim_id",
+        "claim_type",
+        "claim_hash",
+        "source_event_ids",
+        "operation_ids",
+        "visibility",
+        "version_status",
+      ],
+      `${path}.payload`,
+      errors,
+    );
+    checkNonEmptyArray(payload, "source_event_ids", `${path}.payload`, errors);
+    checkNonEmptyArray(payload, "operation_ids", `${path}.payload`, errors);
+    checkKnownArray(payload, "source_event_ids", knownEventIds, `${path}.payload`, errors);
+    checkKnownArray(payload, "operation_ids", knownOperationIds, `${path}.payload`, errors);
+  }
+  if (eventType === "evidence.refs.created") {
+    checkReferenceList(payload, "evidence_refs", `${path}.payload`, errors);
+  }
+  if (eventType === "business.refs.resolved") {
+    checkRequired(payload, ["resolver_status"], `${path}.payload`, errors);
+    checkReferenceList(
+      payload,
+      "business_refs",
+      `${path}.payload`,
+      errors,
+      payload.resolver_status === "unresolved",
+    );
+  }
+  const actionState = ACTION_STATE_BY_EVENT[eventType];
+  if (!actionState) return;
+  checkRequired(payload, ["action_instance_id", "status"], `${path}.payload`, errors);
+  const fixedStatus: Record<string, string> = {
+    "action.recommended": "recommended",
+    "action.approval_requested": "approval_requested",
+    "action.approved": "approved",
+    "action.rejected": "rejected",
+  };
+  if (fixedStatus[eventType] && payload.status !== fixedStatus[eventType]) {
+    errors.push(
+      err(
+        "BKN_TRACE_ACTION_TRANSITION_INVALID",
+        `${path}.payload.status`,
+        `${eventType} requires status=${fixedStatus[eventType]}`,
+      ),
+    );
+  }
+  if (eventType === "action.recommended") {
+    checkRequired(
+      payload,
+      ["action_type", "target_refs", "reason_hash"],
+      `${path}.payload`,
+      errors,
+    );
+    checkNonEmptyArray(payload, "target_refs", `${path}.payload`, errors);
+  }
+  if (eventType === "action.approval_requested") {
+    checkRequired(payload, ["policy_ref"], `${path}.payload`, errors);
+  }
+  if (eventType === "action.approved" || eventType === "action.rejected") {
+    checkRequired(payload, ["actor_ref", "policy_decision_ref"], `${path}.payload`, errors);
+  }
+  if (eventType === "action.executed") {
+    checkOneOf(payload, ["invocation_ref", "tool_ref"], `${path}.payload`, errors);
+    if (payload.status === "error") {
+      checkRequired(payload, ["error_category", "error_hash"], `${path}.payload`, errors);
+    }
+  }
+  if (eventType === "action.result_recorded") {
+    checkRequired(payload, ["result_hash"], `${path}.payload`, errors);
+    checkOneOf(payload, ["artifact_ref", "task_ref"], `${path}.payload`, errors);
+  }
+  const actionID = typeof payload.action_instance_id === "string" ? payload.action_instance_id : "";
+  if (!actionID) return;
+  const claimID = typeof event.claim_id === "string" ? event.claim_id : "";
+  const operationID = typeof event.operation_id === "string" ? event.operation_id : "";
+  const previous = actionStates.get(actionID);
+  if (
+    (!previous && actionState !== "recommended") ||
+    (previous &&
+      (!ACTION_TRANSITIONS[previous.state]?.has(actionState) ||
+        event.causation_event_id !== previous.lastEventID ||
+        claimID !== previous.claimID ||
+        operationID !== previous.operationID))
+  ) {
+    errors.push(
+      err(
+        "BKN_TRACE_ACTION_TRANSITION_INVALID",
+        `${path}.event_type`,
+        `invalid action transition ${previous?.state ?? "<none>"} -> ${actionState}`,
+      ),
+    );
+    return;
+  }
+  actionStates.set(actionID, {
+    state: actionState,
+    claimID,
+    operationID,
+    lastEventID: String(event.event_id ?? ""),
+  });
+}
+
+function checkOneOf(
+  payload: Record<string, unknown>,
+  fields: string[],
+  path: string,
+  errors: FixtureValidationError[],
+): void {
+  if (fields.some((field) => typeof payload[field] === "string" && payload[field] !== "")) return;
+  errors.push(
+    err(
+      "BKN_TRACE_REQUIRED_FIELD_MISSING",
+      `${path}.${fields[0]}`,
+      `one of ${fields.join(" or ")} is required`,
+    ),
+  );
+}
+
+function checkNonEmptyArray(
+  payload: Record<string, unknown>,
+  field: string,
+  path: string,
+  errors: FixtureValidationError[],
+): void {
+  if (Array.isArray(payload[field]) && payload[field].length > 0) return;
+  errors.push(
+    err(
+      "BKN_TRACE_REQUIRED_FIELD_MISSING",
+      `${path}.${field}`,
+      `${field} must be a non-empty array`,
+    ),
+  );
+}
+
+function checkReferenceList(
+  payload: Record<string, unknown>,
+  field: string,
+  path: string,
+  errors: FixtureValidationError[],
+  allowEmpty = false,
+): void {
+  if (!allowEmpty) checkNonEmptyArray(payload, field, path, errors);
+  const refs = Array.isArray(payload[field]) ? payload[field] : [];
+  refs.forEach((value, index) => {
+    const ref = asRecord(value);
+    checkRequired(
+      ref,
+      ["ref_id", "ref_type", "source_system", "validity", "version_status", "visibility"],
+      `${path}.${field}[${index}]`,
+      errors,
+    );
+    checkAllowedKeys(ref, REFERENCE_FIELDS, `${path}.${field}[${index}]`, errors);
+  });
+}
+
+function checkKnownArray(
+  payload: Record<string, unknown>,
+  field: string,
+  known: Set<string>,
+  path: string,
+  errors: FixtureValidationError[],
+): void {
+  if (!Array.isArray(payload[field])) return;
+  for (const value of payload[field]) {
+    if (typeof value === "string" && known.has(value)) continue;
+    errors.push(
+      err(
+        "BKN_TRACE_CAUSATION_INVALID",
+        `${path}.${field}`,
+        `${field} must reference earlier events or operations`,
+      ),
+    );
+  }
+}
+
+function checkAllowedKeys(
+  value: Record<string, unknown>,
+  allowed: Set<string>,
+  path: string,
+  errors: FixtureValidationError[],
+): void {
+  for (const key of Object.keys(value)) {
+    if (allowed.has(key)) continue;
+    errors.push(
+      err(
+        "BKN_TRACE_EVENT_PAYLOAD_FIELD_UNSUPPORTED",
+        `${path}.${key}`,
+        `payload field ${key} is not registered for this event`,
+      ),
+    );
+  }
 }
 
 export function validateFixturePath(path: string): FixturePathValidationResult {

--- a/src/bkn-trace/fixture-validate.ts
+++ b/src/bkn-trace/fixture-validate.ts
@@ -662,6 +662,7 @@ function validateBusinessEvent(
       errors,
     );
     checkNonEmptyArray(payload, "target_refs", `${path}.payload`, errors);
+    checkQualifiedStringRefs(payload, "target_refs", `${path}.payload`, errors);
   }
   if (eventType === "action.approval_requested") {
     checkRequired(payload, ["policy_ref"], `${path}.payload`, errors);
@@ -759,7 +760,46 @@ function checkReferenceList(
       errors,
     );
     checkAllowedKeys(ref, REFERENCE_FIELDS, `${path}.${field}[${index}]`, errors);
+    if (typeof ref.ref_id === "string" && !isQualifiedReference(ref.ref_id)) {
+      errors.push(
+        err(
+          "BKN_TRACE_REFERENCE_ID_INVALID",
+          `${path}.${field}[${index}].ref_id`,
+          "business reference id must include its knowledge-network or resource scope",
+        ),
+      );
+    }
   });
+}
+
+function checkQualifiedStringRefs(
+  payload: Record<string, unknown>,
+  field: string,
+  path: string,
+  errors: FixtureValidationError[],
+): void {
+  const refs = Array.isArray(payload[field]) ? payload[field] : [];
+  refs.forEach((value, index) => {
+    if (typeof value !== "string" || isQualifiedReference(value)) return;
+    errors.push(
+      err(
+        "BKN_TRACE_REFERENCE_ID_INVALID",
+        `${path}.${field}[${index}]`,
+        "business reference id must include its knowledge-network or resource scope",
+      ),
+    );
+  });
+}
+
+function isQualifiedReference(value: string): boolean {
+  const parts = value.trim().split(":");
+  if (parts.some((part) => part.length === 0)) return false;
+  if (["kn", "resource"].includes(parts[0] ?? "")) return parts.length === 2;
+  if (["object", "relation", "action_type", "metric", "field"].includes(parts[0] ?? "")) {
+    return parts.length === 3;
+  }
+  if (parts[0] === "property") return parts.length === 4;
+  return true;
 }
 
 function checkKnownArray(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,8 @@ program
   .option("--compact", "single-line JSON output")
   .option("--full", "human view: show all columns (default trims to the key ones)")
   .option("--biz-domain <s>", "business domain (alias: -bd)")
+  .option("--conversation-id <id>", "BKN Trace conversation id (env: BKN_CONVERSATION_ID)")
+  .option("--interaction-id <id>", "BKN Trace interaction id (env: BKN_INTERACTION_ID)")
   .option("-k, --insecure", "skip TLS verification (dev / self-signed only)")
   .showHelpAfterError();
 

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -5,18 +5,35 @@
 import { readFileSync } from "node:fs";
 import type { Command } from "commander";
 import { type BknClient, createClient } from "../client.js";
+import type { TraceContextOptions } from "../types.js";
 import { InputError } from "../utils/errors.js";
 import type { OutputOptions } from "../utils/output.js";
+
+export function traceOptionsFrom(o: Record<string, unknown>): TraceContextOptions | undefined {
+  const conversationId =
+    (typeof o.conversationId === "string" ? o.conversationId : undefined) ??
+    process.env.BKN_CONVERSATION_ID;
+  const interactionId =
+    (typeof o.interactionId === "string" ? o.interactionId : undefined) ??
+    process.env.BKN_INTERACTION_ID;
+  if (!conversationId && !interactionId) return undefined;
+  return {
+    ...(conversationId ? { conversationId } : {}),
+    ...(interactionId ? { interactionId } : {}),
+  };
+}
 
 /** Build a client from a command's merged (global + local) options. */
 export function clientFrom(cmd: Command): BknClient {
   const o = cmd.optsWithGlobals();
+  const trace = traceOptionsFrom(o);
   return createClient({
     baseUrl: o.baseUrl,
     token: o.token,
     user: o.user,
     businessDomain: o.bizDomain,
     insecure: o.insecure,
+    ...(trace ? { trace } : {}),
   });
 }
 

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -7,7 +7,7 @@ import { rawCall } from "../api/call.js";
 import { resolveContext } from "../config/resolve.js";
 import { group } from "../help/grouped-help.js";
 import { printJson } from "../utils/output.js";
-import { outputOptions } from "./_shared.js";
+import { outputOptions, traceOptionsFrom } from "./_shared.js";
 
 function collect(value: string, prev: string[]): string[] {
   prev.push(value);
@@ -32,12 +32,14 @@ export function callCommand(): Command {
     .option("-v, --verbose", "print request line to stderr")
     .action(async (url: string, opts, cmd: Command) => {
       const g = cmd.optsWithGlobals();
+      const trace = traceOptionsFrom(g);
       const ctx = resolveContext({
         baseUrl: g.baseUrl,
         token: g.token,
         user: g.user,
         businessDomain: g.bizDomain,
         insecure: g.insecure,
+        ...(trace ? { trace } : {}),
       });
       const res = await rawCall(ctx, url, {
         method: opts.request,

--- a/src/commands/trace.ts
+++ b/src/commands/trace.ts
@@ -159,7 +159,7 @@ export function traceCommand(): Command {
 
   cmd
     .command("validate-fixture <path>")
-    .description("Validate BKN Trace phase-one fixture JSON files")
+    .description("Validate BKN Trace 1.0/2.0/2.1 fixture JSON files")
     .action(async (path: string, _opts, cmd: Command) => {
       const result = validateFixturePath(path);
       printJson(result, outputOptions(cmd));
@@ -168,10 +168,10 @@ export function traceCommand(): Command {
 
   const evidence = cmd
     .command("evidence")
-    .description("Submit BKN Trace phase-two evidence events");
+    .description("Submit BKN Trace 2.x business evidence events");
   evidence
     .command("emit <file>")
-    .description("Submit a phase-two evidence event batch JSON file")
+    .description("Submit a BKN Trace 2.0/2.1 event batch JSON file")
     .action(async (file: string, _opts, cmd: Command) => {
       const body = JSON.parse(readFileSync(file, "utf8"));
       printJson(await clientFrom(cmd).trace.emitEvidenceEvents(body), outputOptions(cmd));

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -86,6 +86,12 @@ export function resolveContext(opts: ClientOptions = {}): RequestContext {
       readPlatformConfig(normalized).businessDomain ??
       DEFAULT_BUSINESS_DOMAIN,
     insecure,
+    ...((opts.evidenceIngestToken ?? process.env.BKN_TRACE_EVIDENCE_INGEST_TOKEN)
+      ? {
+          evidenceIngestToken:
+            opts.evidenceIngestToken ?? process.env.BKN_TRACE_EVIDENCE_INGEST_TOKEN,
+        }
+      : {}),
     // Correlation ids come from `opts.trace` only. The CLI reads its flags and
     // env vars in `commands/_shared.ts`; a library client must not inherit an
     // ambient interaction id it would then freeze for its whole lifetime.

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,15 +49,23 @@ export { vega } from "./resources/vega.js";
 export * as auth from "./resources/auth.js";
 
 export type {
+  ActionSummary,
   BusinessEvidenceEventType,
   BusinessGraphResponse,
+  EvidenceArtifact,
+  EvidenceArtifactIngestResponse,
+  EvidenceArtifactType,
   EvidenceEvent,
   EvidenceChainResponse,
   EvidenceIngestRequest,
   EvidenceIngestResponse,
   EvidenceTraceContext,
   GraphPage,
+  RequestSummary,
+  RequestSummaryQuery,
   SnapshotPreviewResponse,
+  SummaryPage,
+  TraceExecutionSummary,
   TraceGraphEdge,
   TraceGraphNode,
   TraceQueryOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ export type {
   EvidenceIngestResponse,
   EvidenceTraceContext,
   GraphPage,
+  InteractionSummary,
   RequestSummary,
   RequestSummaryQuery,
   SnapshotPreviewResponse,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,23 @@ export {
   DEFAULT_QUERY_LIMIT,
 } from "./types.js";
 export { HttpError, InputError } from "./utils/errors.js";
+export {
+  TraceSession,
+  type ActionHandle,
+  type ActionResultInput,
+  type BusinessRefInput,
+  type BusinessRefsInput,
+  type ClaimInput,
+  type EvidenceRefInput,
+  type EvidenceRefsInput,
+  type ExecuteActionInput,
+  type InteractionInput,
+  type OperationEventPayloadMap,
+  type OperationEventType,
+  type OperationInput,
+  type RecommendActionInput,
+  type TraceSessionOptions,
+} from "./trace-session.js";
 
 // Resource namespaces (advanced: use with a resolved RequestContext).
 export { admin } from "./resources/admin.js";
@@ -32,6 +49,7 @@ export { vega } from "./resources/vega.js";
 export * as auth from "./resources/auth.js";
 
 export type {
+  BusinessEvidenceEventType,
   BusinessGraphResponse,
   EvidenceEvent,
   EvidenceChainResponse,

--- a/src/resources/trace.ts
+++ b/src/resources/trace.ts
@@ -33,6 +33,7 @@ import {
   runEvalSet,
 } from "../bkn-trace/eval-set.js";
 import { validateFixturePath } from "../bkn-trace/fixture-validate.js";
+import { TraceSession, type TraceSessionOptions } from "../trace-session.js";
 import type { RequestContext } from "../types.js";
 
 async function semanticJudge(
@@ -99,6 +100,9 @@ export function trace(ctx: RequestContext) {
     search: (body: unknown) => traceSearch(ctx, body),
     /** Submit BKN Trace phase-two claim/evidence/business events. */
     emitEvidenceEvents: (body: EvidenceIngestRequest) => emitEvidenceEvents(ctx, body),
+    /** Create a typed BKN Trace 2.1 session for an Agent or AI application. */
+    createSession: (options: Omit<TraceSessionOptions, "emit">) =>
+      new TraceSession({ ...options, emit: (body) => emitEvidenceEvents(ctx, body) }),
     /** Normalized trace tree/status graph by trace id. */
     graph: (traceId: string) => getTraceGraph(ctx, traceId),
     /** Claim -> evidence/business refs graph by trace id or BKN request id. */

--- a/src/resources/trace.ts
+++ b/src/resources/trace.ts
@@ -4,16 +4,23 @@
 /** Trace resource surface (data fetch + symbolic/rubric diagnose + eval-set). */
 import { fetchAgentInfo, sendChat } from "../api/agent-chat.js";
 import {
+  type EvidenceArtifact,
   type EvidenceIngestRequest,
+  type RequestSummaryQuery,
   type TraceQueryOptions,
   type TraceScope,
+  emitEvidenceArtifact,
   emitEvidenceEvents,
   getBusinessGraph,
+  getEvidenceArtifact,
   getEvidenceChain,
   getRawSpansByConversation,
+  getRequestSummary,
+  getRequestTraces,
   getSnapshotPreview,
   getSpansByConversation,
   getTraceGraph,
+  listRequestSummaries,
   traceSearch,
 } from "../api/trace.js";
 import { claudeAvailable, judgeJson } from "../bkn-trace/claude-judge.js";
@@ -100,6 +107,17 @@ export function trace(ctx: RequestContext) {
     search: (body: unknown) => traceSearch(ctx, body),
     /** Submit BKN Trace phase-two claim/evidence/business events. */
     emitEvidenceEvents: (body: EvidenceIngestRequest) => emitEvidenceEvents(ctx, body),
+    /** Store one authorized BKN Trace 2.2 business-content artifact. */
+    emitArtifact: (body: EvidenceArtifact) => emitEvidenceArtifact(ctx, body),
+    /** Read one authorized BKN Trace 2.2 business-content artifact. */
+    artifact: (artifactId: string) => getEvidenceArtifact(ctx, artifactId),
+    /** Product-facing business request list and request-to-trace drilldown. */
+    requests: {
+      get: (requestId: string) => getRequestSummary(ctx, requestId),
+      list: (query?: RequestSummaryQuery) => listRequestSummaries(ctx, query),
+      traces: (requestId: string, query?: Pick<RequestSummaryQuery, "cursor" | "limit">) =>
+        getRequestTraces(ctx, requestId, query),
+    },
     /** Create a typed BKN Trace 2.1 session for an Agent or AI application. */
     createSession: (options: Omit<TraceSessionOptions, "emit">) =>
       new TraceSession({ ...options, emit: (body) => emitEvidenceEvents(ctx, body) }),

--- a/src/resources/trace.ts
+++ b/src/resources/trace.ts
@@ -14,6 +14,7 @@ import {
   getBusinessGraph,
   getEvidenceArtifact,
   getEvidenceChain,
+  getInteractionSummary,
   getRawSpansByConversation,
   getRequestSummary,
   getRequestTraces,
@@ -117,6 +118,10 @@ export function trace(ctx: RequestContext) {
       list: (query?: RequestSummaryQuery) => listRequestSummaries(ctx, query),
       traces: (requestId: string, query?: Pick<RequestSummaryQuery, "cursor" | "limit">) =>
         getRequestTraces(ctx, requestId, query),
+    },
+    /** Aggregate all OpenBKN requests and traces for one caller-owned interaction. */
+    interactions: {
+      get: (interactionId: string) => getInteractionSummary(ctx, interactionId),
     },
     /** Create a typed BKN Trace 2.1 session for an Agent or AI application. */
     createSession: (options: Omit<TraceSessionOptions, "emit">) =>

--- a/src/trace-context.ts
+++ b/src/trace-context.ts
@@ -7,6 +7,7 @@ import type { TraceContext, TraceContextOptions } from "./types.js";
 const TRACEPARENT_RE = /^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}$/;
 const REQUEST_ID_RE = /^req_[0-9A-Za-z_.-]+$/;
 const CORRELATION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const RFC3339_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/;
 const ALLOWED_BAGGAGE = new Set(["bkn.account.type", "bkn.runtime.env"]);
 
 export function isValidRequestId(value: string | undefined): value is string {
@@ -35,13 +36,30 @@ export function createTraceContext(opts: TraceContextOptions = {}): TraceContext
   const interactionId = isValidCorrelationId(opts.interactionId)
     ? opts.interactionId.trim()
     : undefined;
+  const operationId = isValidCorrelationId(opts.operationId)
+    ? opts.operationId.trim()
+    : `op_${randomUUID()}`;
+  const attempt =
+    Number.isInteger(opts.attempt) && (opts.attempt ?? 0) >= 1 && (opts.attempt ?? 0) <= 1000
+      ? opts.attempt
+      : 1;
+  const observedAt = isValidObservedAt(opts.observedAt)
+    ? opts.observedAt
+    : new Date().toISOString();
   return {
     requestId,
     traceparent,
     ...(conversationId ? { conversationId } : {}),
     ...(interactionId ? { interactionId } : {}),
+    operationId,
+    attempt,
+    observedAt,
     ...(Object.keys(baggage).length > 0 ? { baggage } : {}),
   };
+}
+
+function isValidObservedAt(value: string | undefined): value is string {
+  return typeof value === "string" && RFC3339_RE.test(value) && !Number.isNaN(Date.parse(value));
 }
 
 export function filterBaggage(baggage: Record<string, string> | undefined): Record<string, string> {

--- a/src/trace-context.ts
+++ b/src/trace-context.ts
@@ -36,25 +36,31 @@ export function createTraceContext(opts: TraceContextOptions = {}): TraceContext
   const interactionId = isValidCorrelationId(opts.interactionId)
     ? opts.interactionId.trim()
     : undefined;
-  const operationId = isValidCorrelationId(opts.operationId)
-    ? opts.operationId.trim()
-    : `op_${randomUUID()}`;
+  const operationId = isValidCorrelationId(opts.operationId) ? opts.operationId.trim() : undefined;
   const attempt =
     Number.isInteger(opts.attempt) && (opts.attempt ?? 0) >= 1 && (opts.attempt ?? 0) <= 1000
       ? opts.attempt
-      : 1;
-  const observedAt = isValidObservedAt(opts.observedAt)
-    ? opts.observedAt
-    : new Date().toISOString();
+      : undefined;
+  const observedAt = isValidObservedAt(opts.observedAt) ? opts.observedAt : undefined;
   return {
     requestId,
     traceparent,
     ...(conversationId ? { conversationId } : {}),
     ...(interactionId ? { interactionId } : {}),
-    operationId,
-    attempt,
-    observedAt,
+    ...(operationId ? { operationId } : {}),
+    ...(attempt ? { attempt } : {}),
+    ...(observedAt ? { observedAt } : {}),
     ...(Object.keys(baggage).length > 0 ? { baggage } : {}),
+  };
+}
+
+/** Create one replay-stable context for a logical operation on a potentially long-lived client. */
+export function createOperationTraceContext(trace: TraceContext): TraceContext {
+  return {
+    ...trace,
+    operationId: trace.operationId ?? `op_${randomUUID()}`,
+    attempt: trace.attempt ?? 1,
+    observedAt: isValidObservedAt(trace.observedAt) ? trace.observedAt : new Date().toISOString(),
   };
 }
 

--- a/src/trace-context.ts
+++ b/src/trace-context.ts
@@ -6,10 +6,15 @@ import type { TraceContext, TraceContextOptions } from "./types.js";
 
 const TRACEPARENT_RE = /^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}$/;
 const REQUEST_ID_RE = /^req_[0-9A-Za-z_.-]+$/;
+const CORRELATION_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const ALLOWED_BAGGAGE = new Set(["bkn.account.type", "bkn.runtime.env"]);
 
 export function isValidRequestId(value: string | undefined): value is string {
   return typeof value === "string" && REQUEST_ID_RE.test(value);
+}
+
+export function isValidCorrelationId(value: string | undefined): value is string {
+  return typeof value === "string" && CORRELATION_ID_RE.test(value.trim());
 }
 
 export function isValidTraceparent(value: string | undefined): value is string {
@@ -24,9 +29,17 @@ export function createTraceContext(opts: TraceContextOptions = {}): TraceContext
   const requestId = isValidRequestId(opts.requestId) ? opts.requestId : `req_${randomUUID()}`;
   const traceparent = isValidTraceparent(opts.traceparent) ? opts.traceparent : newTraceparent();
   const baggage = filterBaggage(opts.baggage);
+  const conversationId = isValidCorrelationId(opts.conversationId)
+    ? opts.conversationId.trim()
+    : undefined;
+  const interactionId = isValidCorrelationId(opts.interactionId)
+    ? opts.interactionId.trim()
+    : undefined;
   return {
     requestId,
     traceparent,
+    ...(conversationId ? { conversationId } : {}),
+    ...(interactionId ? { interactionId } : {}),
     ...(Object.keys(baggage).length > 0 ? { baggage } : {}),
   };
 }

--- a/src/trace-session.ts
+++ b/src/trace-session.ts
@@ -18,6 +18,8 @@ export interface TraceSessionOptions {
   producerModule: string;
   spanId: string;
   interactionId?: string;
+  conversationId?: string;
+  contractVersion?: "2.1.0" | "2.2.0";
   emit: EvidenceEmitter;
   idFactory?: IDFactory;
   now?: () => string;
@@ -27,6 +29,7 @@ interface InteractionBase {
   operationName: string;
   intentHash: string;
   mode: "chat" | "task" | "background";
+  questionArtifactRef?: string;
 }
 
 export type InteractionInput = InteractionBase &
@@ -56,6 +59,14 @@ export interface OperationEventPayloadMap {
     version_status?: string;
     resource_refs?: string[];
     field_refs?: string[];
+    query_artifact_ref?: string;
+    result_artifact_ref?: string;
+  };
+  "logic.execution.observed": {
+    logic_ref: string;
+    input_artifact_ref: string;
+    result_artifact_ref: string;
+    status: "ok" | "success" | "error";
   };
   "model.call.observed": {
     model_name: string;
@@ -105,6 +116,7 @@ export interface ClaimInput {
   claimHash: string;
   sourceEventIds: string[];
   operationIds: string[];
+  resultArtifactRef?: string;
   visibility?: string;
   versionStatus?: string;
 }
@@ -163,6 +175,8 @@ export interface RecommendActionInput {
   actionType: string;
   targetRefs: string[];
   reasonHash: string;
+  reasonArtifactRef?: string;
+  inputArtifactRef?: string;
   causationEventId?: string;
 }
 
@@ -178,13 +192,23 @@ export type ExecuteActionInput =
   | { status: "ok"; invocationRef: string }
   | { status: "error"; invocationRef: string; errorCategory: string; errorHash: string };
 
-export type ActionResultInput = { status: string; resultHash: string } & (
-  | { taskRef: string; artifactRef?: string }
-  | { taskRef?: string; artifactRef: string }
+export type ActionResultInput = {
+  status: string;
+  resultHash: string;
+} & (
+  | { resultArtifactRef: string; taskRef?: string; artifactRef?: never }
+  | { taskRef: string; artifactRef?: string; resultArtifactRef?: string }
+  | { taskRef?: string; artifactRef: string; resultArtifactRef?: string }
 );
 
 const PAYLOAD_FIELDS: Record<BusinessEvidenceEventType, Set<string>> = {
-  "agent.interaction.started": new Set(["intent_hash", "mode", "agent_id", "app_ref"]),
+  "agent.interaction.started": new Set([
+    "intent_hash",
+    "mode",
+    "agent_id",
+    "app_ref",
+    "question_artifact_ref",
+  ]),
   "retrieval.completed": new Set([
     "query_hash",
     "candidate_count",
@@ -208,6 +232,14 @@ const PAYLOAD_FIELDS: Record<BusinessEvidenceEventType, Set<string>> = {
     "version_status",
     "resource_refs",
     "field_refs",
+    "query_artifact_ref",
+    "result_artifact_ref",
+  ]),
+  "logic.execution.observed": new Set([
+    "logic_ref",
+    "input_artifact_ref",
+    "result_artifact_ref",
+    "status",
   ]),
   "model.call.observed": new Set([
     "model_name",
@@ -241,6 +273,7 @@ const PAYLOAD_FIELDS: Record<BusinessEvidenceEventType, Set<string>> = {
     "operation_ids",
     "visibility",
     "version_status",
+    "result_artifact_ref",
   ]),
   "evidence.refs.created": new Set(["claim_id", "evidence_refs"]),
   "business.refs.resolved": new Set(["claim_id", "resolver_status", "business_refs"]),
@@ -250,6 +283,8 @@ const PAYLOAD_FIELDS: Record<BusinessEvidenceEventType, Set<string>> = {
     "target_refs",
     "reason_hash",
     "status",
+    "reason_artifact_ref",
+    "input_artifact_ref",
   ]),
   "action.approval_requested": new Set(["action_instance_id", "policy_ref", "status"]),
   "action.approved": new Set(["action_instance_id", "actor_ref", "policy_decision_ref", "status"]),
@@ -267,6 +302,7 @@ const PAYLOAD_FIELDS: Record<BusinessEvidenceEventType, Set<string>> = {
     "result_hash",
     "task_ref",
     "artifact_ref",
+    "result_artifact_ref",
   ]),
 };
 
@@ -275,6 +311,7 @@ const REQUIRED_PAYLOAD_FIELDS: Partial<Record<BusinessEvidenceEventType, string[
   "retrieval.completed": ["query_hash", "candidate_count", "truncated"],
   "knowledge.read.observed": ["kn_id", "read_kind", "version_status"],
   "data.query.observed": ["query_hash", "query_type", "row_count"],
+  "logic.execution.observed": ["logic_ref", "input_artifact_ref", "result_artifact_ref", "status"],
   "model.call.observed": [
     "model_name",
     "model_provider",
@@ -361,6 +398,17 @@ function assertSessionOptions(options: TraceSessionOptions): void {
   if (!/^req_[0-9A-Za-z_.-]+$/.test(trace["bkn.request.id"])) {
     throw new Error("bkn.request.id must start with req_");
   }
+  const conversationId = options.conversationId ?? trace["bkn.conversation.id"];
+  if (conversationId && !/^[0-9A-Za-z_.:-]{1,128}$/.test(conversationId)) {
+    throw new Error("conversationId must be an opaque correlation identifier");
+  }
+  if (
+    options.conversationId &&
+    trace["bkn.conversation.id"] &&
+    options.conversationId !== trace["bkn.conversation.id"]
+  ) {
+    throw new Error("conversationId conflicts with trace bkn.conversation.id");
+  }
   if (!trace["bkn.tenant.id"] && !trace.business_domain) {
     throw new Error("trace requires bkn.tenant.id or business_domain");
   }
@@ -419,6 +467,9 @@ function assertSafePayload(
       throw new Error(`${eventType} payload requires non-empty ${key}`);
     }
   }
+  if (eventType === "action.recommended") {
+    for (const ref of payload.target_refs as string[]) assertQualifiedReference(ref);
+  }
   if (eventType === "evidence.refs.created") {
     assertRefs(payload.evidence_refs, false);
   }
@@ -426,8 +477,15 @@ function assertSafePayload(
     const unresolved = payload.resolver_status === "unresolved";
     assertRefs(payload.business_refs, unresolved);
   }
-  if (eventType === "action.result_recorded" && !payload.task_ref && !payload.artifact_ref) {
-    throw new Error("action.result_recorded requires task_ref or artifact_ref");
+  if (
+    eventType === "action.result_recorded" &&
+    !payload.task_ref &&
+    !payload.artifact_ref &&
+    !payload.result_artifact_ref
+  ) {
+    throw new Error(
+      "action.result_recorded requires task_ref, artifact_ref, or result_artifact_ref",
+    );
   }
   if (eventType === "action.executed" && payload.status === "error") {
     for (const key of ["error_category", "error_hash"]) {
@@ -468,6 +526,7 @@ function assertRefs(value: unknown, allowEmpty: boolean): void {
     ]) {
       if (!ref[key]) throw new Error(`reference requires ${key}`);
     }
+    assertQualifiedReference(String(ref.ref_id));
     assertEnum(ref, "validity", ["observed", "available", "unavailable", "expired", "partial"]);
     assertEnum(ref, "version_status", ["versioned", "unversioned", "not_auditable"]);
     assertEnum(ref, "visibility", [
@@ -478,6 +537,20 @@ function assertRefs(value: unknown, allowEmpty: boolean): void {
       "unresolved",
       "unauthorized",
     ]);
+  }
+}
+
+function assertQualifiedReference(value: string): void {
+  const parts = value.trim().split(":");
+  const namespace = parts[0] ?? "";
+  let valid = parts.every((part) => part.length > 0);
+  if (["kn", "resource"].includes(namespace)) valid = valid && parts.length === 2;
+  if (["object", "relation", "action_type", "metric", "field"].includes(namespace)) {
+    valid = valid && parts.length === 3;
+  }
+  if (namespace === "property") valid = valid && parts.length === 4;
+  if (!valid) {
+    throw new Error("business reference id must include its knowledge-network or resource scope");
   }
 }
 
@@ -513,6 +586,7 @@ export class TraceSession {
   private readonly producerModule: string;
   private readonly spanId: string;
   private readonly emit: EvidenceEmitter;
+  private readonly contractVersion: "2.1.0" | "2.2.0";
   private readonly idFactory: IDFactory;
   private readonly now: () => string;
   private readonly events: EvidenceEvent[] = [];
@@ -525,9 +599,13 @@ export class TraceSession {
   constructor(options: TraceSessionOptions) {
     assertSessionOptions(options);
     this.trace = clone(options.trace);
+    if (options.conversationId) {
+      this.trace["bkn.conversation.id"] = options.conversationId;
+    }
     this.producerModule = options.producerModule;
     this.spanId = options.spanId;
     this.emit = options.emit;
+    this.contractVersion = options.contractVersion ?? "2.1.0";
     this.idFactory = options.idFactory ?? randomUUID;
     this.now = options.now ?? defaultNow;
     this.interactionId = options.interactionId ?? this.idFactory();
@@ -541,6 +619,7 @@ export class TraceSession {
         mode: input.mode,
         ...(input.agentId ? { agent_id: input.agentId } : {}),
         ...(input.appRef ? { app_ref: input.appRef } : {}),
+        ...(input.questionArtifactRef ? { question_artifact_ref: input.questionArtifactRef } : {}),
       },
     });
   }
@@ -572,6 +651,7 @@ export class TraceSession {
         operation_ids: input.operationIds,
         visibility: input.visibility ?? "visible",
         version_status: input.versionStatus ?? "unversioned",
+        ...(input.resultArtifactRef ? { result_artifact_ref: input.resultArtifactRef } : {}),
       },
     });
     this.claimEventIDs.set(input.claimId, event.event_id);
@@ -650,6 +730,8 @@ export class TraceSession {
         action_type: input.actionType,
         target_refs: input.targetRefs,
         reason_hash: input.reasonHash,
+        ...(input.reasonArtifactRef ? { reason_artifact_ref: input.reasonArtifactRef } : {}),
+        ...(input.inputArtifactRef ? { input_artifact_ref: input.inputArtifactRef } : {}),
         status: "recommended",
       },
     });
@@ -752,6 +834,7 @@ export class TraceSession {
       status: input.status,
       ...(input.taskRef ? { task_ref: input.taskRef } : {}),
       ...(input.artifactRef ? { artifact_ref: input.artifactRef } : {}),
+      ...(input.resultArtifactRef ? { result_artifact_ref: input.resultArtifactRef } : {}),
     });
     internal.state = "result_recorded";
     internal.lastEventId = event.event_id;
@@ -798,6 +881,7 @@ export class TraceSession {
     },
   ): EvidenceEvent {
     assertSafePayload(eventType, input.payload);
+    this.assertContractPayload(eventType, input.payload);
     if (eventType !== "agent.interaction.started") {
       if (!input.causationEventId) throw new Error(`${eventType} requires causation_event_id`);
       if (!this.eventIDs.has(input.causationEventId)) {
@@ -817,7 +901,7 @@ export class TraceSession {
     const event: EvidenceEvent = {
       event_id: eventID,
       event_type: eventType,
-      "bkn.trace.schema.version": "2.1.0",
+      "bkn.trace.schema.version": this.contractVersion,
       observed_at: timestamp,
       emitted_at: timestamp,
       producer_module: this.producerModule,
@@ -843,13 +927,50 @@ export class TraceSession {
     const batch = this.events.filter((event) => requestedIDs.has(event.event_id));
     if (batch.length === 0) return undefined;
     const response = await this.emit({
-      "bkn.trace.schema.version": "2.1.0",
+      "bkn.trace.schema.version": this.contractVersion,
       trace: clone(this.trace),
       events: clone(batch),
     });
     const remaining = this.events.filter((event) => !requestedIDs.has(event.event_id));
     this.events.splice(0, this.events.length, ...remaining);
     return response;
+  }
+
+  private assertContractPayload(
+    eventType: BusinessEvidenceEventType,
+    payload: Record<string, unknown>,
+  ): void {
+    if (this.contractVersion !== "2.2.0") return;
+    const requiredArtifactFields: Partial<Record<BusinessEvidenceEventType, string[]>> = {
+      "agent.interaction.started": ["question_artifact_ref"],
+      "data.query.observed": ["query_artifact_ref", "result_artifact_ref"],
+      "logic.execution.observed": ["input_artifact_ref", "result_artifact_ref"],
+      "claim.created": ["result_artifact_ref"],
+      "action.recommended": ["input_artifact_ref"],
+      "action.result_recorded": ["result_artifact_ref"],
+    };
+    for (const field of requiredArtifactFields[eventType] ?? []) {
+      const value = payload[field];
+      if (
+        typeof value !== "string" ||
+        !/^artifact:[0-9A-Za-z][0-9A-Za-z_.:-]{0,127}$/.test(value)
+      ) {
+        throw new Error(`${eventType} payload requires valid ${field}`);
+      }
+    }
+    for (const [field, value] of Object.entries(payload)) {
+      if (field.endsWith("_artifact_ref") && value !== undefined) {
+        if (
+          typeof value !== "string" ||
+          !/^artifact:[0-9A-Za-z][0-9A-Za-z_.:-]{0,127}$/.test(value)
+        ) {
+          throw new Error(`${eventType} payload requires valid ${field}`);
+        }
+      }
+    }
+    if (eventType === "action.result_recorded" && payload.artifact_ref !== undefined) {
+      throw new Error("action.result_recorded 2.2 does not accept legacy artifact_ref");
+    }
   }
 
   private assertKnownRefs(values: string[], known: Set<string>, kind: string): void {

--- a/src/trace-session.ts
+++ b/src/trace-session.ts
@@ -1,0 +1,882 @@
+// Copyright (c) 2026 OpenBKN. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the project root.
+
+import { randomUUID } from "node:crypto";
+import type {
+  BusinessEvidenceEventType,
+  EvidenceEvent,
+  EvidenceIngestRequest,
+  EvidenceIngestResponse,
+  EvidenceTraceContext,
+} from "./api/trace.js";
+
+type EvidenceEmitter = (body: EvidenceIngestRequest) => Promise<EvidenceIngestResponse>;
+type IDFactory = () => string;
+
+export interface TraceSessionOptions {
+  trace: EvidenceTraceContext;
+  producerModule: string;
+  spanId: string;
+  interactionId?: string;
+  emit: EvidenceEmitter;
+  idFactory?: IDFactory;
+  now?: () => string;
+}
+
+interface InteractionBase {
+  operationName: string;
+  intentHash: string;
+  mode: "chat" | "task" | "background";
+}
+
+export type InteractionInput = InteractionBase &
+  ({ agentId: string; appRef?: string } | { agentId?: string; appRef: string });
+
+export interface OperationEventPayloadMap {
+  "retrieval.completed": {
+    query_hash: string;
+    candidate_count: number;
+    truncated: boolean;
+    version_status?: string;
+    source_refs?: string[];
+  };
+  "knowledge.read.observed": {
+    kn_id: string;
+    read_kind: string;
+    version_status: string;
+    schema_version?: string;
+    business_refs?: string[];
+  };
+  "data.query.observed": {
+    query_hash: string;
+    query_type: string;
+    row_count: number;
+    truncated?: boolean;
+    as_of?: string;
+    version_status?: string;
+    resource_refs?: string[];
+    field_refs?: string[];
+  };
+  "model.call.observed": {
+    model_name: string;
+    model_provider: string;
+    status: "ok" | "error";
+    input_token_count: number;
+    output_token_count: number;
+    prompt_hash: string;
+    output_hash: string;
+    error_category?: string;
+    error_hash?: string;
+  };
+  "tool.called": {
+    tool_id: string;
+    tool_name: string;
+    args_hash: string;
+    visibility: string;
+    version_status: string;
+  };
+  "tool.result.observed": {
+    tool_id: string;
+    tool_name: string;
+    status: "success" | "error";
+    result_hash?: string;
+    error_hash?: string;
+    visibility: string;
+    version_status: string;
+  };
+}
+
+export type OperationEventType = keyof OperationEventPayloadMap;
+
+export interface OperationInput<T extends OperationEventType = OperationEventType> {
+  operationName: string;
+  causationEventId: string;
+  operationId?: string;
+  attempt?: number;
+  claimId?: string;
+  payload: OperationEventPayloadMap[T];
+}
+
+export interface ClaimInput {
+  operationName: string;
+  causationEventId: string;
+  claimId: string;
+  claimType: "answer" | "recommendation" | "structured_output" | "finding";
+  claimHash: string;
+  sourceEventIds: string[];
+  operationIds: string[];
+  visibility?: string;
+  versionStatus?: string;
+}
+
+export interface EvidenceRefInput {
+  refId: string;
+  refType: string;
+  sourceSystem: string;
+  validity: "observed" | "available" | "unavailable" | "expired" | "partial";
+  versionStatus: "versioned" | "unversioned" | "not_auditable";
+  visibility: "visible" | "redacted" | "hidden" | "omitted" | "unresolved" | "unauthorized";
+  summaryHash?: string;
+}
+
+export interface EvidenceRefsInput {
+  operationName: string;
+  claimId: string;
+  causationEventId?: string;
+  refs: EvidenceRefInput[];
+}
+
+export interface BusinessRefInput {
+  refId: string;
+  refType: "knowledge_network" | "object" | "property" | "relation" | "metric" | "logic" | "action";
+  sourceSystem: string;
+  validity: "observed" | "available" | "unavailable" | "expired" | "partial";
+  versionStatus: "versioned" | "unversioned" | "not_auditable";
+  visibility: "visible" | "redacted" | "hidden" | "omitted" | "unresolved" | "unauthorized";
+}
+
+export interface BusinessRefsInput {
+  operationName: string;
+  claimId: string;
+  causationEventId?: string;
+  resolverStatus: "resolved" | "partial" | "unresolved";
+  refs: BusinessRefInput[];
+}
+
+export interface ActionHandle {
+  readonly actionInstanceId: string;
+  readonly claimId: string;
+  readonly operationId: string;
+  readonly lastEventId: string;
+  readonly state:
+    | "recommended"
+    | "approval_requested"
+    | "approved"
+    | "rejected"
+    | "executed"
+    | "result_recorded";
+}
+
+export interface RecommendActionInput {
+  operationName: string;
+  claimId: string;
+  actionType: string;
+  targetRefs: string[];
+  reasonHash: string;
+  causationEventId?: string;
+}
+
+interface InternalAction {
+  actionInstanceId: string;
+  claimId: string;
+  operationId: string;
+  lastEventId: string;
+  state: ActionHandle["state"];
+}
+
+export type ExecuteActionInput =
+  | { status: "ok"; invocationRef: string }
+  | { status: "error"; invocationRef: string; errorCategory: string; errorHash: string };
+
+export type ActionResultInput = { status: string; resultHash: string } & (
+  | { taskRef: string; artifactRef?: string }
+  | { taskRef?: string; artifactRef: string }
+);
+
+const PAYLOAD_FIELDS: Record<BusinessEvidenceEventType, Set<string>> = {
+  "agent.interaction.started": new Set(["intent_hash", "mode", "agent_id", "app_ref"]),
+  "retrieval.completed": new Set([
+    "query_hash",
+    "candidate_count",
+    "truncated",
+    "version_status",
+    "source_refs",
+  ]),
+  "knowledge.read.observed": new Set([
+    "kn_id",
+    "read_kind",
+    "version_status",
+    "schema_version",
+    "business_refs",
+  ]),
+  "data.query.observed": new Set([
+    "query_hash",
+    "query_type",
+    "row_count",
+    "truncated",
+    "as_of",
+    "version_status",
+    "resource_refs",
+    "field_refs",
+  ]),
+  "model.call.observed": new Set([
+    "model_name",
+    "model_provider",
+    "status",
+    "input_token_count",
+    "output_token_count",
+    "prompt_hash",
+    "output_hash",
+    "error_category",
+    "error_hash",
+  ]),
+  "tool.called": new Set(["tool_id", "tool_name", "args_hash", "visibility", "version_status"]),
+  "tool.result.observed": new Set([
+    "tool_id",
+    "tool_name",
+    "status",
+    "result_hash",
+    "result_length",
+    "result_count",
+    "error_hash",
+    "error_category",
+    "visibility",
+    "version_status",
+  ]),
+  "claim.created": new Set([
+    "claim_id",
+    "claim_type",
+    "claim_hash",
+    "source_event_ids",
+    "operation_ids",
+    "visibility",
+    "version_status",
+  ]),
+  "evidence.refs.created": new Set(["claim_id", "evidence_refs"]),
+  "business.refs.resolved": new Set(["claim_id", "resolver_status", "business_refs"]),
+  "action.recommended": new Set([
+    "action_instance_id",
+    "action_type",
+    "target_refs",
+    "reason_hash",
+    "status",
+  ]),
+  "action.approval_requested": new Set(["action_instance_id", "policy_ref", "status"]),
+  "action.approved": new Set(["action_instance_id", "actor_ref", "policy_decision_ref", "status"]),
+  "action.rejected": new Set(["action_instance_id", "actor_ref", "policy_decision_ref", "status"]),
+  "action.executed": new Set([
+    "action_instance_id",
+    "status",
+    "invocation_ref",
+    "error_category",
+    "error_hash",
+  ]),
+  "action.result_recorded": new Set([
+    "action_instance_id",
+    "status",
+    "result_hash",
+    "task_ref",
+    "artifact_ref",
+  ]),
+};
+
+const REQUIRED_PAYLOAD_FIELDS: Partial<Record<BusinessEvidenceEventType, string[]>> = {
+  "agent.interaction.started": ["intent_hash", "mode"],
+  "retrieval.completed": ["query_hash", "candidate_count", "truncated"],
+  "knowledge.read.observed": ["kn_id", "read_kind", "version_status"],
+  "data.query.observed": ["query_hash", "query_type", "row_count"],
+  "model.call.observed": [
+    "model_name",
+    "model_provider",
+    "status",
+    "input_token_count",
+    "output_token_count",
+    "prompt_hash",
+    "output_hash",
+  ],
+  "tool.called": ["tool_id", "tool_name", "args_hash", "visibility", "version_status"],
+  "tool.result.observed": ["tool_id", "tool_name", "status", "visibility", "version_status"],
+  "claim.created": [
+    "claim_id",
+    "claim_type",
+    "claim_hash",
+    "source_event_ids",
+    "operation_ids",
+    "visibility",
+    "version_status",
+  ],
+  "evidence.refs.created": ["claim_id", "evidence_refs"],
+  "business.refs.resolved": ["claim_id", "resolver_status", "business_refs"],
+  "action.recommended": [
+    "action_instance_id",
+    "action_type",
+    "target_refs",
+    "reason_hash",
+    "status",
+  ],
+  "action.approval_requested": ["action_instance_id", "policy_ref", "status"],
+  "action.approved": ["action_instance_id", "actor_ref", "policy_decision_ref", "status"],
+  "action.rejected": ["action_instance_id", "actor_ref", "policy_decision_ref", "status"],
+  "action.executed": ["action_instance_id", "status", "invocation_ref"],
+  "action.result_recorded": ["action_instance_id", "status", "result_hash"],
+};
+
+const REF_FIELDS = new Set([
+  "ref_id",
+  "ref_type",
+  "source_system",
+  "validity",
+  "version_status",
+  "visibility",
+  "summary_hash",
+]);
+const RAW_KEYS = new Set([
+  "authorization",
+  "cookie",
+  "access_token",
+  "refresh_token",
+  "id_token",
+  "api_key",
+  "password",
+  "private_key",
+  "prompt",
+  "user_question",
+  "approval_comment",
+  "sql",
+  "query_params",
+  "rows",
+]);
+const HASH_RE = /^sha256:[0-9a-f]{64}$/;
+const RAW_VALUE_PATTERNS = [
+  /bearer\s+[A-Za-z0-9._-]+/i,
+  /\bselect\s+.+\s+from\b/is,
+  /\binsert\s+into\b/i,
+  /\bupdate\s+\S+\s+set\b/i,
+  /\bdelete\s+from\b/i,
+  /[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}/,
+  /https?:\/\/[^\s"']+/i,
+];
+
+function defaultNow(): string {
+  return new Date().toISOString();
+}
+
+function assertSessionOptions(options: TraceSessionOptions): void {
+  const trace = options.trace;
+  if (!/^[0-9a-f]{32}$/.test(trace.trace_id)) throw new Error("trace_id must be 32 hex characters");
+  const traceparent = /^00-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$/.exec(trace.traceparent);
+  if (!traceparent || traceparent[1] !== trace.trace_id) {
+    throw new Error("traceparent must be valid and match trace_id");
+  }
+  if (!/^req_[0-9A-Za-z_.-]+$/.test(trace["bkn.request.id"])) {
+    throw new Error("bkn.request.id must start with req_");
+  }
+  if (!trace["bkn.tenant.id"] && !trace.business_domain) {
+    throw new Error("trace requires bkn.tenant.id or business_domain");
+  }
+  if (!trace["bkn.account.id"] || !trace["bkn.account.type"]) {
+    throw new Error("trace requires account id and type");
+  }
+  if (!/^[0-9a-f]{16}$/.test(options.spanId)) throw new Error("spanId must be 16 hex characters");
+  if (!options.producerModule.trim()) throw new Error("producerModule is required");
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function assertSafePayload(
+  eventType: BusinessEvidenceEventType,
+  payload: Record<string, unknown>,
+): void {
+  const allowed = PAYLOAD_FIELDS[eventType];
+  for (const key of Object.keys(payload)) {
+    if (!allowed.has(key)) throw new Error(`${eventType} payload field is not registered: ${key}`);
+  }
+  for (const key of REQUIRED_PAYLOAD_FIELDS[eventType] ?? []) {
+    if (payload[key] === undefined || payload[key] === "") {
+      throw new Error(`${eventType} payload requires ${key}`);
+    }
+  }
+  if (eventType === "agent.interaction.started" && !payload.agent_id && !payload.app_ref) {
+    throw new Error("agent.interaction.started requires agent_id or app_ref");
+  }
+  if (eventType === "agent.interaction.started") {
+    assertEnum(payload, "mode", ["chat", "task", "background"]);
+  }
+  if (eventType === "model.call.observed" || eventType === "action.executed") {
+    assertEnum(payload, "status", ["ok", "error"]);
+  }
+  if (eventType === "model.call.observed" && payload.status === "error") {
+    for (const key of ["error_category", "error_hash"]) {
+      if (!payload[key]) throw new Error(`model.call.observed error requires ${key}`);
+    }
+  }
+  if (eventType === "tool.result.observed") {
+    assertEnum(payload, "status", ["success", "error"]);
+    if (payload.status === "success" && !payload.result_hash) {
+      throw new Error("tool.result.observed success requires result_hash");
+    }
+    if (payload.status === "error" && !payload.error_hash) {
+      throw new Error("tool.result.observed error requires error_hash");
+    }
+  }
+  if (eventType === "business.refs.resolved") {
+    assertEnum(payload, "resolver_status", ["resolved", "partial", "unresolved"]);
+  }
+  for (const key of ["source_event_ids", "operation_ids", "target_refs"] as const) {
+    if (key in payload && (!Array.isArray(payload[key]) || payload[key].length === 0)) {
+      throw new Error(`${eventType} payload requires non-empty ${key}`);
+    }
+  }
+  if (eventType === "evidence.refs.created") {
+    assertRefs(payload.evidence_refs, false);
+  }
+  if (eventType === "business.refs.resolved") {
+    const unresolved = payload.resolver_status === "unresolved";
+    assertRefs(payload.business_refs, unresolved);
+  }
+  if (eventType === "action.result_recorded" && !payload.task_ref && !payload.artifact_ref) {
+    throw new Error("action.result_recorded requires task_ref or artifact_ref");
+  }
+  if (eventType === "action.executed" && payload.status === "error") {
+    for (const key of ["error_category", "error_hash"]) {
+      if (!payload[key]) throw new Error(`action.executed error requires ${key}`);
+    }
+  }
+  const fixedStatus: Partial<Record<BusinessEvidenceEventType, string>> = {
+    "action.recommended": "recommended",
+    "action.approval_requested": "approval_requested",
+    "action.approved": "approved",
+    "action.rejected": "rejected",
+  };
+  if (fixedStatus[eventType] && payload.status !== fixedStatus[eventType]) {
+    throw new Error(`${eventType} requires status=${fixedStatus[eventType]}`);
+  }
+  scanSafeValue(payload, "payload");
+}
+
+function assertRefs(value: unknown, allowEmpty: boolean): void {
+  if (!Array.isArray(value) || (!allowEmpty && value.length === 0)) {
+    throw new Error("reference list must be a non-empty array");
+  }
+  for (const item of value) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      throw new Error("reference must be an object");
+    }
+    const ref = item as Record<string, unknown>;
+    for (const key of Object.keys(ref)) {
+      if (!REF_FIELDS.has(key)) throw new Error(`reference field is not registered: ${key}`);
+    }
+    for (const key of [
+      "ref_id",
+      "ref_type",
+      "source_system",
+      "validity",
+      "version_status",
+      "visibility",
+    ]) {
+      if (!ref[key]) throw new Error(`reference requires ${key}`);
+    }
+    assertEnum(ref, "validity", ["observed", "available", "unavailable", "expired", "partial"]);
+    assertEnum(ref, "version_status", ["versioned", "unversioned", "not_auditable"]);
+    assertEnum(ref, "visibility", [
+      "visible",
+      "redacted",
+      "hidden",
+      "omitted",
+      "unresolved",
+      "unauthorized",
+    ]);
+  }
+}
+
+function assertEnum(value: Record<string, unknown>, key: string, allowed: string[]): void {
+  if (!allowed.includes(String(value[key]))) {
+    throw new Error(`${key} must be one of ${allowed.join(", ")}`);
+  }
+}
+
+function scanSafeValue(value: unknown, path: string): void {
+  if (Array.isArray(value)) {
+    value.forEach((child, index) => scanSafeValue(child, `${path}[${index}]`));
+    return;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      if (RAW_KEYS.has(key.toLowerCase())) throw new Error(`raw sensitive payload field: ${key}`);
+      if (key.endsWith("_hash") && child !== "" && !HASH_RE.test(String(child))) {
+        throw new Error(`${path}.${key} must be a sha256 hash`);
+      }
+      scanSafeValue(child, `${path}.${key}`);
+    }
+    return;
+  }
+  if (typeof value === "string" && RAW_VALUE_PATTERNS.some((pattern) => pattern.test(value))) {
+    throw new Error(`raw sensitive payload value at ${path}`);
+  }
+}
+
+export class TraceSession {
+  readonly interactionId: string;
+  private readonly trace: EvidenceTraceContext;
+  private readonly producerModule: string;
+  private readonly spanId: string;
+  private readonly emit: EvidenceEmitter;
+  private readonly idFactory: IDFactory;
+  private readonly now: () => string;
+  private readonly events: EvidenceEvent[] = [];
+  private readonly eventIDs = new Set<string>();
+  private readonly operationIDs = new Set<string>();
+  private readonly claimEventIDs = new Map<string, string>();
+  private readonly actions = new WeakMap<ActionHandle, InternalAction>();
+  private flushTail: Promise<void> = Promise.resolve();
+
+  constructor(options: TraceSessionOptions) {
+    assertSessionOptions(options);
+    this.trace = clone(options.trace);
+    this.producerModule = options.producerModule;
+    this.spanId = options.spanId;
+    this.emit = options.emit;
+    this.idFactory = options.idFactory ?? randomUUID;
+    this.now = options.now ?? defaultNow;
+    this.interactionId = options.interactionId ?? this.idFactory();
+  }
+
+  startInteraction(input: InteractionInput): EvidenceEvent {
+    return this.append("agent.interaction.started", {
+      operationName: input.operationName,
+      payload: {
+        intent_hash: input.intentHash,
+        mode: input.mode,
+        ...(input.agentId ? { agent_id: input.agentId } : {}),
+        ...(input.appRef ? { app_ref: input.appRef } : {}),
+      },
+    });
+  }
+
+  observeOperation<T extends OperationEventType>(
+    eventType: T,
+    input: OperationInput<T>,
+  ): EvidenceEvent {
+    const operationId = input.operationId ?? this.idFactory();
+    this.operationIDs.add(operationId);
+    return this.append(eventType, { ...input, operationId });
+  }
+
+  createClaim(input: ClaimInput): EvidenceEvent {
+    if (input.sourceEventIds.length === 0 || input.operationIds.length === 0) {
+      throw new Error("claim requires at least one source event and operation");
+    }
+    this.assertKnownRefs(input.sourceEventIds, this.eventIDs, "event");
+    this.assertKnownRefs(input.operationIds, this.operationIDs, "operation");
+    const event = this.append("claim.created", {
+      operationName: input.operationName,
+      causationEventId: input.causationEventId,
+      claimId: input.claimId,
+      payload: {
+        claim_id: input.claimId,
+        claim_type: input.claimType,
+        claim_hash: input.claimHash,
+        source_event_ids: input.sourceEventIds,
+        operation_ids: input.operationIds,
+        visibility: input.visibility ?? "visible",
+        version_status: input.versionStatus ?? "unversioned",
+      },
+    });
+    this.claimEventIDs.set(input.claimId, event.event_id);
+    return event;
+  }
+
+  createEvidenceRefs(input: EvidenceRefsInput): EvidenceEvent {
+    const claimEventID = this.requireClaim(input.claimId);
+    if (input.refs.length === 0) throw new Error("evidence refs must not be empty");
+    const operationId = this.idFactory();
+    this.operationIDs.add(operationId);
+    const event = this.append("evidence.refs.created", {
+      operationName: input.operationName,
+      operationId,
+      causationEventId: input.causationEventId ?? claimEventID,
+      claimId: input.claimId,
+      payload: {
+        claim_id: input.claimId,
+        evidence_refs: input.refs.map((ref) => ({
+          ref_id: ref.refId,
+          ref_type: ref.refType,
+          source_system: ref.sourceSystem,
+          validity: ref.validity,
+          version_status: ref.versionStatus,
+          visibility: ref.visibility,
+          ...(ref.summaryHash ? { summary_hash: ref.summaryHash } : {}),
+        })),
+      },
+    });
+    this.claimEventIDs.set(input.claimId, event.event_id);
+    return event;
+  }
+
+  resolveBusinessRefs(input: BusinessRefsInput): EvidenceEvent {
+    const claimEventID = this.requireClaim(input.claimId);
+    if (input.resolverStatus === "resolved" && input.refs.length === 0) {
+      throw new Error("resolved business refs must not be empty");
+    }
+    const operationId = this.idFactory();
+    this.operationIDs.add(operationId);
+    const event = this.append("business.refs.resolved", {
+      operationName: input.operationName,
+      operationId,
+      causationEventId: input.causationEventId ?? claimEventID,
+      claimId: input.claimId,
+      payload: {
+        claim_id: input.claimId,
+        resolver_status: input.resolverStatus,
+        business_refs: input.refs.map((ref) => ({
+          ref_id: ref.refId,
+          ref_type: ref.refType,
+          source_system: ref.sourceSystem,
+          validity: ref.validity,
+          version_status: ref.versionStatus,
+          visibility: ref.visibility,
+        })),
+      },
+    });
+    this.claimEventIDs.set(input.claimId, event.event_id);
+    return event;
+  }
+
+  recommendAction(input: RecommendActionInput): ActionHandle {
+    const claimEventID = this.requireClaim(input.claimId);
+    if (input.targetRefs.length === 0) throw new Error("action target refs must not be empty");
+    const operationId = this.idFactory();
+    const actionInstanceId = this.idFactory();
+    this.operationIDs.add(operationId);
+    const event = this.append("action.recommended", {
+      operationName: input.operationName,
+      operationId,
+      causationEventId: input.causationEventId ?? claimEventID,
+      claimId: input.claimId,
+      payload: {
+        action_instance_id: actionInstanceId,
+        action_type: input.actionType,
+        target_refs: input.targetRefs,
+        reason_hash: input.reasonHash,
+        status: "recommended",
+      },
+    });
+    const internal: InternalAction = {
+      actionInstanceId,
+      claimId: input.claimId,
+      operationId,
+      lastEventId: event.event_id,
+      state: "recommended",
+    };
+    const handle = Object.freeze({
+      get actionInstanceId() {
+        return internal.actionInstanceId;
+      },
+      get claimId() {
+        return internal.claimId;
+      },
+      get operationId() {
+        return internal.operationId;
+      },
+      get lastEventId() {
+        return internal.lastEventId;
+      },
+      get state() {
+        return internal.state;
+      },
+    });
+    this.actions.set(handle, internal);
+    return handle;
+  }
+
+  requestActionApproval(action: ActionHandle, input: { policyRef: string }): EvidenceEvent {
+    const internal = this.expectActionState(action, "recommended");
+    const event = this.appendAction(internal, "action.approval_requested", {
+      action_instance_id: internal.actionInstanceId,
+      policy_ref: input.policyRef,
+      status: "approval_requested",
+    });
+    internal.state = "approval_requested";
+    internal.lastEventId = event.event_id;
+    return event;
+  }
+
+  approveAction(
+    action: ActionHandle,
+    input: { actorRef: string; policyDecisionRef: string },
+  ): EvidenceEvent {
+    const internal = this.expectActionState(action, "approval_requested");
+    const event = this.appendAction(internal, "action.approved", {
+      action_instance_id: internal.actionInstanceId,
+      actor_ref: input.actorRef,
+      policy_decision_ref: input.policyDecisionRef,
+      status: "approved",
+    });
+    internal.state = "approved";
+    internal.lastEventId = event.event_id;
+    return event;
+  }
+
+  rejectAction(
+    action: ActionHandle,
+    input: { actorRef: string; policyDecisionRef: string },
+  ): EvidenceEvent {
+    const internal = this.expectActionState(action, "approval_requested");
+    const event = this.appendAction(internal, "action.rejected", {
+      action_instance_id: internal.actionInstanceId,
+      actor_ref: input.actorRef,
+      policy_decision_ref: input.policyDecisionRef,
+      status: "rejected",
+    });
+    internal.state = "rejected";
+    internal.lastEventId = event.event_id;
+    return event;
+  }
+
+  executeAction(action: ActionHandle, input: ExecuteActionInput): EvidenceEvent {
+    const internal = this.expectActionState(
+      action,
+      "approved",
+      "requires approval before execution",
+    );
+    const event = this.appendAction(internal, "action.executed", {
+      action_instance_id: internal.actionInstanceId,
+      status: input.status,
+      invocation_ref: input.invocationRef,
+      ...(input.status === "error"
+        ? { error_category: input.errorCategory, error_hash: input.errorHash }
+        : {}),
+    });
+    internal.state = "executed";
+    internal.lastEventId = event.event_id;
+    return event;
+  }
+
+  recordActionResult(action: ActionHandle, input: ActionResultInput): EvidenceEvent {
+    const internal = this.expectActionState(action, "executed");
+    const event = this.appendAction(internal, "action.result_recorded", {
+      action_instance_id: internal.actionInstanceId,
+      result_hash: input.resultHash,
+      status: input.status,
+      ...(input.taskRef ? { task_ref: input.taskRef } : {}),
+      ...(input.artifactRef ? { artifact_ref: input.artifactRef } : {}),
+    });
+    internal.state = "result_recorded";
+    internal.lastEventId = event.event_id;
+    return event;
+  }
+
+  pendingEvents(): EvidenceEvent[] {
+    return clone(this.events);
+  }
+
+  flush(): Promise<EvidenceIngestResponse | undefined> {
+    const requestedIDs = new Set(this.events.map((event) => event.event_id));
+    const operation = this.flushTail.then(() => this.flushEvents(requestedIDs));
+    this.flushTail = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    return operation;
+  }
+
+  private appendAction(
+    action: InternalAction,
+    eventType: BusinessEvidenceEventType,
+    payload: Record<string, unknown>,
+  ): EvidenceEvent {
+    return this.append(eventType, {
+      operationName: eventType,
+      operationId: action.operationId,
+      causationEventId: action.lastEventId,
+      claimId: action.claimId,
+      payload,
+    });
+  }
+
+  private append(
+    eventType: BusinessEvidenceEventType,
+    input: {
+      operationName: string;
+      operationId?: string;
+      causationEventId?: string;
+      claimId?: string;
+      attempt?: number;
+      payload: Record<string, unknown>;
+    },
+  ): EvidenceEvent {
+    assertSafePayload(eventType, input.payload);
+    if (eventType !== "agent.interaction.started") {
+      if (!input.causationEventId) throw new Error(`${eventType} requires causation_event_id`);
+      if (!this.eventIDs.has(input.causationEventId)) {
+        throw new Error(`unknown event reference: ${input.causationEventId}`);
+      }
+    }
+    if (
+      eventType !== "agent.interaction.started" &&
+      eventType !== "claim.created" &&
+      !input.operationId
+    ) {
+      throw new Error(`${eventType} requires operation_id`);
+    }
+    const eventID = this.idFactory();
+    if (this.eventIDs.has(eventID)) throw new Error(`duplicate event id: ${eventID}`);
+    const timestamp = this.now();
+    const event: EvidenceEvent = {
+      event_id: eventID,
+      event_type: eventType,
+      "bkn.trace.schema.version": "2.1.0",
+      observed_at: timestamp,
+      emitted_at: timestamp,
+      producer_module: this.producerModule,
+      trace_id: this.trace.trace_id,
+      span_id: this.spanId,
+      "bkn.request.id": this.trace["bkn.request.id"],
+      "bkn.operation.name": input.operationName,
+      interaction_id: this.interactionId,
+      ...(input.operationId ? { operation_id: input.operationId } : {}),
+      ...(input.causationEventId ? { causation_event_id: input.causationEventId } : {}),
+      ...(input.claimId ? { claim_id: input.claimId } : {}),
+      ...(input.attempt ? { attempt: input.attempt } : {}),
+      payload: clone(input.payload),
+    };
+    this.events.push(clone(event));
+    this.eventIDs.add(eventID);
+    return clone(event);
+  }
+
+  private async flushEvents(
+    requestedIDs: Set<string>,
+  ): Promise<EvidenceIngestResponse | undefined> {
+    const batch = this.events.filter((event) => requestedIDs.has(event.event_id));
+    if (batch.length === 0) return undefined;
+    const response = await this.emit({
+      "bkn.trace.schema.version": "2.1.0",
+      trace: clone(this.trace),
+      events: clone(batch),
+    });
+    const remaining = this.events.filter((event) => !requestedIDs.has(event.event_id));
+    this.events.splice(0, this.events.length, ...remaining);
+    return response;
+  }
+
+  private assertKnownRefs(values: string[], known: Set<string>, kind: string): void {
+    for (const value of values) {
+      if (!known.has(value)) throw new Error(`unknown ${kind} reference: ${value}`);
+    }
+  }
+
+  private requireClaim(claimID: string): string {
+    const eventID = this.claimEventIDs.get(claimID);
+    if (!eventID) throw new Error(`unknown claim reference: ${claimID}`);
+    return eventID;
+  }
+
+  private expectActionState(
+    action: ActionHandle,
+    expected: ActionHandle["state"],
+    message?: string,
+  ): InternalAction {
+    const internal = this.actions.get(action);
+    if (!internal) throw new Error("action handle does not belong to this trace session");
+    if (internal.state !== expected) {
+      if (message) throw new Error(`action ${internal.actionInstanceId} ${message}`);
+      throw new Error(
+        `action ${internal.actionInstanceId} must be ${expected}, got ${internal.state}`,
+      );
+    }
+    return internal;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,8 @@ export interface ClientOptions {
   businessDomain?: string;
   /** Skip TLS verification (dev / self-signed only). */
   insecure?: boolean;
+  /** Dedicated producer credential, sent only to BKN Trace evidence write endpoints. */
+  evidenceIngestToken?: string;
   /** Optional BKN Trace phase-one context for request correlation. */
   trace?: TraceContextOptions;
 }
@@ -29,6 +31,8 @@ export interface RequestContext {
   token: string;
   businessDomain: string;
   insecure: boolean;
+  /** Dedicated producer credential; never sent to read or non-Trace endpoints. */
+  evidenceIngestToken?: string;
   /** Stable per-client BKN Trace context propagated on outbound requests. */
   trace?: TraceContext;
   /**
@@ -51,6 +55,12 @@ export interface TraceContextOptions {
   conversationId?: string;
   /** Caller-owned id for one user question and its operations. The SDK never generates one. */
   interactionId?: string;
+  /** Replay-stable operation id. Generated once for the client request when omitted. */
+  operationId?: string;
+  /** Retry ordinal for the operation. Defaults to 1. */
+  attempt?: number;
+  /** Producer observation time in RFC3339 format. Generated once when omitted. */
+  observedAt?: string;
   /** Baggage values are allowlisted before propagation. */
   baggage?: Record<string, string>;
 }
@@ -60,6 +70,9 @@ export interface TraceContext {
   traceparent: string;
   conversationId?: string;
   interactionId?: string;
+  operationId?: string;
+  attempt?: number;
+  observedAt?: string;
   baggage?: Record<string, string>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,10 @@ export interface TraceContextOptions {
   requestId?: string;
   /** W3C Trace Context header. Generated when omitted or invalid. */
   traceparent?: string;
+  /** Caller-owned business conversation id. The SDK never generates one. */
+  conversationId?: string;
+  /** Caller-owned id for one user question and its operations. The SDK never generates one. */
+  interactionId?: string;
   /** Baggage values are allowlisted before propagation. */
   baggage?: Record<string, string>;
 }
@@ -54,6 +58,8 @@ export interface TraceContextOptions {
 export interface TraceContext {
   requestId: string;
   traceparent: string;
+  conversationId?: string;
+  interactionId?: string;
   baggage?: Record<string, string>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,11 +55,11 @@ export interface TraceContextOptions {
   conversationId?: string;
   /** Caller-owned id for one user question and its operations. The SDK never generates one. */
   interactionId?: string;
-  /** Replay-stable operation id. Generated once for the client request when omitted. */
+  /** Replay-stable operation id. Transports generate one per logical operation when omitted. */
   operationId?: string;
   /** Retry ordinal for the operation. Defaults to 1. */
   attempt?: number;
-  /** Producer observation time in RFC3339 format. Generated once when omitted. */
+  /** Producer observation time in RFC3339 format. Generated per logical operation when omitted. */
   observedAt?: string;
   /** Baggage values are allowlisted before propagation. */
   baggage?: Record<string, string>;

--- a/test/e2e/bkn-trace-business-interaction.mjs
+++ b/test/e2e/bkn-trace-business-interaction.mjs
@@ -1,0 +1,465 @@
+#!/usr/bin/env node
+
+import { createHash, randomBytes } from "node:crypto";
+import { createClient } from "../../dist/index.js";
+
+const question = "6月份有哪些需求预测单，列出来，需求总量是多少？";
+const baseUrl = process.env.BKN_BASE_URL ?? "http://localhost";
+const token = process.env.BKN_TOKEN;
+const businessDomain = requiredEnv("BKN_BUSINESS_DOMAIN");
+const accountId = requiredEnv("BKN_ACCOUNT_ID");
+const accountType = process.env.BKN_ACCOUNT_TYPE ?? "user";
+const knId = process.env.BKN_KN_ID ?? "supplychain_hd0202";
+const forecastYear = numeric(process.env.BKN_FORECAST_YEAR, 2026);
+const expectedForecastCount = numeric(process.env.BKN_EXPECTED_FORECAST_COUNT, 63);
+const expectedTotalDemand = numeric(process.env.BKN_EXPECTED_TOTAL_DEMAND, 11_594);
+const runId = randomBytes(8).toString("hex");
+const conversationId = process.env.BKN_CONVERSATION_ID ?? `conversation_supplychain_${runId}`;
+const interactionId = process.env.BKN_INTERACTION_ID ?? `interaction_june_forecast_${runId}`;
+const agentRef = process.env.BKN_AGENT_REF ?? "app:sdk-bkn-trace-e2e";
+
+const schemaClient = operationClient("schema");
+const schema = await schemaClient.context.toolCall(knId, "search_schema", {
+  query: question,
+  response_format: "json",
+  include_columns: true,
+  max_concepts: 20,
+});
+const schemaBinding = extractForecastBinding(schema);
+
+const sql = buildForecastSql(schemaBinding, forecastYear);
+const dataClient = operationClient("data");
+const dataResult = await dataClient.context.toolCall(knId, "run_sql", {
+  sql,
+  response_format: "json",
+});
+const rows = extractRows(dataResult);
+if (rows.length === 0) throw new Error("run_sql returned no June forecast rows");
+
+const forecastCount = numeric(rows[0]?.forecast_count, rows.length);
+const totalDemand = numeric(rows[0]?.total_demand);
+if (!Number.isFinite(totalDemand)) {
+  throw new Error("run_sql did not return a numeric total_demand");
+}
+assert(
+  forecastCount === expectedForecastCount,
+  `forecast count mismatch: expected=${expectedForecastCount} actual=${forecastCount}`,
+);
+assert(
+  totalDemand === expectedTotalDemand,
+  `total demand mismatch: expected=${expectedTotalDemand} actual=${totalDemand}`,
+);
+const answer = {
+  summary: `6月份共有 ${forecastCount} 条需求预测，需求总量为 ${totalDemand}。`,
+  forecast_count: forecastCount,
+  total_demand: totalDemand,
+  forecasts: rows.map(({ forecast_count, total_demand, ...row }) => row),
+};
+
+const evidenceClient = operationClient("evidence");
+const evidenceIdentity = identityOf(evidenceClient);
+const refs = {
+  object: `object:${knId}:${schemaBinding.objectTypeId}`,
+  resource: `resource:${schemaBinding.resourceId}`,
+  month: `property:${knId}:${schemaBinding.objectTypeId}:${schemaBinding.month.logicalName}`,
+  demand: `property:${knId}:${schemaBinding.objectTypeId}:${schemaBinding.demand.logicalName}`,
+};
+const artifacts = {
+  question: artifact("question", question, [refs.object]),
+  query: artifact("query", { language: "trino", sql }, [refs.resource, refs.month, refs.demand]),
+  data: artifact("data_result", dataResult, [refs.resource, refs.object]),
+  logic: artifact(
+    "logic_execution",
+    {
+      formula: "COUNT(rows), SUM(consensus_demand)",
+      forecast_count: forecastCount,
+      total_demand: totalDemand,
+    },
+    [refs.object, refs.demand],
+  ),
+  result: artifact("result", answer, [refs.object, refs.resource, refs.month, refs.demand]),
+};
+for (const value of Object.values(artifacts)) {
+  await evidenceClient.trace.emitArtifact(value);
+}
+
+const session = evidenceClient.trace.createSession({
+  trace: {
+    trace_id: evidenceIdentity.traceId,
+    traceparent: evidenceIdentity.traceparent,
+    "bkn.request.id": evidenceIdentity.requestId,
+    "bkn.conversation.id": conversationId,
+    business_domain: businessDomain,
+    "bkn.account.id": accountId,
+    "bkn.account.type": accountType,
+  },
+  producerModule: "sdk-bkn-trace-business-e2e",
+  spanId: evidenceIdentity.spanId,
+  conversationId,
+  interactionId,
+  contractVersion: "2.2.0",
+});
+const interaction = session.startInteraction({
+  operationName: "supplychain.forecast.answer",
+  intentHash: hash(question),
+  mode: "task",
+  appRef: agentRef,
+  questionArtifactRef: artifactRef(artifacts.question),
+});
+const retrieval = session.observeOperation("retrieval.completed", {
+  operationName: "supplychain.schema.retrieve",
+  causationEventId: interaction.event_id,
+  payload: {
+    query_hash: hash(question),
+    candidate_count: countSchemaConcepts(schema),
+    truncated: false,
+    version_status: "versioned",
+    source_refs: [`kn:${knId}`],
+  },
+});
+const knowledge = session.observeOperation("knowledge.read.observed", {
+  operationName: "supplychain.forecast.schema.read",
+  causationEventId: retrieval.event_id,
+  payload: {
+    kn_id: knId,
+    read_kind: "object_property_resource_schema",
+    version_status: "versioned",
+    business_refs: [refs.object, refs.month, refs.demand, refs.resource],
+  },
+});
+const data = session.observeOperation("data.query.observed", {
+  operationName: "supplychain.forecast.june.query",
+  causationEventId: knowledge.event_id,
+  payload: {
+    query_hash: hash(sql),
+    query_type: "aggregate_and_list",
+    row_count: forecastCount,
+    truncated: false,
+    version_status: "versioned",
+    resource_refs: [refs.resource],
+    field_refs: [refs.month, refs.demand],
+    query_artifact_ref: artifactRef(artifacts.query),
+    result_artifact_ref: artifactRef(artifacts.data),
+  },
+});
+const logic = session.observeOperation("logic.execution.observed", {
+  operationName: "supplychain.forecast.total.calculate",
+  causationEventId: data.event_id,
+  payload: {
+    logic_ref: "logic:supplychain:count_and_sum_forecast",
+    input_artifact_ref: artifactRef(artifacts.data),
+    result_artifact_ref: artifactRef(artifacts.logic),
+    status: "success",
+  },
+});
+const claim = session.createClaim({
+  operationName: "supplychain.forecast.answer.create",
+  causationEventId: logic.event_id,
+  claimId: `claim_june_forecast_${runId}`,
+  claimType: "answer",
+  claimHash: hash(answer),
+  sourceEventIds: [knowledge.event_id, data.event_id, logic.event_id],
+  operationIds: [knowledge.operation_id, data.operation_id, logic.operation_id],
+  resultArtifactRef: artifactRef(artifacts.result),
+  versionStatus: "versioned",
+});
+const evidence = session.createEvidenceRefs({
+  operationName: "supplychain.forecast.evidence.link",
+  claimId: claim.claim_id,
+  refs: [
+    evidenceRef(`evidence:kn:${knId}`, "knowledge_network", "bkn"),
+    evidenceRef(`evidence:resource:${schemaBinding.resourceId}`, "data_resource", "vega"),
+  ],
+});
+session.resolveBusinessRefs({
+  operationName: "supplychain.forecast.business.resolve",
+  claimId: claim.claim_id,
+  causationEventId: evidence.event_id,
+  resolverStatus: "resolved",
+  refs: [
+    businessRef(refs.object, "object"),
+    businessRef(refs.month, "property"),
+    businessRef(refs.demand, "property"),
+    businessRef(refs.resource, "resource"),
+  ],
+});
+await session.flush();
+
+const queryClient = createClient({
+  baseUrl,
+  ...(token ? { token } : {}),
+  businessDomain,
+  insecure: envFlag("BKN_INSECURE"),
+});
+const expectedRequestIds = [
+  schemaClient.ctx.trace.requestId,
+  dataClient.ctx.trace.requestId,
+  evidenceIdentity.requestId,
+];
+const summary = await pollInteraction(queryClient, expectedRequestIds);
+const evidenceChain = await queryClient.trace.evidenceChain(
+  { requestId: evidenceIdentity.requestId },
+  { limit: 500 },
+);
+const storedQuestion = await queryClient.trace.artifact(artifacts.question.artifact_id);
+const storedResult = await queryClient.trace.artifact(artifacts.result.artifact_id);
+
+assert(summary.conversation_id === conversationId, "conversation id was not preserved");
+assert(summary.status === "completed", `interaction status is not completed: ${summary.status}`);
+assert(summary.requests.length >= 3, "interaction must aggregate at least three requests");
+assert(summary.traces.length >= 3, "interaction must aggregate at least three traces");
+assert(
+  expectedRequestIds.every((id) => summary.requests.some((item) => item.request_id === id)),
+  "interaction is missing one or more SDK request ids",
+);
+assert((evidenceChain.data.claims ?? []).length > 0, "evidence chain has no claim");
+assert((evidenceChain.data.evidence_refs ?? []).length >= 2, "evidence chain is incomplete");
+assert(storedQuestion.content === question, "question artifact content is not readable");
+assert(
+  storedResult.content?.total_demand === totalDemand,
+  "result artifact content is not readable",
+);
+
+console.log(
+  JSON.stringify(
+    {
+      passed: true,
+      conversation_id: conversationId,
+      interaction_id: interactionId,
+      request_ids: expectedRequestIds,
+      trace_ids: [
+        identityOf(schemaClient).traceId,
+        identityOf(dataClient).traceId,
+        evidenceIdentity.traceId,
+      ],
+      question,
+      answer,
+      interaction: {
+        status: summary.status,
+        request_count: summary.requests.length,
+        trace_count: summary.traces.length,
+      },
+    },
+    null,
+    2,
+  ),
+);
+
+function operationClient(name) {
+  return createClient({
+    baseUrl,
+    ...(token ? { token } : {}),
+    businessDomain,
+    insecure: envFlag("BKN_INSECURE"),
+    trace: {
+      requestId: `req_e2e_${runId}_${name}`,
+      conversationId,
+      interactionId,
+      operationId: `op_e2e_${runId}_${name}`,
+    },
+  });
+}
+
+function identityOf(client) {
+  const trace = client.ctx.trace;
+  if (!trace) throw new Error("SDK trace context is missing");
+  const [, traceId, spanId] = trace.traceparent.split("-");
+  if (!traceId || !spanId) throw new Error("SDK traceparent is invalid");
+  return { requestId: trace.requestId, traceparent: trace.traceparent, traceId, spanId };
+}
+
+function artifact(type, content, businessRefs) {
+  const id = `art_${type}_${runId}`;
+  return {
+    artifact_id: id,
+    artifact_type: type,
+    "bkn.request.id": evidenceIdentity.requestId,
+    trace_id: evidenceIdentity.traceId,
+    interaction_id: interactionId,
+    business_refs: businessRefs,
+    content_type: "application/json",
+    schema_version: "2.2.0",
+    observed_at: new Date().toISOString(),
+    content_hash: hash(content),
+    content,
+    business_domain: businessDomain,
+    "bkn.account.id": accountId,
+    "bkn.account.type": accountType,
+    initiator: `account:${accountId}`,
+    agent_or_app: agentRef,
+  };
+}
+
+function artifactRef(value) {
+  return `artifact:${value.artifact_id}`;
+}
+
+function evidenceRef(refId, refType, sourceSystem) {
+  return {
+    refId,
+    refType,
+    sourceSystem,
+    validity: "observed",
+    versionStatus: "versioned",
+    visibility: "visible",
+  };
+}
+
+function businessRef(refId, refType) {
+  return {
+    refId,
+    refType,
+    sourceSystem: refType === "resource" ? "vega" : "bkn",
+    validity: "available",
+    versionStatus: "versioned",
+    visibility: "visible",
+  };
+}
+
+async function pollInteraction(client, requestIds) {
+  let latest;
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    try {
+      latest = await client.trace.interactions.get(interactionId);
+      const complete = requestIds.every((id) =>
+        latest.requests.some((item) => item.request_id === id),
+      );
+      if (complete && latest.traces.length >= requestIds.length) return latest;
+    } catch (error) {
+      if (error?.status !== 404) throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new Error(`interaction summary did not converge: ${JSON.stringify(latest)}`);
+}
+
+function extractForecastBinding(value) {
+  const candidates = [];
+  walk(value, (item) => {
+    const properties = item.data_properties ?? item.properties;
+    const source = item.data_source ?? item.data_sources;
+    if (Array.isArray(properties) && source) candidates.push({ item, properties, source });
+  });
+  const selected =
+    candidates.find(
+      ({ item, properties }) =>
+        `${item.id ?? ""} ${item.name ?? ""} ${item.display_name ?? ""} ${item.concept_id ?? ""} ${item.concept_name ?? ""}`.match(
+          /forecast|需求预测/i,
+        ) && hasProperty(properties, ["consensus_demand", "qty", "demand_quantity"]),
+    ) ??
+    candidates.find(
+      ({ properties }) =>
+        hasProperty(properties, ["consensus_demand", "qty", "demand_quantity"]) &&
+        hasProperty(properties, ["month", "startdate", "forecast_month", "bizdate"]),
+    );
+  if (!selected) throw new Error("search_schema did not return the forecast object binding");
+
+  const sources = Array.isArray(selected.source) ? selected.source : [selected.source];
+  const resourceId = sources
+    .map((source) => source?.id ?? source?.resource_id)
+    .find((id) => typeof id === "string" && id);
+  const objectTypeId = selected.item.id ?? selected.item.object_type_id ?? selected.item.concept_id;
+  const month = propertyBinding(selected.properties, [
+    "month",
+    "startdate",
+    "forecast_month",
+    "bizdate",
+  ]);
+  const demand = propertyBinding(selected.properties, [
+    "consensus_demand",
+    "qty",
+    "demand_quantity",
+  ]);
+  const product = propertyBinding(selected.properties, ["product_code", "material_number"]);
+  const order = propertyBinding(selected.properties, ["confirmed_order", "billno", "id"]);
+  if (!resourceId || !objectTypeId) throw new Error("forecast schema binding is incomplete");
+  return { resourceId, objectTypeId, month, demand, product, order };
+}
+
+function hasProperty(properties, logicalNames) {
+  return properties.some((property) => logicalNames.includes(property.name));
+}
+
+function propertyBinding(properties, logicalNames) {
+  const property = logicalNames
+    .map((logicalName) => properties.find((item) => item.name === logicalName))
+    .find(Boolean);
+  if (!property) throw new Error(`forecast schema is missing one of: ${logicalNames.join(", ")}`);
+  const column = property.column ?? property.mapped_field ?? property.name;
+  return { logicalName: property.name, column };
+}
+
+function buildForecastSql(binding, year) {
+  const columns = [binding.product, binding.order, binding.demand, binding.month].map(
+    ({ column }) => quoteIdentifier(column),
+  );
+  const month = quoteIdentifier(binding.month.column);
+  const demand = quoteIdentifier(binding.demand.column);
+  const periodStart = `${year}-06-01`;
+  const periodEnd = `${year}-07-01`;
+  return [
+    `SELECT ${columns.join(", ")},`,
+    "COUNT(*) OVER () AS forecast_count,",
+    `SUM(CAST(${demand} AS DOUBLE)) OVER () AS total_demand`,
+    `FROM {{.${binding.resourceId}}}`,
+    `WHERE ${month} >= '${periodStart}' AND ${month} < '${periodEnd}'`,
+    `ORDER BY ${month}, ${quoteIdentifier(binding.product.column)}`,
+  ].join(" ");
+}
+
+function extractRows(value) {
+  if (Array.isArray(value?.entries)) return value.entries;
+  if (Array.isArray(value?.data?.entries)) return value.data.entries;
+  throw new Error("run_sql response does not contain entries");
+}
+
+function countSchemaConcepts(value) {
+  return ["object_types", "relation_types", "action_types", "metric_types"].reduce(
+    (count, key) => count + (Array.isArray(value?.[key]) ? value[key].length : 0),
+    0,
+  );
+}
+
+function walk(value, visitor) {
+  if (!value || typeof value !== "object") return;
+  if (!Array.isArray(value)) visitor(value);
+  for (const child of Array.isArray(value) ? value : Object.values(value)) walk(child, visitor);
+}
+
+function quoteIdentifier(value) {
+  return `"${String(value).replaceAll('"', '""')}"`;
+}
+
+function numeric(value, fallback = Number.NaN) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function hash(value) {
+  return `sha256:${createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function requiredEnv(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function envFlag(name) {
+  return /^(1|true|yes)$/i.test(process.env[name] ?? "");
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}

--- a/test/unit/context-loader.test.ts
+++ b/test/unit/context-loader.test.ts
@@ -58,7 +58,10 @@ function toolCallHeaders(f: typeof fetch): Headers {
 }
 
 // A fresh kn per test avoids the module-level session cache masking the initialize POST.
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
 
 describe("progressive KN detail (get_kn_detail)", () => {
   it("propagates the complete replay-stable business trace context to MCP calls", async () => {
@@ -76,6 +79,33 @@ describe("progressive KN detail (get_kn_detail)", () => {
     expect(headers.get("bkn-operation-id")).toBe("op_supplychain_schema_search");
     expect(headers.get("bkn-attempt")).toBe("1");
     expect(headers.get("bkn-event-observed-at")).toBe("2026-07-27T09:00:00.000Z");
+  });
+
+  it("generates fresh operation context for each call on a long-lived client", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-27T09:00:00.000Z"));
+    const f = mockMcp();
+    const longLivedCtx = {
+      ...ctx,
+      trace: {
+        requestId: ctx.trace?.requestId ?? "",
+        traceparent: ctx.trace?.traceparent ?? "",
+        conversationId: ctx.trace?.conversationId,
+        interactionId: ctx.trace?.interactionId,
+      },
+    };
+
+    await getKnDetail(longLivedCtx, "kn-long-lived-a");
+    vi.setSystemTime(new Date("2026-07-27T09:01:00.000Z"));
+    await getKnDetail(longLivedCtx, "kn-long-lived-b");
+
+    const headers = (f as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls
+      .filter(([, init]) => JSON.parse(init.body as string).method === "tools/call")
+      .map(([, init]) => new Headers(init.headers));
+    expect(headers).toHaveLength(2);
+    expect(headers[0]?.get("bkn-operation-id")).not.toBe(headers[1]?.get("bkn-operation-id"));
+    expect(headers[0]?.get("bkn-event-observed-at")).toBe("2026-07-27T09:00:00.000Z");
+    expect(headers[1]?.get("bkn-event-observed-at")).toBe("2026-07-27T09:01:00.000Z");
   });
 
   it("defaults to no detail_level (server default = summary), asks for JSON", async () => {

--- a/test/unit/context-loader.test.ts
+++ b/test/unit/context-loader.test.ts
@@ -10,6 +10,15 @@ const ctx: RequestContext = {
   token: "t",
   businessDomain: "bd_public",
   insecure: false,
+  trace: {
+    requestId: "req_context_loader_001",
+    traceparent: "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
+    conversationId: "conversation_supply_chain",
+    interactionId: "interaction_june_forecast",
+    operationId: "op_supplychain_schema_search",
+    attempt: 1,
+    observedAt: "2026-07-27T09:00:00.000Z",
+  },
 };
 
 /** Mock the MCP endpoint: every POST returns a session id + a JSON-RPC result. */
@@ -39,10 +48,36 @@ function toolCallBody(f: typeof fetch): { name: string; arguments: Record<string
   throw new Error("no tools/call POST captured");
 }
 
+function toolCallHeaders(f: typeof fetch): Headers {
+  const calls = (f as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls;
+  for (const [, init] of calls) {
+    const body = JSON.parse(init.body as string) as { method?: string };
+    if (body.method === "tools/call") return new Headers(init.headers);
+  }
+  throw new Error("no tools/call POST captured");
+}
+
 // A fresh kn per test avoids the module-level session cache masking the initialize POST.
 afterEach(() => vi.unstubAllGlobals());
 
 describe("progressive KN detail (get_kn_detail)", () => {
+  it("propagates the complete replay-stable business trace context to MCP calls", async () => {
+    const f = mockMcp();
+    await getKnDetail(ctx, "kn-trace-headers");
+
+    const headers = toolCallHeaders(f);
+    expect(headers.get("bkn-request-id")).toBe("req_context_loader_001");
+    expect(headers.get("x-request-id")).toBe("req_context_loader_001");
+    expect(headers.get("traceparent")).toBe(
+      "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
+    );
+    expect(headers.get("bkn-conversation-id")).toBe("conversation_supply_chain");
+    expect(headers.get("bkn-interaction-id")).toBe("interaction_june_forecast");
+    expect(headers.get("bkn-operation-id")).toBe("op_supplychain_schema_search");
+    expect(headers.get("bkn-attempt")).toBe("1");
+    expect(headers.get("bkn-event-observed-at")).toBe("2026-07-27T09:00:00.000Z");
+  });
+
   it("defaults to no detail_level (server default = summary), asks for JSON", async () => {
     const f = mockMcp();
     await getKnDetail(ctx, "kn-a");

--- a/test/unit/fixture-validate.test.ts
+++ b/test/unit/fixture-validate.test.ts
@@ -365,7 +365,7 @@ describe("validateFixturePath", () => {
       payload: {
         action_instance_id: "action_1",
         action_type: "create_monitor",
-        target_refs: ["object:material:M-1001"],
+        target_refs: ["object:supplychain:material"],
         reason_hash: `sha256:${"4".repeat(64)}`,
         status: "recommended",
       },
@@ -428,6 +428,37 @@ describe("validateFixturePath", () => {
     expect(result.ok).toBe(true);
     expect(result.results[0]?.errors).toContainEqual(
       expect.objectContaining({ code: "BKN_TRACE_ACTION_TRANSITION_INVALID" }),
+    );
+  });
+
+  it("rejects ambiguous short business references", () => {
+    const fixture = businessFixture([
+      businessEvent("business.refs.resolved", {
+        claim_id: "claim_1",
+        payload: {
+          claim_id: "claim_1",
+          resolver_status: "resolved",
+          business_refs: [
+            {
+              ref_id: "object:customer",
+              ref_type: "object",
+              source_system: "bkn",
+              validity: "available",
+              version_status: "versioned",
+              visibility: "visible",
+            },
+          ],
+        },
+      }),
+    ]);
+    fixture.fixture_type = "negative";
+    fixture.expected_result = "fail";
+
+    const result = validateFixturePath(writeFixture("short-ref-negative.json", fixture));
+
+    expect(result.ok).toBe(true);
+    expect(result.results[0]?.errors).toContainEqual(
+      expect.objectContaining({ code: "BKN_TRACE_REFERENCE_ID_INVALID" }),
     );
   });
 });

--- a/test/unit/fixture-validate.test.ts
+++ b/test/unit/fixture-validate.test.ts
@@ -62,6 +62,40 @@ function baseFixture(overrides: Record<string, unknown> = {}): Record<string, un
   return { ...fixture, ...overrides };
 }
 
+function businessFixture(events: Record<string, unknown>[]): Record<string, unknown> {
+  const fixture = baseFixture({
+    "bkn.trace.schema.version": "2.1.0",
+    fixture_id: "fixture_business_2_1",
+    scenario: "business_vertical_slice",
+    events,
+  });
+  const logs = fixture.logs as Record<string, unknown>[];
+  logs[0]!["bkn.trace.schema.version"] = "2.1.0";
+  return fixture;
+}
+
+function businessEvent(
+  eventType: string,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    event_id: `evt_${eventType.replaceAll(".", "_")}`,
+    event_type: eventType,
+    "bkn.trace.schema.version": "2.1.0",
+    observed_at: "2026-07-25T08:00:00.000000000Z",
+    emitted_at: "2026-07-25T08:00:00.001000000Z",
+    producer_module: "third-party-agent",
+    trace_id: "11111111111111111111111111111111",
+    span_id: "2222222222222222",
+    "bkn.request.id": "req_fixture_001",
+    "bkn.operation.name": eventType,
+    interaction_id: "int_fixture_001",
+    operation_id: "op_fixture_001",
+    payload: {},
+    ...overrides,
+  };
+}
+
 afterEach(() => {
   for (const dir of temps.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
@@ -129,5 +163,271 @@ describe("validateFixturePath", () => {
       "fixture_positive",
       "fixture_sensitive",
     ]);
+  });
+
+  it("accepts a 2.1 business interaction with explicit causality", () => {
+    const interaction = businessEvent("agent.interaction.started", {
+      event_id: "evt_interaction",
+      operation_id: undefined,
+      payload: {
+        intent_hash: `sha256:${"1".repeat(64)}`,
+        mode: "task",
+        agent_id: "agent_1",
+      },
+    });
+    const data = businessEvent("data.query.observed", {
+      event_id: "evt_data",
+      causation_event_id: "evt_interaction",
+      payload: {
+        query_hash: `sha256:${"2".repeat(64)}`,
+        query_type: "aggregate",
+        row_count: 2,
+      },
+    });
+    const claim = businessEvent("claim.created", {
+      event_id: "evt_claim",
+      operation_id: undefined,
+      causation_event_id: "evt_data",
+      claim_id: "claim_1",
+      payload: {
+        claim_id: "claim_1",
+        claim_type: "answer",
+        claim_hash: `sha256:${"3".repeat(64)}`,
+        source_event_ids: ["evt_data"],
+        operation_ids: ["op_fixture_001"],
+        visibility: "visible",
+        version_status: "versioned",
+      },
+    });
+    const file = writeFixture("business.json", businessFixture([interaction, data, claim]));
+
+    const result = validateFixturePath(file);
+
+    expect(result.ok).toBe(true);
+    expect(result.results[0]).toMatchObject({ result: "pass", contractVersion: "2.1.0" });
+  });
+
+  it("rejects a 2.1 operation event without operation_id", () => {
+    const event = businessEvent("data.query.observed", { operation_id: undefined });
+    const fixture = businessFixture([event]);
+    fixture.fixture_type = "negative";
+    fixture.expected_result = "fail";
+    const file = writeFixture("business-negative.json", fixture);
+
+    const result = validateFixturePath(file);
+
+    expect(result.ok).toBe(true);
+    expect(result.results[0]?.errors).toContainEqual(
+      expect.objectContaining({ code: "BKN_TRACE_REQUIRED_FIELD_MISSING" }),
+    );
+  });
+
+  it("rejects legacy aliases in a 2.1 knowledge event payload", () => {
+    const event = businessEvent("knowledge.read.observed", {
+      causation_event_id: "evt_interaction",
+      payload: {
+        knowledge_network_ref: "kn:supplychain:v3",
+        result_count: 3,
+      },
+    });
+    const fixture = businessFixture([event]);
+    fixture.fixture_type = "negative";
+    fixture.expected_result = "fail";
+    const file = writeFixture("business-legacy-alias-negative.json", fixture);
+
+    const result = validateFixturePath(file);
+
+    expect(result.ok).toBe(true);
+    expect(result.results[0]?.errors).toContainEqual(
+      expect.objectContaining({
+        code: "BKN_TRACE_REQUIRED_FIELD_MISSING",
+        path: expect.stringContaining("kn_id"),
+      }),
+    );
+  });
+
+  it("rejects private events and raw unregistered payload fields in 2.1", () => {
+    const privateEvent = businessEvent("structured_output.validated", {
+      causation_event_id: "evt_interaction",
+      payload: { status: "ok" },
+    });
+    const data = businessEvent("data.query.observed", {
+      event_id: "evt_data_raw",
+      causation_event_id: "evt_interaction",
+      payload: {
+        query_hash: `sha256:${"2".repeat(64)}`,
+        query_type: "aggregate",
+        row_count: 1,
+        approval_comment: "approved without review",
+      },
+    });
+    const fixture = businessFixture([privateEvent, data]);
+    fixture.fixture_type = "negative";
+    fixture.expected_result = "fail";
+    const file = writeFixture("business-private-payload-negative.json", fixture);
+
+    const result = validateFixturePath(file);
+
+    expect(result.ok).toBe(true);
+    expect(result.results[0]?.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "BKN_TRACE_EVENT_TYPE_UNSUPPORTED" }),
+        expect.objectContaining({ code: "BKN_TRACE_SENSITIVE_VALUE_LEAKED" }),
+      ]),
+    );
+  });
+
+  it("rejects forward causation and event/envelope version mismatch", () => {
+    const interaction = businessEvent("agent.interaction.started", {
+      event_id: "evt_interaction",
+      operation_id: undefined,
+      payload: {
+        intent_hash: `sha256:${"1".repeat(64)}`,
+        mode: "task",
+        agent_id: "agent_1",
+      },
+    });
+    const first = businessEvent("data.query.observed", {
+      event_id: "evt_data_first",
+      causation_event_id: "evt_data_later",
+      "bkn.trace.schema.version": "2.0.0",
+      payload: {
+        query_hash: `sha256:${"2".repeat(64)}`,
+        query_type: "aggregate",
+        row_count: 1,
+      },
+    });
+    const later = businessEvent("data.query.observed", {
+      event_id: "evt_data_later",
+      causation_event_id: "evt_interaction",
+      payload: {
+        query_hash: `sha256:${"3".repeat(64)}`,
+        query_type: "aggregate",
+        row_count: 1,
+      },
+    });
+    const fixture = businessFixture([interaction, first, later]);
+    fixture.fixture_type = "negative";
+    fixture.expected_result = "fail";
+    const file = writeFixture("business-causation-negative.json", fixture);
+
+    const result = validateFixturePath(file);
+
+    expect(result.ok).toBe(true);
+    expect(result.results[0]?.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "BKN_TRACE_CAUSATION_INVALID" }),
+        expect.objectContaining({ code: "BKN_TRACE_SCHEMA_VERSION_UNSUPPORTED" }),
+      ]),
+    );
+  });
+
+  it("rejects action identity drift even when state order is valid", () => {
+    const interaction = businessEvent("agent.interaction.started", {
+      event_id: "evt_interaction",
+      operation_id: undefined,
+      payload: {
+        intent_hash: `sha256:${"1".repeat(64)}`,
+        mode: "task",
+        agent_id: "agent_1",
+      },
+    });
+    const data = businessEvent("data.query.observed", {
+      event_id: "evt_data",
+      operation_id: "op_data",
+      causation_event_id: "evt_interaction",
+      payload: {
+        query_hash: `sha256:${"2".repeat(64)}`,
+        query_type: "aggregate",
+        row_count: 1,
+      },
+    });
+    const claim = businessEvent("claim.created", {
+      event_id: "evt_claim",
+      operation_id: undefined,
+      causation_event_id: "evt_data",
+      claim_id: "claim_1",
+      payload: {
+        claim_id: "claim_1",
+        claim_type: "recommendation",
+        claim_hash: `sha256:${"3".repeat(64)}`,
+        source_event_ids: ["evt_data"],
+        operation_ids: ["op_data"],
+        visibility: "visible",
+        version_status: "versioned",
+      },
+    });
+    const recommended = businessEvent("action.recommended", {
+      event_id: "evt_recommended",
+      operation_id: "op_action",
+      causation_event_id: "evt_claim",
+      claim_id: "claim_1",
+      payload: {
+        action_instance_id: "action_1",
+        action_type: "create_monitor",
+        target_refs: ["object:material:M-1001"],
+        reason_hash: `sha256:${"4".repeat(64)}`,
+        status: "recommended",
+      },
+    });
+    const requested = businessEvent("action.approval_requested", {
+      event_id: "evt_requested",
+      operation_id: "op_action",
+      causation_event_id: "evt_recommended",
+      claim_id: "claim_1",
+      payload: {
+        action_instance_id: "action_1",
+        policy_ref: "policy:monitor",
+        status: "approval_requested",
+      },
+    });
+    const approved = businessEvent("action.approved", {
+      event_id: "evt_approved",
+      operation_id: "op_action_drift",
+      causation_event_id: "evt_requested",
+      claim_id: "claim_1",
+      payload: {
+        action_instance_id: "action_1",
+        actor_ref: "account:approver",
+        policy_decision_ref: "decision:allow",
+        status: "approved",
+      },
+    });
+    const fixture = businessFixture([interaction, data, claim, recommended, requested, approved]);
+    fixture.fixture_type = "negative";
+    fixture.expected_result = "fail";
+    const file = writeFixture("action-identity-negative.json", fixture);
+
+    const result = validateFixturePath(file);
+
+    expect(result.ok).toBe(true);
+    expect(result.results[0]?.errors).toContainEqual(
+      expect.objectContaining({ code: "BKN_TRACE_ACTION_TRANSITION_INVALID" }),
+    );
+  });
+
+  it("rejects an action execution that skips approval", () => {
+    const recommended = businessEvent("action.recommended", {
+      event_id: "evt_recommended",
+      claim_id: "claim_1",
+      payload: { action_instance_id: "action_1", status: "recommended" },
+    });
+    const executed = businessEvent("action.executed", {
+      event_id: "evt_executed",
+      causation_event_id: "evt_recommended",
+      claim_id: "claim_1",
+      payload: { action_instance_id: "action_1", status: "ok" },
+    });
+    const fixture = businessFixture([recommended, executed]);
+    fixture.fixture_type = "negative";
+    fixture.expected_result = "fail";
+    const file = writeFixture("action-negative.json", fixture);
+
+    const result = validateFixturePath(file);
+
+    expect(result.ok).toBe(true);
+    expect(result.results[0]?.errors).toContainEqual(
+      expect.objectContaining({ code: "BKN_TRACE_ACTION_TRANSITION_INVALID" }),
+    );
   });
 });

--- a/test/unit/trace-context.test.ts
+++ b/test/unit/trace-context.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { buildHeaders } from "../../src/api/headers.js";
+import { traceOptionsFrom } from "../../src/commands/_shared.js";
 import { resolveContext } from "../../src/config/resolve.js";
 import type { RequestContext } from "../../src/types.js";
 
@@ -58,5 +59,66 @@ describe("resolveContext trace defaults", () => {
     expect(resolved.trace?.traceparent).toBe(
       "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
     );
+  });
+});
+
+describe("caller-owned conversation and interaction ids", () => {
+  it("propagates explicitly supplied ids as headers", () => {
+    const resolved = resolveContext({
+      baseUrl: "https://demo.example.com",
+      token: "SECRET",
+      trace: {
+        conversationId: "agent:thread_supply_chain",
+        interactionId: "int_supply_chain_001",
+      },
+    } as Parameters<typeof resolveContext>[0]);
+
+    const headers = buildHeaders(resolved);
+    expect(headers["bkn-conversation-id"]).toBe("agent:thread_supply_chain");
+    expect(headers["bkn-interaction-id"]).toBe("int_supply_chain_001");
+  });
+
+  it("does not generate grouping ids when the caller supplies none", () => {
+    const resolved = resolveContext({
+      baseUrl: "https://demo.example.com",
+      token: "SECRET",
+    });
+    const headers = buildHeaders(resolved);
+    expect(headers).not.toHaveProperty("bkn-conversation-id");
+    expect(headers).not.toHaveProperty("bkn-interaction-id");
+  });
+
+  it("drops malformed grouping ids without rejecting the request", () => {
+    const resolved = resolveContext({
+      baseUrl: "https://demo.example.com",
+      token: "SECRET",
+      trace: {
+        conversationId: "bad id with spaces",
+        interactionId: "x".repeat(129),
+      },
+    } as Parameters<typeof resolveContext>[0]);
+
+    const headers = buildHeaders(resolved);
+    expect(headers).not.toHaveProperty("bkn-conversation-id");
+    expect(headers).not.toHaveProperty("bkn-interaction-id");
+  });
+
+  it("keeps CLI env fallback out of long-lived SDK clients", () => {
+    vi.stubEnv("BKN_CONVERSATION_ID", "cli:conversation_1");
+    vi.stubEnv("BKN_INTERACTION_ID", "cli:interaction_1");
+    try {
+      const resolved = resolveContext({
+        baseUrl: "https://demo.example.com",
+        token: "SECRET",
+      });
+      expect(resolved.trace?.conversationId).toBeUndefined();
+      expect(resolved.trace?.interactionId).toBeUndefined();
+      expect(traceOptionsFrom({})).toEqual({
+        conversationId: "cli:conversation_1",
+        interactionId: "cli:interaction_1",
+      });
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 });

--- a/test/unit/trace-context.test.ts
+++ b/test/unit/trace-context.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { buildHeaders } from "../../src/api/headers.js";
 import { traceOptionsFrom } from "../../src/commands/_shared.js";
 import { resolveContext } from "../../src/config/resolve.js";
+import { createOperationTraceContext } from "../../src/trace-context.js";
 import type { RequestContext } from "../../src/types.js";
 
 const ctx: RequestContext = {
@@ -43,12 +44,12 @@ describe("resolveContext trace defaults", () => {
     const resolved = resolveContext({ baseUrl: "https://demo.example.com", token: "SECRET" });
     expect(resolved.trace?.requestId).toMatch(/^req_[0-9A-Za-z_.-]+$/);
     expect(resolved.trace?.traceparent).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-01$/);
-    expect(resolved.trace?.operationId).toMatch(/^op_[0-9a-f-]+$/);
-    expect(resolved.trace?.attempt).toBe(1);
-    expect(resolved.trace?.observedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(resolved.trace?.operationId).toBeUndefined();
+    expect(resolved.trace?.attempt).toBeUndefined();
+    expect(resolved.trace?.observedAt).toBeUndefined();
     expect(buildHeaders(resolved)["bkn-request-id"]).toBe(resolved.trace?.requestId);
-    expect(buildHeaders(resolved)["bkn-operation-id"]).toBe(resolved.trace?.operationId);
-    expect(buildHeaders(resolved)["bkn-event-observed-at"]).toBe(resolved.trace?.observedAt);
+    expect(buildHeaders(resolved)).not.toHaveProperty("bkn-operation-id");
+    expect(buildHeaders(resolved)).not.toHaveProperty("bkn-event-observed-at");
   });
 
   it("accepts a caller supplied request id and valid traceparent", () => {
@@ -66,17 +67,22 @@ describe("resolveContext trace defaults", () => {
     );
   });
 
-  it("replaces a non-RFC3339 observed time and keeps the generated value stable", () => {
+  it("creates replay-stable operation context per logical call, not per client", () => {
     const resolved = resolveContext({
       baseUrl: "https://demo.example.com",
       token: "SECRET",
       trace: { observedAt: "July 27 2026 09:00:00 GMT" },
     });
-    const first = buildHeaders(resolved);
-    const replay = buildHeaders(resolved);
-    expect(first["bkn-event-observed-at"]).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
-    expect(replay["bkn-event-observed-at"]).toBe(first["bkn-event-observed-at"]);
-    expect(replay["bkn-operation-id"]).toBe(first["bkn-operation-id"]);
+    if (!resolved.trace) throw new Error("trace context missing");
+    const firstOperation = createOperationTraceContext(resolved.trace);
+    const replay = buildHeaders({ ...resolved, trace: firstOperation });
+    const secondOperation = createOperationTraceContext(resolved.trace);
+
+    expect(resolved.trace.observedAt).toBeUndefined();
+    expect(firstOperation.operationId).not.toBe(secondOperation.operationId);
+    expect(firstOperation.observedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(replay["bkn-event-observed-at"]).toBe(firstOperation.observedAt);
+    expect(replay["bkn-operation-id"]).toBe(firstOperation.operationId);
   });
 });
 

--- a/test/unit/trace-context.test.ts
+++ b/test/unit/trace-context.test.ts
@@ -43,7 +43,12 @@ describe("resolveContext trace defaults", () => {
     const resolved = resolveContext({ baseUrl: "https://demo.example.com", token: "SECRET" });
     expect(resolved.trace?.requestId).toMatch(/^req_[0-9A-Za-z_.-]+$/);
     expect(resolved.trace?.traceparent).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-01$/);
+    expect(resolved.trace?.operationId).toMatch(/^op_[0-9a-f-]+$/);
+    expect(resolved.trace?.attempt).toBe(1);
+    expect(resolved.trace?.observedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
     expect(buildHeaders(resolved)["bkn-request-id"]).toBe(resolved.trace?.requestId);
+    expect(buildHeaders(resolved)["bkn-operation-id"]).toBe(resolved.trace?.operationId);
+    expect(buildHeaders(resolved)["bkn-event-observed-at"]).toBe(resolved.trace?.observedAt);
   });
 
   it("accepts a caller supplied request id and valid traceparent", () => {
@@ -59,6 +64,19 @@ describe("resolveContext trace defaults", () => {
     expect(resolved.trace?.traceparent).toBe(
       "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
     );
+  });
+
+  it("replaces a non-RFC3339 observed time and keeps the generated value stable", () => {
+    const resolved = resolveContext({
+      baseUrl: "https://demo.example.com",
+      token: "SECRET",
+      trace: { observedAt: "July 27 2026 09:00:00 GMT" },
+    });
+    const first = buildHeaders(resolved);
+    const replay = buildHeaders(resolved);
+    expect(first["bkn-event-observed-at"]).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(replay["bkn-event-observed-at"]).toBe(first["bkn-event-observed-at"]);
+    expect(replay["bkn-operation-id"]).toBe(first["bkn-operation-id"]);
   });
 });
 

--- a/test/unit/trace-session.test.ts
+++ b/test/unit/trace-session.test.ts
@@ -52,6 +52,128 @@ function session(overrides: Partial<ConstructorParameters<typeof TraceSession>[0
 }
 
 describe("TraceSession", () => {
+  it("preserves a caller-owned conversation across the evidence interaction", async () => {
+    const { value, emit } = session({ conversationId: "conversation_supply_chain" });
+    value.startInteraction({
+      operationName: "agent.run",
+      intentHash: `sha256:${"1".repeat(64)}`,
+      mode: "task",
+      agentId: "agent_1",
+    });
+
+    await value.flush();
+
+    expect(emit.mock.calls[0]?.[0].trace["bkn.conversation.id"]).toBe("conversation_supply_chain");
+  });
+
+  it("builds a 2.2 session only from already-persisted artifact references", async () => {
+    const { value, emit } = session({ contractVersion: "2.2.0" });
+
+    expect(() =>
+      value.startInteraction({
+        operationName: "agent.run",
+        intentHash: `sha256:${"1".repeat(64)}`,
+        mode: "task",
+        agentId: "agent_1",
+      }),
+    ).toThrow(/question_artifact_ref/);
+
+    const interaction = value.startInteraction({
+      operationName: "agent.run",
+      intentHash: `sha256:${"1".repeat(64)}`,
+      mode: "task",
+      agentId: "agent_1",
+      questionArtifactRef: "artifact:art_question_001",
+    });
+    const data = value.observeOperation("data.query.observed", {
+      operationName: "data.query",
+      causationEventId: interaction.event_id,
+      payload: {
+        query_artifact_ref: "artifact:art_query_001",
+        query_hash: `sha256:${"2".repeat(64)}`,
+        query_type: "aggregate",
+        result_artifact_ref: "artifact:art_data_result_001",
+        row_count: 2,
+      },
+    });
+    value.createClaim({
+      operationName: "agent.claim.create",
+      causationEventId: data.event_id,
+      claimId: "claim_1",
+      claimType: "answer",
+      claimHash: `sha256:${"3".repeat(64)}`,
+      operationIds: [data.operation_id as string],
+      resultArtifactRef: "artifact:art_result_001",
+      sourceEventIds: [data.event_id],
+    });
+
+    await value.flush();
+
+    const request = emit.mock.calls[0]?.[0];
+    expect(request?.["bkn.trace.schema.version"]).toBe("2.2.0");
+    expect(request?.events[0]?.payload.question_artifact_ref).toBe("artifact:art_question_001");
+    expect(request?.events.at(-1)?.payload.result_artifact_ref).toBe("artifact:art_result_001");
+  });
+
+  it("records a 2.2 action result using only its persisted result artifact", () => {
+    const { value } = session({ contractVersion: "2.2.0" });
+    const interaction = value.startInteraction({
+      operationName: "agent.run",
+      intentHash: `sha256:${"1".repeat(64)}`,
+      mode: "task",
+      agentId: "agent_1",
+      questionArtifactRef: "artifact:art_question_001",
+    });
+    const data = value.observeOperation("data.query.observed", {
+      operationName: "data.query",
+      causationEventId: interaction.event_id,
+      payload: {
+        query_artifact_ref: "artifact:art_query_001",
+        query_hash: `sha256:${"2".repeat(64)}`,
+        query_type: "aggregate",
+        result_artifact_ref: "artifact:art_data_result_001",
+        row_count: 1,
+      },
+    });
+    value.createClaim({
+      operationName: "agent.claim.create",
+      causationEventId: data.event_id,
+      claimId: "claim_1",
+      claimType: "recommendation",
+      claimHash: `sha256:${"3".repeat(64)}`,
+      operationIds: [data.operation_id as string],
+      resultArtifactRef: "artifact:art_result_001",
+      sourceEventIds: [data.event_id],
+    });
+    const action = value.recommendAction({
+      operationName: "action.recommend",
+      claimId: "claim_1",
+      actionType: "create_forecast_monitor",
+      targetRefs: ["object:supplychain:material"],
+      reasonHash: `sha256:${"4".repeat(64)}`,
+      inputArtifactRef: "artifact:art_action_input_001",
+    });
+    value.requestActionApproval(action, { policyRef: "policy:e2e" });
+    value.approveAction(action, {
+      actorRef: "account:account_1",
+      policyDecisionRef: "decision:allow",
+    });
+    value.executeAction(action, { status: "ok", invocationRef: "tool:monitor" });
+
+    const result = value.recordActionResult(action, {
+      status: "created",
+      resultHash: `sha256:${"5".repeat(64)}`,
+      resultArtifactRef: "artifact:art_action_result_001",
+    });
+
+    expect(result.payload).toMatchObject({
+      result_artifact_ref: "artifact:art_action_result_001",
+      status: "created",
+    });
+    expect(result.payload).not.toHaveProperty("artifact_ref");
+    expect(result.payload).not.toHaveProperty("task_ref");
+  });
+
   it("builds a causal interaction, operation, and claim without raw JSON", async () => {
     const { value, emit } = session();
     const interaction = value.startInteraction({
@@ -211,7 +333,7 @@ describe("TraceSession", () => {
       resolverStatus: "resolved",
       refs: [
         {
-          refId: "object:material:M-1001",
+          refId: "object:supplychain:material",
           refType: "object",
           sourceSystem: "bkn",
           validity: "available",
@@ -225,7 +347,7 @@ describe("TraceSession", () => {
     expect(business.event_type).toBe("business.refs.resolved");
     expect(business.causation_event_id).toBe(evidence.event_id);
     expect(business.payload.business_refs).toEqual([
-      expect.objectContaining({ ref_id: "object:material:M-1001", ref_type: "object" }),
+      expect.objectContaining({ ref_id: "object:supplychain:material", ref_type: "object" }),
     ]);
   });
 
@@ -383,7 +505,7 @@ describe("TraceSession", () => {
       operationName: "action.recommend",
       claimId: "claim_1",
       actionType: "create_forecast_monitor",
-      targetRefs: ["object:material:M-1001"],
+      targetRefs: ["object:supplychain:material"],
       reasonHash: `sha256:${"4".repeat(64)}`,
     });
 
@@ -456,5 +578,57 @@ describe("TraceSession", () => {
     expect(() =>
       value.executeAction(action, { status: "ok", invocationRef: "tool:monitor" }),
     ).toThrow(/approval/i);
+  });
+
+  it("rejects ambiguous short business and action references", () => {
+    const { value } = session();
+    const interaction = value.startInteraction({
+      operationName: "agent.run",
+      intentHash: `sha256:${"1".repeat(64)}`,
+      mode: "task",
+      agentId: "agent_1",
+    });
+    const data = value.observeOperation("data.query.observed", {
+      operationName: "data.query",
+      causationEventId: interaction.event_id,
+      payload: { query_hash: `sha256:${"2".repeat(64)}`, query_type: "aggregate", row_count: 1 },
+    });
+    value.createClaim({
+      operationName: "agent.claim.create",
+      causationEventId: data.event_id,
+      claimId: "claim_1",
+      claimType: "recommendation",
+      claimHash: `sha256:${"3".repeat(64)}`,
+      sourceEventIds: [data.event_id],
+      operationIds: [data.operation_id as string],
+    });
+
+    expect(() =>
+      value.resolveBusinessRefs({
+        operationName: "agent.business.resolve",
+        claimId: "claim_1",
+        resolverStatus: "resolved",
+        refs: [
+          {
+            refId: "object:customer",
+            refType: "object",
+            sourceSystem: "bkn",
+            validity: "available",
+            versionStatus: "versioned",
+            visibility: "visible",
+          },
+        ],
+      }),
+    ).toThrow(/knowledge-network or resource scope/i);
+
+    expect(() =>
+      value.recommendAction({
+        operationName: "action.recommend",
+        claimId: "claim_1",
+        actionType: "create_monitor",
+        targetRefs: ["object:customer"],
+        reasonHash: `sha256:${"4".repeat(64)}`,
+      }),
+    ).toThrow(/knowledge-network or resource scope/i);
   });
 });

--- a/test/unit/trace-session.test.ts
+++ b/test/unit/trace-session.test.ts
@@ -1,0 +1,460 @@
+import { describe, expect, it, vi } from "vitest";
+import type { EvidenceIngestRequest, EvidenceIngestResponse } from "../../src/api/trace.js";
+import { TraceSession } from "../../src/trace-session.js";
+
+const NOW = "2026-07-25T08:00:00.000000000Z";
+
+function session(overrides: Partial<ConstructorParameters<typeof TraceSession>[0]> = {}) {
+  const ids = [
+    "evt_interaction",
+    "op_data",
+    "evt_data",
+    "evt_claim",
+    "op_action",
+    "action_1",
+    "evt_recommended",
+    "evt_requested",
+    "evt_approved",
+    "evt_executed",
+    "evt_result",
+  ];
+  const emit = vi.fn<(body: EvidenceIngestRequest) => Promise<EvidenceIngestResponse>>(
+    async (body) => ({
+      trace_id: body.trace.trace_id,
+      "bkn.request.id": body.trace["bkn.request.id"],
+      "bkn.trace.schema.version": body["bkn.trace.schema.version"],
+      accepted_event_count: body.events.length,
+      claim_count: 1,
+      evidence_ref_count: 0,
+      business_ref_count: 0,
+    }),
+  );
+  return {
+    emit,
+    value: new TraceSession({
+      trace: {
+        trace_id: "11111111111111111111111111111111",
+        traceparent: "00-11111111111111111111111111111111-2222222222222222-01",
+        "bkn.request.id": "req_session_001",
+        business_domain: "bd_test",
+        "bkn.account.id": "account_1",
+        "bkn.account.type": "app",
+      },
+      producerModule: "third-party-agent",
+      spanId: "2222222222222222",
+      interactionId: "int_session_001",
+      idFactory: () => ids.shift() ?? "id_exhausted",
+      now: () => NOW,
+      emit,
+      ...overrides,
+    }),
+  };
+}
+
+describe("TraceSession", () => {
+  it("builds a causal interaction, operation, and claim without raw JSON", async () => {
+    const { value, emit } = session();
+    const interaction = value.startInteraction({
+      operationName: "agent.run",
+      intentHash: `sha256:${"1".repeat(64)}`,
+      mode: "task",
+      agentId: "agent_1",
+    });
+    const data = value.observeOperation("data.query.observed", {
+      operationName: "data.query",
+      causationEventId: interaction.event_id,
+      payload: {
+        query_hash: `sha256:${"2".repeat(64)}`,
+        query_type: "aggregate",
+        row_count: 2,
+      },
+    });
+    const claim = value.createClaim({
+      operationName: "agent.claim.create",
+      causationEventId: data.event_id,
+      claimId: "claim_1",
+      claimType: "answer",
+      claimHash: `sha256:${"3".repeat(64)}`,
+      sourceEventIds: [data.event_id],
+      operationIds: [data.operation_id as string],
+    });
+
+    await value.flush();
+
+    expect(claim.claim_id).toBe("claim_1");
+    expect(emit).toHaveBeenCalledOnce();
+    const request = emit.mock.calls[0]?.[0];
+    expect(request?.["bkn.trace.schema.version"]).toBe("2.1.0");
+    expect(request?.events.map((event) => event.event_type)).toEqual([
+      "agent.interaction.started",
+      "data.query.observed",
+      "claim.created",
+    ]);
+    expect(value.pendingEvents()).toHaveLength(0);
+  });
+
+  it("rejects a claim that references an event outside the session", () => {
+    const { value } = session();
+    expect(() =>
+      value.createClaim({
+        operationName: "agent.claim.create",
+        causationEventId: "evt_missing",
+        claimId: "claim_1",
+        claimType: "answer",
+        claimHash: `sha256:${"3".repeat(64)}`,
+        sourceEventIds: ["evt_missing"],
+        operationIds: ["op_missing"],
+      }),
+    ).toThrow(/evt_missing/);
+  });
+
+  it("rejects a non-root event without direct causation at runtime", () => {
+    const { value } = session();
+    const interaction = value.startInteraction({
+      operationName: "agent.run",
+      intentHash: `sha256:${"1".repeat(64)}`,
+      mode: "task",
+      agentId: "agent_1",
+    });
+    const data = value.observeOperation("data.query.observed", {
+      operationName: "data.query",
+      causationEventId: interaction.event_id,
+      payload: {
+        query_hash: `sha256:${"2".repeat(64)}`,
+        query_type: "aggregate",
+        row_count: 1,
+      },
+    });
+
+    expect(() =>
+      value.createClaim({
+        operationName: "agent.claim.create",
+        claimId: "claim_1",
+        claimType: "finding",
+        claimHash: `sha256:${"3".repeat(64)}`,
+        sourceEventIds: [data.event_id],
+        operationIds: [data.operation_id as string],
+      } as never),
+    ).toThrow(/causation/i);
+  });
+
+  it("rejects unregistered or raw sensitive payload fields at runtime", () => {
+    const { value } = session();
+    const interaction = value.startInteraction({
+      operationName: "agent.run",
+      intentHash: `sha256:${"1".repeat(64)}`,
+      mode: "task",
+      agentId: "agent_1",
+    });
+
+    expect(() =>
+      value.observeOperation("data.query.observed", {
+        operationName: "data.query",
+        causationEventId: interaction.event_id,
+        payload: {
+          query_hash: `sha256:${"2".repeat(64)}`,
+          query_type: "aggregate",
+          row_count: 1,
+          sql: "update inventory set available = 0",
+        },
+      } as never),
+    ).toThrow(/sql|payload/i);
+  });
+
+  it("records controlled evidence and business references for a known claim", () => {
+    const { value } = session();
+    const interaction = value.startInteraction({
+      operationName: "agent.run",
+      intentHash: `sha256:${"1".repeat(64)}`,
+      mode: "task",
+      agentId: "agent_1",
+    });
+    const knowledge = value.observeOperation("knowledge.read.observed", {
+      operationName: "knowledge.read",
+      causationEventId: interaction.event_id,
+      payload: {
+        kn_id: "supplychain",
+        read_kind: "object_relation_schema",
+        version_status: "versioned",
+        schema_version: "supplychain:v3",
+      },
+    });
+    value.createClaim({
+      operationName: "agent.claim.create",
+      causationEventId: knowledge.event_id,
+      claimId: "claim_1",
+      claimType: "finding",
+      claimHash: `sha256:${"3".repeat(64)}`,
+      sourceEventIds: [knowledge.event_id],
+      operationIds: [knowledge.operation_id as string],
+    });
+
+    const evidence = value.createEvidenceRefs({
+      operationName: "agent.evidence.link",
+      claimId: "claim_1",
+      refs: [
+        {
+          refId: "evidence:material-shortage:1",
+          refType: "data_resource",
+          sourceSystem: "vega",
+          validity: "observed",
+          versionStatus: "versioned",
+          visibility: "visible",
+          summaryHash: `sha256:${"4".repeat(64)}`,
+        },
+      ],
+    });
+    const business = value.resolveBusinessRefs({
+      operationName: "agent.business.resolve",
+      claimId: "claim_1",
+      causationEventId: evidence.event_id,
+      resolverStatus: "resolved",
+      refs: [
+        {
+          refId: "object:material:M-1001",
+          refType: "object",
+          sourceSystem: "bkn",
+          validity: "available",
+          versionStatus: "versioned",
+          visibility: "visible",
+        },
+      ],
+    });
+
+    expect(evidence.event_type).toBe("evidence.refs.created");
+    expect(business.event_type).toBe("business.refs.resolved");
+    expect(business.causation_event_id).toBe(evidence.event_id);
+    expect(business.payload.business_refs).toEqual([
+      expect.objectContaining({ ref_id: "object:material:M-1001", ref_type: "object" }),
+    ]);
+  });
+
+  it("records an unresolved business resolver outcome without inventing a ref", () => {
+    const { value } = session();
+    const interaction = value.startInteraction({
+      operationName: "agent.run",
+      intentHash: `sha256:${"1".repeat(64)}`,
+      mode: "task",
+      agentId: "agent_1",
+    });
+    const data = value.observeOperation("data.query.observed", {
+      operationName: "data.query",
+      causationEventId: interaction.event_id,
+      payload: {
+        query_hash: `sha256:${"2".repeat(64)}`,
+        query_type: "aggregate",
+        row_count: 1,
+      },
+    });
+    value.createClaim({
+      operationName: "agent.claim.create",
+      causationEventId: data.event_id,
+      claimId: "claim_1",
+      claimType: "finding",
+      claimHash: `sha256:${"3".repeat(64)}`,
+      sourceEventIds: [data.event_id],
+      operationIds: [data.operation_id as string],
+    });
+
+    const unresolved = value.resolveBusinessRefs({
+      operationName: "agent.business.resolve",
+      claimId: "claim_1",
+      resolverStatus: "unresolved",
+      refs: [],
+    });
+
+    expect(unresolved.payload).toMatchObject({
+      resolver_status: "unresolved",
+      business_refs: [],
+    });
+  });
+
+  it("keeps queued event content immutable after returning it to the caller", () => {
+    const { value } = session();
+    const event = value.startInteraction({
+      operationName: "agent.run",
+      intentHash: `sha256:${"1".repeat(64)}`,
+      mode: "task",
+      agentId: "agent_1",
+    });
+
+    event.payload.mode = "background";
+
+    expect(value.pendingEvents()[0]?.payload.mode).toBe("task");
+  });
+
+  it("rejects action recommendations for a claim outside the session", () => {
+    const { value } = session();
+    expect(() =>
+      value.recommendAction({
+        operationName: "action.recommend",
+        claimId: "claim_missing",
+        actionType: "create_forecast_monitor",
+        targetRefs: ["object:material:M-1001"],
+        reasonHash: `sha256:${"4".repeat(64)}`,
+      }),
+    ).toThrow(/claim_missing/);
+  });
+
+  it("keeps stable queued events when emit fails so flush can retry", async () => {
+    const emit = vi.fn().mockRejectedValueOnce(new Error("offline")).mockResolvedValueOnce({});
+    const { value } = session({ emit });
+    value.startInteraction({
+      operationName: "agent.run",
+      intentHash: `sha256:${"1".repeat(64)}`,
+      mode: "task",
+      agentId: "agent_1",
+    });
+
+    await expect(value.flush()).rejects.toThrow("offline");
+    const eventId = value.pendingEvents()[0]?.event_id;
+    await value.flush();
+
+    expect(emit).toHaveBeenCalledTimes(2);
+    expect(emit.mock.calls[0]?.[0].events[0].event_id).toBe(eventId);
+    expect(emit.mock.calls[1]?.[0].events[0].event_id).toBe(eventId);
+  });
+
+  it("serializes concurrent flushes without resending or dropping queued events", async () => {
+    let releaseFirst: (() => void) | undefined;
+    const firstPending = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const batches: EvidenceIngestRequest[] = [];
+    const emit = vi.fn(async (body: EvidenceIngestRequest) => {
+      batches.push(body);
+      if (batches.length === 1) await firstPending;
+      return {} as EvidenceIngestResponse;
+    });
+    const { value } = session({ emit });
+    value.startInteraction({
+      operationName: "agent.run.first",
+      intentHash: `sha256:${"1".repeat(64)}`,
+      mode: "task",
+      agentId: "agent_1",
+    });
+
+    const firstFlush = value.flush();
+    value.startInteraction({
+      operationName: "agent.run.second",
+      intentHash: `sha256:${"2".repeat(64)}`,
+      mode: "task",
+      agentId: "agent_1",
+    });
+    const secondFlush = value.flush();
+
+    await Promise.resolve();
+    expect(emit).toHaveBeenCalledTimes(1);
+    releaseFirst?.();
+    await Promise.all([firstFlush, secondFlush]);
+
+    expect(batches.map((batch) => batch.events.length)).toEqual([1, 1]);
+    expect(batches[0]?.events[0]?.event_id).not.toBe(batches[1]?.events[0]?.event_id);
+    expect(value.pendingEvents()).toHaveLength(0);
+  });
+
+  it("enforces the action lifecycle before submission", () => {
+    const { value } = session();
+    const interaction = value.startInteraction({
+      operationName: "agent.run",
+      intentHash: `sha256:${"1".repeat(64)}`,
+      mode: "task",
+      agentId: "agent_1",
+    });
+    const data = value.observeOperation("data.query.observed", {
+      operationName: "data.query",
+      causationEventId: interaction.event_id,
+      payload: {
+        query_hash: `sha256:${"2".repeat(64)}`,
+        query_type: "aggregate",
+        row_count: 1,
+      },
+    });
+    value.createClaim({
+      operationName: "agent.claim.create",
+      causationEventId: data.event_id,
+      claimId: "claim_1",
+      claimType: "recommendation",
+      claimHash: `sha256:${"3".repeat(64)}`,
+      sourceEventIds: [data.event_id],
+      operationIds: [data.operation_id as string],
+    });
+    const action = value.recommendAction({
+      operationName: "action.recommend",
+      claimId: "claim_1",
+      actionType: "create_forecast_monitor",
+      targetRefs: ["object:material:M-1001"],
+      reasonHash: `sha256:${"4".repeat(64)}`,
+    });
+
+    expect(() =>
+      value.executeAction(action, { status: "ok", invocationRef: "tool:monitor" }),
+    ).toThrow(/approval/i);
+
+    value.requestActionApproval(action, { policyRef: "policy:e2e" });
+    value.approveAction(action, {
+      actorRef: "account:account_1",
+      policyDecisionRef: "decision:allow",
+    });
+    value.executeAction(action, { status: "ok", invocationRef: "tool:monitor" });
+    value.recordActionResult(action, {
+      status: "created",
+      resultHash: `sha256:${"5".repeat(64)}`,
+      taskRef: "monitor-task:1",
+    });
+
+    expect(
+      value
+        .pendingEvents()
+        .slice(-5)
+        .map((event) => event.event_type),
+    ).toEqual([
+      "action.recommended",
+      "action.approval_requested",
+      "action.approved",
+      "action.executed",
+      "action.result_recorded",
+    ]);
+  });
+
+  it("does not trust caller mutation of an action handle", () => {
+    const { value } = session();
+    const interaction = value.startInteraction({
+      operationName: "agent.run",
+      intentHash: `sha256:${"1".repeat(64)}`,
+      mode: "task",
+      agentId: "agent_1",
+    });
+    const data = value.observeOperation("data.query.observed", {
+      operationName: "data.query",
+      causationEventId: interaction.event_id,
+      payload: {
+        query_hash: `sha256:${"2".repeat(64)}`,
+        query_type: "aggregate",
+        row_count: 1,
+      },
+    });
+    value.createClaim({
+      operationName: "agent.claim.create",
+      causationEventId: data.event_id,
+      claimId: "claim_1",
+      claimType: "recommendation",
+      claimHash: `sha256:${"3".repeat(64)}`,
+      sourceEventIds: [data.event_id],
+      operationIds: [data.operation_id as string],
+    });
+    const action = value.recommendAction({
+      operationName: "action.recommend",
+      claimId: "claim_1",
+      actionType: "create_forecast_monitor",
+      targetRefs: ["object:material:M-1001"],
+      reasonHash: `sha256:${"4".repeat(64)}`,
+    });
+
+    expect(Reflect.set(action, "state", "approved")).toBe(false);
+
+    expect(() =>
+      value.executeAction(action, { status: "ok", invocationRef: "tool:monitor" }),
+    ).toThrow(/approval/i);
+  });
+});

--- a/test/unit/trace.test.ts
+++ b/test/unit/trace.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  emitEvidenceArtifact,
   emitEvidenceEvents,
   getBusinessGraph,
+  getEvidenceArtifact,
   getEvidenceChain,
+  getRequestSummary,
+  getRequestTraces,
   getSnapshotPreview,
   getSpansByConversation,
   getTraceGraph,
+  listRequestSummaries,
   traceSearch,
 } from "../../src/api/trace.js";
 import { trace } from "../../src/resources/trace.js";
@@ -97,6 +102,101 @@ describe("emitEvidenceEvents", () => {
     expect(c[1].method).toBe("POST");
     expect(JSON.parse(c[1].body as string).events[0].event_type).toBe("claim.created");
     expect(result.accepted_event_count).toBe(1);
+  });
+});
+
+describe("BKN Trace 2.2 business runs and artifacts", () => {
+  it("writes an artifact and reads it back through authorized endpoints", async () => {
+    const artifact = {
+      artifact_id: "art_question_001",
+      artifact_type: "question" as const,
+      "bkn.request.id": "req_business_001",
+      trace_id: "11111111111111111111111111111111",
+      content_type: "application/json",
+      schema_version: "2.2.0" as const,
+      observed_at: "2026-07-27T09:00:00Z",
+      content_hash: `sha256:${"1".repeat(64)}`,
+      content: "客户 A 的风险为什么上升？",
+      business_domain: "customer-risk",
+      "bkn.account.id": "account_1",
+      "bkn.account.type": "app",
+    };
+    const f = mockFetchSeq([{ artifact_id: artifact.artifact_id, created: true }, artifact]);
+
+    await emitEvidenceArtifact(ctx, artifact);
+    const loaded = await getEvidenceArtifact(ctx, artifact.artifact_id);
+
+    const [writeCall, readCall] = calls(f);
+    if (!writeCall || !readCall) throw new Error("missing calls");
+    expect(new URL(writeCall[0]).pathname).toBe("/api/agent-observability/v1/evidence/artifacts");
+    expect(writeCall[1].method).toBe("POST");
+    expect(new URL(readCall[0]).pathname).toBe(
+      "/api/agent-observability/v1/evidence/artifacts/art_question_001",
+    );
+    expect(loaded.content).toBe("客户 A 的风险为什么上升？");
+  });
+
+  it("lists business requests and follows request-to-trace links", async () => {
+    const f = mockFetchSeq([
+      {
+        entries: [
+          {
+            request_id: "req_business_001",
+            status: "completed",
+            evidence_completeness: "complete",
+            action_summary: {},
+            trace_count: 1,
+          },
+        ],
+        total: 1,
+      },
+      {
+        request_id: "req_business_001",
+        status: "completed",
+        evidence_completeness: "complete",
+        action_summary: {},
+        trace_count: 1,
+      },
+      {
+        entries: [
+          {
+            trace_id: "trace_001",
+            request_id: "req_business_001",
+            status: "completed",
+            span_count: 7,
+          },
+        ],
+        total: 1,
+      },
+    ]);
+
+    const page = await listRequestSummaries(ctx, {
+      evidenceCompleteness: "complete",
+      keyword: "客户 A",
+      knowledgeNetwork: "customer-risk-network",
+      limit: 30,
+      status: "completed",
+    });
+    const summary = await getRequestSummary(ctx, "req_business_001");
+    const traces = await getRequestTraces(ctx, "req_business_001", { limit: 30 });
+
+    const [listCall, summaryCall, tracesCall] = calls(f);
+    if (!listCall || !summaryCall || !tracesCall) throw new Error("missing calls");
+    const listURL = new URL(listCall[0]);
+    expect(listURL.pathname).toBe("/api/agent-observability/v1/requests");
+    expect(listURL.searchParams.get("keyword")).toBe("客户 A");
+    expect(listURL.searchParams.get("status")).toBe("completed");
+    expect(listURL.searchParams.get("knowledge_network")).toBe("customer-risk-network");
+    expect(listURL.searchParams.get("evidence_completeness")).toBe("complete");
+    expect(new URL(summaryCall[0]).pathname).toBe(
+      "/api/agent-observability/v1/requests/req_business_001",
+    );
+    expect(new URL(tracesCall[0]).pathname).toBe(
+      "/api/agent-observability/v1/requests/req_business_001/traces",
+    );
+    expect(page.entries[0]?.request_id).toBe("req_business_001");
+    expect(summary.request_id).toBe("req_business_001");
+    expect(traces.entries[0]?.request_id).toBe("req_business_001");
   });
 });
 

--- a/test/unit/trace.test.ts
+++ b/test/unit/trace.test.ts
@@ -135,7 +135,9 @@ describe("BKN Trace 2.2 business runs and artifacts", () => {
     expect(new Headers(writeCall[1].headers).get("x-bkn-trace-ingest-token")).toBe(
       "producer-ingest-token",
     );
+    expect(writeCall[1].redirect).toBe("manual");
     expect(new Headers(readCall[1].headers).get("x-bkn-trace-ingest-token")).toBeNull();
+    expect(readCall[1].redirect).toBeUndefined();
   });
 
   it("writes an artifact and reads it back through authorized endpoints", async () => {

--- a/test/unit/trace.test.ts
+++ b/test/unit/trace.test.ts
@@ -106,6 +106,38 @@ describe("emitEvidenceEvents", () => {
 });
 
 describe("BKN Trace 2.2 business runs and artifacts", () => {
+  it("sends the dedicated ingest token only to evidence write endpoints", async () => {
+    const ingestCtx = {
+      ...ctx,
+      evidenceIngestToken: "producer-ingest-token",
+    } as RequestContext;
+    const artifact = {
+      artifact_id: "art_auth_001",
+      artifact_type: "question" as const,
+      "bkn.request.id": "req_auth_001",
+      trace_id: "11111111111111111111111111111111",
+      content_type: "application/json",
+      schema_version: "2.2.0" as const,
+      observed_at: "2026-07-27T09:00:00Z",
+      content_hash: `sha256:${"1".repeat(64)}`,
+      content: "test",
+      business_domain: "bd_public",
+      "bkn.account.id": "account_1",
+      "bkn.account.type": "app",
+    };
+    const f = mockFetchSeq([{ artifact_id: artifact.artifact_id, created: true }, artifact]);
+
+    await emitEvidenceArtifact(ingestCtx, artifact);
+    await getEvidenceArtifact(ingestCtx, artifact.artifact_id);
+
+    const [writeCall, readCall] = calls(f);
+    if (!writeCall || !readCall) throw new Error("missing calls");
+    expect(new Headers(writeCall[1].headers).get("x-bkn-trace-ingest-token")).toBe(
+      "producer-ingest-token",
+    );
+    expect(new Headers(readCall[1].headers).get("x-bkn-trace-ingest-token")).toBeNull();
+  });
+
   it("writes an artifact and reads it back through authorized endpoints", async () => {
     const artifact = {
       artifact_id: "art_question_001",
@@ -197,6 +229,59 @@ describe("BKN Trace 2.2 business runs and artifacts", () => {
     expect(page.entries[0]?.request_id).toBe("req_business_001");
     expect(summary.request_id).toBe("req_business_001");
     expect(traces.entries[0]?.request_id).toBe("req_business_001");
+  });
+
+  it("reads an interaction aggregate and filters requests by lifecycle ids", async () => {
+    const f = mockFetchSeq([
+      {
+        entries: [],
+        total: 0,
+      },
+      {
+        interaction_id: "interaction_june_forecast",
+        conversation_id: "conversation_supply_chain",
+        status: "completed",
+        requests: [
+          {
+            request_id: "req_schema",
+            conversation_id: "conversation_supply_chain",
+            interaction_id: "interaction_june_forecast",
+            status: "completed",
+            evidence_completeness: "complete",
+            action_summary: {},
+            trace_count: 1,
+          },
+        ],
+        traces: [
+          {
+            trace_id: "trace_schema",
+            request_id: "req_schema",
+            conversation_id: "conversation_supply_chain",
+            interaction_id: "interaction_june_forecast",
+            status: "completed",
+            span_count: 4,
+          },
+        ],
+      },
+    ]);
+
+    await listRequestSummaries(ctx, {
+      conversationId: "conversation_supply_chain",
+      interactionId: "interaction_june_forecast",
+    });
+    const interaction = await trace(ctx).interactions.get("interaction_june_forecast");
+
+    const [listCall, interactionCall] = calls(f);
+    if (!listCall || !interactionCall) throw new Error("missing calls");
+    const listURL = new URL(listCall[0]);
+    expect(listURL.searchParams.get("conversation_id")).toBe("conversation_supply_chain");
+    expect(listURL.searchParams.get("interaction_id")).toBe("interaction_june_forecast");
+    expect(new URL(interactionCall[0]).pathname).toBe(
+      "/api/agent-observability/v1/interactions/interaction_june_forecast",
+    );
+    expect(interaction.conversation_id).toBe("conversation_supply_chain");
+    expect(interaction.requests[0]?.interaction_id).toBe("interaction_june_forecast");
+    expect(interaction.traces[0]?.conversation_id).toBe("conversation_supply_chain");
   });
 });
 

--- a/test/unit/trace.test.ts
+++ b/test/unit/trace.test.ts
@@ -8,6 +8,7 @@ import {
   getTraceGraph,
   traceSearch,
 } from "../../src/api/trace.js";
+import { trace } from "../../src/resources/trace.js";
 import type { RequestContext } from "../../src/types.js";
 
 const ctx: RequestContext = {
@@ -96,6 +97,50 @@ describe("emitEvidenceEvents", () => {
     expect(c[1].method).toBe("POST");
     expect(JSON.parse(c[1].body as string).events[0].event_type).toBe("claim.created");
     expect(result.accepted_event_count).toBe(1);
+  });
+});
+
+describe("trace resource session", () => {
+  it("binds TraceSession.flush to the evidence ingestion endpoint", async () => {
+    const f = mockFetchSeq([
+      {
+        trace_id: "8c0d0000000000000000000000000001",
+        "bkn.request.id": "req_session_resource_001",
+        "bkn.trace.schema.version": "2.1.0",
+        accepted_event_count: 1,
+        claim_count: 0,
+        evidence_ref_count: 0,
+        business_ref_count: 0,
+      },
+    ]);
+    const session = trace(ctx).createSession({
+      trace: {
+        trace_id: "8c0d0000000000000000000000000001",
+        traceparent: "00-8c0d0000000000000000000000000001-1f12000000000001-01",
+        "bkn.request.id": "req_session_resource_001",
+        business_domain: "bd_test",
+        "bkn.account.id": "acct_demo",
+        "bkn.account.type": "app",
+      },
+      producerModule: "third-party-agent",
+      spanId: "1f12000000000001",
+      interactionId: "interaction_1",
+      idFactory: () => "event_1",
+      now: () => "2026-07-25T12:00:00.000Z",
+    });
+    session.startInteraction({
+      operationName: "agent.run",
+      intentHash: `sha256:${"1".repeat(64)}`,
+      mode: "task",
+      appRef: "app:sdk-test",
+    });
+
+    await session.flush();
+
+    const c = calls(f)[0];
+    if (!c) throw new Error("no call");
+    expect(new URL(c[0]).pathname).toBe("/api/agent-observability/v1/evidence/events");
+    expect(JSON.parse(c[1].body as string)["bkn.trace.schema.version"]).toBe("2.1.0");
   });
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "noEmit": true,
     "outDir": "dist"
   },
-  "include": ["src", "test"]
+  "include": ["src", "test", "examples"]
 }


### PR DESCRIPTION
## 变更
- Context Loader MCP 复用统一 Trace header builder
- 补齐 replay-stable operation/attempt/observed-at 传播
- 支持专用 evidence ingest token，且仅发送到证据写接口
- 增加 Interaction 查询 SDK 与真实 HD 供应链 E2E

## 真实验收
- 问题：6月份有哪些需求预测单，列出来，需求总量是多少？
- 结果：63 条，需求总量 11594
- 同一 Interaction 聚合 3 个 request、3 个 trace，状态 completed

## 验证
- npm test：257 passed，1 live skipped
- npm run lint
- npm run test:e2e:trace-business

## 依赖
- Foundry 终态汇总 PR 合并后，E2E 的 completed 断言生效。