### PR TITLE
fix(vega): align SDK build task contract

### DIFF
--- a/docs/product-specs/vega.md
+++ b/docs/product-specs/vega.md
@@ -14,39 +14,35 @@ Browse the Vega catalog — data sources, views, atomic views, connector types �
 ## Index build (BuildTask)
 
 Building a resource's index is a **BuildTask** — `POST /build-tasks` with a
-`CreateBuildTaskRequest`. The config lives **on the task** (persisted on the
-BuildTask), not pre-set on the catalog/resource. The task creates the index then
-writes `index_name` back onto the resource.
+`CreateBuildTaskRequest`. Index configuration belongs to the Resource: the CLI
+first updates it through `resource.configureIndex`, then creates a task that
+snapshots that configuration.
 
-`CreateBuildTaskRequest` (= the build params, all first-class CLI flags — no raw `call` needed):
+`CreateBuildTaskRequest`:
 
 | Field | Required | CLI flag | Meaning |
 | ----- | -------- | -------- | ------- |
 | `resource_id` | ✅ | `<resource-id>` (positional) | Which resource to build |
 | `mode` | ✅ | `--mode batch\|streaming` | Build mode |
-| `embedding_fields` | — | `--embedding-fields a,b` | Fields to vectorize |
-| `build_key_fields` | — | `--build-key-fields k` | Key fields (batch: time field; streaming: unique row id) |
-| `embedding_model` | — | `--embedding-model <id>` | Embedding model (default if omitted) |
-| `model_dimensions` | — | `--model-dimensions <n>` | Vector dimensions |
+| `execute_type` | — | `--execute-type incremental\|full` | Batch execution type; defaults to `full` |
 
 CLI:
 
-- `openbkn vega dataset build <resource-id> --mode batch [--embedding-fields …] [--build-key-fields …] [--embedding-model …] [--model-dimensions …] [--wait] [--timeout <s>]` — create a BuildTask.
-- `openbkn vega dataset build-status <resource-id> <task-id>` — progress: `state` + `SyncedCount` / `VectorizedCount`.
-
-**Reasonable-state fix:** legacy only forwarded `--mode` and forced a raw `call /build-tasks` for everything else. Here the whole `CreateBuildTaskRequest` is exposed as flags.
+- `openbkn vega dataset build <resource-id> --mode batch [--embedding-fields …] [--build-key-fields …] [--embedding-model …] [--fulltext-fields …] [--execute-type incremental|full] [--wait] [--timeout <s>]` — optional index flags update the Resource, then create a BuildTask.
+- `openbkn vega dataset build-status <task-id>` — progress: `status` + `synced_count` / `vectorized_count`.
+- `openbkn vega dataset build-start <task-id> [--reset]` — `--reset` restarts only a full task; it is ignored for incremental tasks.
 
 **Field searchability is separate** — declared on the resource property schema via
-`feature_type` (`keyword` | `fulltext` | `vector`). The BuildTask only decides
-*what to embed / how*; whether a field is searchable at all is a schema concern.
+`feature_type` (`keyword` | `fulltext` | `vector`). The Resource configuration
+determines what is indexed; the BuildTask uses its snapshot.
 
 ## SDK touchpoints
 
-- `resources/vega.ts` over `api/vega.ts`. BuildTask create/status map to `POST /build-tasks` and `GET /build-tasks/{id}` (resource gets `index_name` filled back).
+- `resources/vega.ts` over `api/vega.ts`. BuildTask create/status map to `POST /build-tasks` and `GET /build-tasks/{id}`. The create response contains only `id`; obtain task state and its persisted `execute_type` through the status endpoint.
 
 ## Edge cases
 
 - Preview is bounded (limit 50); never stream full datasets.
 - Health checks summarize per-resource status; a partial failure is reported per resource, not as a single opaque error.
 - Build is **not** freely re-runnable — it kicks a task and returns a `task-id`; never auto-retry, surface the id for `build-status` polling.
-- `--mode batch` expects a time `build-key-field`; `streaming` expects a unique row id — validate at the boundary.
+- `execute_type` is batch-only. Streaming tasks must not send it. A failed batch task resumes by default; use `--reset` only when a full task must rebuild from the beginning.

--- a/skills/openbkn/references/vega.md
+++ b/skills/openbkn/references/vega.md
@@ -9,7 +9,7 @@
 | `sql --query "<sql>"` / `sql -d <json>` | Run SQL or OpenSearch DSL directly against a data source. SQL uses a `{{<resource-id>}}` table placeholder; DSL identifies its resource with top-level `resource_id`. See [§ vega sql](#vega-sql--run-sql--dsl-against-a-data-source). |
 | `resource …` | Vega-backend resources (mirror of top-level `resource`). |
 | `dataset build <resource-id> --mode batch\|streaming [--embedding-fields a,b] [--build-key-fields k] [--embedding-model <id>] [--fulltext-fields a,b] [--fulltext-analyzer <n>] [--execute-type incremental\|full] [--wait] [--timeout <s>]` | Create an index BuildTask. **Index build lives on the resource (one resource = one table); there is no KN-level build.** `batch` requires `--build-key-fields` (else `400 build_key_fields is required for batch mode`). |
-| `dataset build-status <resource-id> <task-id>` | BuildTask state + progress. |
+| `dataset build-status <task-id>` | BuildTask status + progress. |
 
 ## `vega sql` — run SQL / DSL against a data source
 

--- a/src/api/vega.ts
+++ b/src/api/vega.ts
@@ -16,12 +16,33 @@ const VEGA_BASE = "/api/vega-backend/v1";
 export const BuildMode = z.enum(["batch", "streaming"]);
 export type BuildMode = z.infer<typeof BuildMode>;
 
+export const BuildTaskExecuteType = z.enum(["incremental", "full"]);
+export type BuildTaskExecuteType = z.infer<typeof BuildTaskExecuteType>;
+
+export const BuildTaskStatus = z.enum([
+  "init",
+  "running",
+  "stopping",
+  "stopped",
+  "completed",
+  "failed",
+]);
+export type BuildTaskStatus = z.infer<typeof BuildTaskStatus>;
+
 /** POST /build-tasks body. */
-export const CreateBuildTaskRequest = z.object({
-  resource_id: z.string().min(1),
-  mode: BuildMode,
-  execute_type: z.enum(["incremental", "full"]).optional(),
-});
+export const CreateBuildTaskRequest = z.discriminatedUnion("mode", [
+  z.object({
+    resource_id: z.string().min(1),
+    mode: z.literal("batch"),
+    execute_type: BuildTaskExecuteType.optional(),
+  }),
+  z.object({
+    resource_id: z.string().min(1),
+    mode: z.literal("streaming"),
+    // Streaming tasks do not have an execution type.
+    execute_type: z.never().optional(),
+  }),
+]);
 export type CreateBuildTaskRequest = z.infer<typeof CreateBuildTaskRequest>;
 
 // Lenient: create vs list vs status responses carry different subsets — `status`
@@ -31,13 +52,14 @@ export const BuildTask = z
     id: z.string(),
     resource_id: z.string().optional(),
     mode: BuildMode.optional(),
-    status: z.string().optional(),
+    status: BuildTaskStatus.optional(),
     state: z.string().optional(),
     total_count: z.number().optional(),
     synced_count: z.number().optional(),
     vectorized_count: z.number().optional(),
     index_config: z.unknown().optional(),
     catalog_id: z.string().optional(),
+    execute_type: BuildTaskExecuteType.optional(),
     index_health: z
       .object({
         embedding: z.string(),
@@ -70,10 +92,10 @@ export interface ListBuildTasksOptions {
   offset?: number;
   resourceId?: string;
   catalogId?: string;
-  status?: string | string[];
+  status?: BuildTaskStatus | BuildTaskStatus[];
   active?: boolean;
   mode?: BuildMode;
-  orderBy?: "default" | "created_at" | "updated_at" | "status" | "mode";
+  orderBy?: "default" | "created_at" | "updated_at";
   order?: "asc" | "desc";
 }
 

--- a/src/commands/vega.ts
+++ b/src/commands/vega.ts
@@ -377,9 +377,9 @@ export function vegaCommand(): Command {
     });
 
   dataset
-    .command("build-status <resource-id> <task-id>")
+    .command("build-status <task-id>")
     .description("Show a BuildTask's state and progress")
-    .action(async (_resourceId: string, taskId: string, _opts, cmd: Command) => {
+    .action(async (taskId: string, _opts, cmd: Command) => {
       const task = await clientFrom(cmd).vega.buildStatus(taskId);
       printJson(task, outputOptions(cmd));
     });
@@ -394,7 +394,7 @@ export function vegaCommand(): Command {
     .option("--status <status>", "comma-separated statuses")
     .option("--active", "only running/init tasks")
     .option("--mode <mode>", "filter by mode: batch | streaming")
-    .option("--order-by <field>", "default | created_at | updated_at | status | mode")
+    .option("--order-by <field>", "default | created_at | updated_at")
     .option("--order <dir>", "asc | desc")
     .action(async (opts, cmd: Command) => {
       printJson(
@@ -416,7 +416,7 @@ export function vegaCommand(): Command {
   dataset
     .command("build-start <task-id>")
     .description("Start a BuildTask")
-    .option("--reset", "restart from the beginning")
+    .option("--reset", "restart a full task from the beginning (ignored for incremental tasks)")
     .action(async (taskId: string, opts, cmd: Command) => {
       printJson(
         await clientFrom(cmd).vega.startBuildTask(taskId, { reset: opts.reset }),

--- a/test/unit/vega.test.ts
+++ b/test/unit/vega.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  CreateBuildTaskRequest,
   catalogHealthStatus,
   createBuildTask,
   createCatalog,
   deleteBuildTasks,
+  getBuildTask,
   getCatalog,
   listBuildTasks,
   listCatalogResources,
@@ -117,11 +119,12 @@ describe("vega uses the vega-backend base path", () => {
 
 describe("createBuildTask", () => {
   it("POSTs to /build-tasks under vega-backend", async () => {
-    const f = mockFetch({ id: "t-1", resource_id: "r-1", mode: "batch" });
-    await createBuildTask(ctx, { resource_id: "r-1", mode: "batch" });
+    const f = mockFetch({ id: "t-1" });
+    const task = await createBuildTask(ctx, { resource_id: "r-1", mode: "batch" });
     const call = firstCall(f);
     expect(new URL(call[0]).pathname).toBe("/api/vega-backend/v1/build-tasks");
     expect(call[1].method).toBe("POST");
+    expect(task).toEqual({ id: "t-1" });
   });
 
   it("sends execute_type but no resource index fields in the task body", async () => {
@@ -135,6 +138,16 @@ describe("createBuildTask", () => {
     expect(body).toEqual({ resource_id: "r-1", mode: "batch", execute_type: "full" });
   });
 
+  it("rejects execute_type for streaming tasks before making a request", () => {
+    expect(
+      CreateBuildTaskRequest.safeParse({
+        resource_id: "r-1",
+        mode: "streaming",
+        execute_type: "full",
+      }).success,
+    ).toBe(false);
+  });
+
   it("lists build tasks with server-side filters", async () => {
     const f = mockFetch({ entries: [] });
     await listBuildTasks(ctx, {
@@ -143,7 +156,7 @@ describe("createBuildTask", () => {
       status: ["running", "init"],
       active: true,
       mode: "batch",
-      orderBy: "status",
+      orderBy: "updated_at",
       order: "asc",
       limit: 5,
       offset: 10,
@@ -155,10 +168,18 @@ describe("createBuildTask", () => {
     expect(u.searchParams.get("status")).toBe("running,init");
     expect(u.searchParams.get("active")).toBe("true");
     expect(u.searchParams.get("mode")).toBe("batch");
-    expect(u.searchParams.get("order_by")).toBe("status");
+    expect(u.searchParams.get("order_by")).toBe("updated_at");
     expect(u.searchParams.get("order")).toBe("asc");
     expect(u.searchParams.get("limit")).toBe("5");
     expect(u.searchParams.get("offset")).toBe("10");
+  });
+
+  it("exposes the persisted batch execute_type on task responses", async () => {
+    mockFetch({ id: "t-1", mode: "batch", execute_type: "incremental" });
+    await expect(getBuildTask(ctx, "t-1")).resolves.toMatchObject({
+      id: "t-1",
+      execute_type: "incremental",
+    });
   });
 
   it("starts, stops, and deletes build tasks", async () => {


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Align BuildTask request and response types with vega-backend, including persisted `execute_type` and streaming validation.
- [x] Restrict build-task sorting and clarify reset semantics in the CLI.
- [x] Update Vega product and skill reference documentation.

---

## Why

- Related Issue: [openbkn-ai/bkn-foundry#501](https://github.com/openbkn-ai/bkn-foundry/issues/501)
- Related Feature: Persisted batch build execute type
- Background: The SDK exposed stale build-task options and did not type the backend's persisted execution type.

---

## How

- Key implementation points: Added typed execution/status enums, rejects `execute_type` for streaming tasks, and adds response and request regression tests.
- Breaking changes (API, config, database, etc.): `openbkn vega dataset build-status` now accepts only `<task-id>`; the unused `<resource-id>` argument was removed.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `npm run ci` — 267 passed, 1 live test skipped.

---

## Risk & Rollback

- Potential risks: Consumers using the obsolete two-argument `build-status` CLI form must remove the resource ID.
- Rollback plan: Revert commit `2d77995`.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: CreateBuildTask remains compatible with the backend's `{id}`-only response.