### PR TITLE
feat(trace): 补齐第三方 Agent 受管交互与溯源接口

### DIFF
--- a/src/api/context-loader.ts
+++ b/src/api/context-loader.ts
@@ -14,6 +14,7 @@ import { authFetch } from "./auth-fetch.js";
 import { buildHeaders } from "./headers.js";
 import { request } from "./http.js";
 import { tlsFetch } from "./tls.js";
+import type { OperationReceipt } from "./trace-lifecycle.js";
 
 const MCP_PATH = "/api/agent-retrieval/v1/mcp";
 const PROTOCOL = "2024-11-05";
@@ -111,21 +112,44 @@ async function ensureSession(ctx: RequestContext, knId: string): Promise<string>
   return sessionId;
 }
 
-/** Unwrap a JSON-RPC result, decoding the MCP content[].text JSON payload. */
-function unwrap(parsed: unknown): unknown {
+export interface ManagedToolResult<T = unknown> {
+  value: T;
+  receipt: OperationReceipt;
+}
+
+interface UnwrappedToolResult {
+  value: unknown;
+  receipt?: OperationReceipt;
+}
+
+/** Unwrap a JSON-RPC result without discarding its trusted lifecycle receipt. */
+function unwrapToolResult(parsed: unknown): UnwrappedToolResult {
   const rpc = parsed as { result?: unknown; error?: { message: string } };
   if (rpc.error) throw new Error(`Context-loader error: ${rpc.error.message}`);
   const result = rpc.result as Record<string, unknown> | undefined;
-  if (result === undefined) return parsed;
+  if (result === undefined) return { value: parsed };
+  const structuredContent = result.structuredContent;
+  const receipt = (structuredContent as { bkn_receipt?: OperationReceipt } | undefined)
+    ?.bkn_receipt;
   const content = result.content;
+  if (result.isError === true) {
+    const message =
+      Array.isArray(content) && content[0] && typeof content[0].text === "string"
+        ? content[0].text
+        : "tool call failed";
+    throw new Error(`Context-loader error: ${message}`);
+  }
   if (Array.isArray(content) && content[0] && typeof content[0].text === "string") {
     try {
-      return JSON.parse(content[0].text);
+      return { value: JSON.parse(content[0].text), receipt };
     } catch {
-      return { raw: content[0].text };
+      if (structuredContent !== undefined) {
+        return { value: structuredContent, receipt };
+      }
+      return { value: { raw: content[0].text }, receipt };
     }
   }
-  return result;
+  return { value: result, receipt };
 }
 
 /** Call any MCP tool by name. */
@@ -143,7 +167,29 @@ export async function callTool(
     params: { name, arguments: args },
     id: nextId(),
   });
-  return unwrap(parseBody(text));
+  return unwrapToolResult(parseBody(text)).value;
+}
+
+/** Call a lifecycle-managed MCP tool and retain the trusted operation receipt. */
+export async function callManagedTool<T = unknown>(
+  ctx: RequestContext,
+  knId: string,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ManagedToolResult<T>> {
+  const operationCtx = operationContext(ctx);
+  const sessionId = await ensureSession(operationCtx, knId);
+  const { text } = await post(operationCtx, knId, sessionId, {
+    jsonrpc: "2.0",
+    method: "tools/call",
+    params: { name, arguments: args },
+    id: nextId(),
+  });
+  const result = unwrapToolResult(parseBody(text));
+  if (!result.receipt) {
+    throw new Error("Context-loader managed tool response did not include bkn_receipt");
+  }
+  return { value: result.value as T, receipt: result.receipt };
 }
 
 /** Call a generic MCP method (tools/list, resources/list, ...). */

--- a/src/api/trace.ts
+++ b/src/api/trace.ts
@@ -13,8 +13,9 @@ import { request } from "./http.js";
 const SEARCH = "/api/agent-observability/v1/traces/_search";
 const EVIDENCE_EVENTS = "/api/agent-observability/v1/evidence/events";
 const EVIDENCE_ARTIFACTS = "/api/agent-observability/v1/evidence/artifacts";
-const REQUESTS = "/api/agent-observability/v1/requests";
-const INTERACTIONS = "/api/agent-observability/v1/interactions";
+const BUSINESS_PROVENANCE = "/api/agent-observability/v1/business-provenance";
+const REQUESTS = `${BUSINESS_PROVENANCE}/requests`;
+const INTERACTIONS = `${BUSINESS_PROVENANCE}/interactions`;
 const TRACES = "/api/agent-observability/v1/traces";
 
 interface SearchHits {

--- a/src/resources/context-loader.ts
+++ b/src/resources/context-loader.ts
@@ -5,6 +5,7 @@
 import {
   type DetailLevel,
   type SearchSchemaOptions,
+  callManagedTool,
   callMethod,
   callTool,
   findSkills,
@@ -42,6 +43,8 @@ export function context(ctx: RequestContext) {
     tools: (knId: string) => listTools(ctx, knId),
     toolCall: (knId: string, name: string, args: Record<string, unknown>) =>
       callTool(ctx, knId, name, args),
+    managedToolCall: <T = unknown>(knId: string, name: string, args: Record<string, unknown>) =>
+      callManagedTool<T>(ctx, knId, name, args),
     // Generic MCP method passthrough — covers methods not yet wrapped, so the
     // surface doesn't have to grow every time the server adds one.
     callMethod: (knId: string, method: string, params?: Record<string, unknown>) =>

--- a/test/e2e/bkn-trace-managed-business-interaction.mjs
+++ b/test/e2e/bkn-trace-managed-business-interaction.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+
+import { randomBytes } from "node:crypto";
+import { createClient } from "../../dist/index.js";
+
+const baseUrl = process.env.BKN_BASE_URL ?? "http://localhost";
+const businessDomain = process.env.BKN_BUSINESS_DOMAIN ?? "bd_public";
+const knId = process.env.BKN_KN_ID ?? "supplychain_hd0202";
+const runId = randomBytes(8).toString("hex");
+const client = createClient({ baseUrl, businessDomain });
+
+const conversation = await client.context.toolCall(knId, "bkn_create_conversation", {
+  external_conversation_key: `sdk-supply-chain-${runId}`,
+  idempotency_key: `create-${runId}`,
+});
+assertString(conversation?.conversation_id, "conversation_id");
+
+const juneQuestion = "6月份有哪些需求预测单，列出来，需求总量是多少？";
+const june = await runInteraction({
+  key: "june",
+  question: juneQuestion,
+  start: "2026-06-01",
+  end: "2026-07-01",
+  answerFor: (rows) => {
+    const forecastCount = Number(rows[0]?.forecast_count);
+    const totalDemand = Number(rows[0]?.total_demand);
+    if (forecastCount !== 63 || totalDemand !== 11_594) {
+      throw new Error(
+        `unexpected June forecast result: count=${forecastCount}, total=${totalDemand}`,
+      );
+    }
+    return `6月份共有 ${forecastCount} 条需求预测，需求总量为 ${totalDemand}。`;
+  },
+});
+
+const comparisonQuestion = "7月份有哪些需求预测单，各个产品的预测需求量是多少？相比6月有什么变化？";
+const comparison = await runInteraction({
+  key: "july-comparison",
+  question: comparisonQuestion,
+  start: "2026-06-01",
+  end: "2026-08-01",
+  answerFor: (rows, binding) => {
+    const monthly = aggregateByMonth(rows, binding);
+    if (monthly["2026-06"]?.count !== 63 || monthly["2026-06"]?.total !== 11_594) {
+      throw new Error(`unexpected June comparison baseline: ${JSON.stringify(monthly["2026-06"])}`);
+    }
+    if (monthly["2026-07"]?.count !== 40 || monthly["2026-07"]?.total !== 4_586) {
+      throw new Error(`unexpected July forecast result: ${JSON.stringify(monthly["2026-07"])}`);
+    }
+    const decrease = monthly["2026-06"].total - monthly["2026-07"].total;
+    return `7月份共有 40 条需求预测，需求总量为 4586；相比6月减少 ${decrease}，约下降60%。`;
+  },
+});
+
+const interactions = [june, comparison];
+const operations = interactions.flatMap((item) => item.operations);
+if (interactions.length !== 2 || operations.length < 4) {
+  throw new Error(
+    `invalid provenance hierarchy: interactions=${interactions.length}, operations=${operations.length}`,
+  );
+}
+
+console.log(
+  JSON.stringify(
+    {
+      passed: true,
+      conversation_id: conversation.conversation_id,
+      expected_view_counts: { conversations: 1, interactions: 2, openbkn_calls: operations.length },
+      interactions,
+    },
+    null,
+    2,
+  ),
+);
+
+async function runInteraction({ key, question, start, end, answerFor }) {
+  const interaction = await client.context.toolCall(knId, "bkn_start_interaction", {
+    conversation_id: conversation.conversation_id,
+    idempotency_key: `interaction-${key}-${runId}`,
+    question,
+  });
+  assertString(interaction?.interaction_id, "interaction_id");
+  assertString(interaction?.lease_token, "lease_token");
+
+  const schemaCall = await operationClient().context.managedToolCall(knId, "search_schema", {
+    query: question,
+    response_format: "json",
+    include_columns: true,
+    max_concepts: 20,
+    bkn_context: businessContext(interaction.interaction_id, `${key}-schema-search`),
+  });
+  const binding = extractForecastBinding(schemaCall.value);
+  const dataCall = await operationClient().context.managedToolCall(knId, "run_sql", {
+    sql: buildForecastSql(binding, start, end),
+    response_format: "json",
+    bkn_context: businessContext(interaction.interaction_id, `${key}-forecast-query`),
+  });
+  const rows = extractRows(dataCall.value);
+  if (rows.length === 0) throw new Error(`run_sql returned no rows for ${key}`);
+
+  const answer = answerFor(rows, binding);
+  const receipts = [schemaCall.receipt, dataCall.receipt];
+  const completed = await client.context.toolCall(knId, "bkn_complete_interaction", {
+    interaction_id: interaction.interaction_id,
+    terminal_idempotency_key: `complete-${key}-${runId}`,
+    lease_token: interaction.lease_token,
+    lease_epoch: interaction.lease_epoch,
+    completion_manifest_version: "3.0.0",
+    completion_reason: "answered",
+    answer,
+    expected_operations: receipts.map((receipt) => ({
+      operation_id: receipt.operation_id,
+      required: true,
+    })),
+    expected_receipts: receipts.map((receipt) => ({
+      receipt_id: receipt.receipt_id,
+      required: true,
+    })),
+  });
+  return {
+    interaction_id: interaction.interaction_id,
+    question,
+    answer,
+    execution_status: completed.execution_status,
+    evidence_status: completed.evidence_status,
+    operations: receipts.map((receipt) => ({
+      operation_id: receipt.operation_id,
+      operation_key: receipt.operation_key,
+      tool_name: receipt.tool_name,
+      receipt_id: receipt.receipt_id,
+      trace_id: receipt.trace_id,
+      request_id: receipt.request_id,
+      evidence_durability: receipt.evidence_durability,
+      business_refs: receipt.business_refs,
+    })),
+  };
+}
+
+function operationClient() {
+  return createClient({ baseUrl, businessDomain });
+}
+
+function businessContext(interactionId, operationKey) {
+  return {
+    conversation_id: conversation.conversation_id,
+    interaction_id: interactionId,
+    operation_key: operationKey,
+  };
+}
+
+function extractForecastBinding(value) {
+  const candidates = [];
+  walk(value, (item) => {
+    const properties = item.data_properties ?? item.properties;
+    const source = item.data_source ?? item.data_sources;
+    if (Array.isArray(properties) && source) candidates.push({ item, properties, source });
+  });
+  const selected =
+    candidates.find(
+      ({ item, properties }) =>
+        `${item.id ?? ""} ${item.name ?? ""} ${item.display_name ?? ""} ${item.concept_id ?? ""} ${item.concept_name ?? ""}`.match(
+          /forecast|需求预测/i,
+        ) && hasProperty(properties, ["consensus_demand", "qty", "demand_quantity"]),
+    ) ??
+    candidates.find(
+      ({ properties }) =>
+        hasProperty(properties, ["consensus_demand", "qty", "demand_quantity"]) &&
+        hasProperty(properties, ["month", "startdate", "forecast_month", "bizdate"]),
+    );
+  if (!selected) throw new Error("search_schema did not return the forecast object binding");
+
+  const sources = Array.isArray(selected.source) ? selected.source : [selected.source];
+  const resourceId = sources
+    .map((source) => source?.id ?? source?.resource_id)
+    .find((id) => typeof id === "string" && id);
+  const month = propertyBinding(selected.properties, [
+    "month",
+    "startdate",
+    "forecast_month",
+    "bizdate",
+  ]);
+  const demand = propertyBinding(selected.properties, [
+    "consensus_demand",
+    "qty",
+    "demand_quantity",
+  ]);
+  const product = propertyBinding(selected.properties, ["product_code", "material_number"]);
+  const order = propertyBinding(selected.properties, ["confirmed_order", "billno", "id"]);
+  if (!resourceId) throw new Error("forecast schema binding is missing its data resource");
+  return { resourceId, month, demand, product, order };
+}
+
+function hasProperty(properties, logicalNames) {
+  return properties.some((property) => logicalNames.includes(property.name));
+}
+
+function propertyBinding(properties, logicalNames) {
+  const property = logicalNames
+    .map((logicalName) => properties.find((item) => item.name === logicalName))
+    .find(Boolean);
+  if (!property) throw new Error(`forecast schema is missing one of: ${logicalNames.join(", ")}`);
+  return {
+    logicalName: property.name,
+    column: property.column ?? property.mapped_field ?? property.name,
+  };
+}
+
+function buildForecastSql(binding, start, end) {
+  const columns = [binding.product, binding.order, binding.demand, binding.month].map(
+    ({ column }) => quoteIdentifier(column),
+  );
+  const month = quoteIdentifier(binding.month.column);
+  const demand = quoteIdentifier(binding.demand.column);
+  return [
+    `SELECT ${columns.join(", ")},`,
+    "COUNT(*) OVER () AS forecast_count,",
+    `SUM(CAST(${demand} AS DOUBLE)) OVER () AS total_demand`,
+    `FROM {{.${binding.resourceId}}}`,
+    `WHERE ${month} >= '${start}' AND ${month} < '${end}'`,
+    `ORDER BY ${month}, ${quoteIdentifier(binding.product.column)}`,
+  ].join(" ");
+}
+
+function aggregateByMonth(rows, binding) {
+  const result = {};
+  for (const row of rows) {
+    const month = String(row[binding.month.column] ?? "").slice(0, 7);
+    if (!month) continue;
+    result[month] ??= { count: 0, total: 0 };
+    result[month].count += 1;
+    result[month].total += Number(row[binding.demand.column] ?? 0);
+  }
+  return result;
+}
+
+function extractRows(value) {
+  if (Array.isArray(value?.entries)) return value.entries;
+  if (Array.isArray(value?.data?.entries)) return value.data.entries;
+  throw new Error("run_sql response does not contain entries");
+}
+
+function walk(value, visitor) {
+  if (!value || typeof value !== "object") return;
+  if (!Array.isArray(value)) visitor(value);
+  for (const child of Array.isArray(value) ? value : Object.values(value)) walk(child, visitor);
+}
+
+function quoteIdentifier(value) {
+  return `"${String(value).replaceAll('"', '""')}"`;
+}
+
+function assertString(value, name) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`managed lifecycle response is missing ${name}`);
+  }
+}

--- a/test/unit/context-loader.test.ts
+++ b/test/unit/context-loader.test.ts
@@ -2,7 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See the LICENSE file in the project root.
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getKnDetail, getObjectTypes, getRelationTypes } from "../../src/api/context-loader.js";
+import {
+  callManagedTool,
+  callTool,
+  getKnDetail,
+  getObjectTypes,
+  getRelationTypes,
+} from "../../src/api/context-loader.js";
 import type { RequestContext } from "../../src/types.js";
 
 const ctx: RequestContext = {
@@ -139,5 +145,151 @@ describe("drill-down (get_object_types / get_relation_types)", () => {
     const p = toolCallBody(f);
     expect(p.name).toBe("get_relation_types");
     expect(p.arguments.ids).toEqual(["rel_a"]);
+  });
+});
+
+describe("managed MCP tool calls", () => {
+  it("returns structured lifecycle output when the text content is descriptive", async () => {
+    const conversation = {
+      conversation_id: "conversation_supply_chain",
+      external_conversation_key: "cursor-supply-chain",
+      status: "active",
+    };
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        content: [{ type: "text", text: "managed lifecycle state updated" }],
+        structuredContent: conversation,
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(body, { status: 200, headers: { "mcp-session-id": "lifecycle-s1" } }),
+      ),
+    );
+
+    await expect(
+      callTool(ctx, "kn-lifecycle", "bkn_create_conversation", {
+        external_conversation_key: "cursor-supply-chain",
+      }),
+    ).resolves.toEqual(conversation);
+  });
+
+  it("rejects MCP tool errors instead of returning them as business values", async () => {
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: "conversation_required: call bkn_create_conversation first",
+          },
+        ],
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () => new Response(body, { status: 200, headers: { "mcp-session-id": "error-s1" } }),
+      ),
+    );
+
+    await expect(
+      callManagedTool(ctx, "kn-error", "search_schema", {
+        query: "6月份需求预测",
+      }),
+    ).rejects.toThrow(
+      "Context-loader error: conversation_required: call bkn_create_conversation first",
+    );
+  });
+
+  it("rejects managed tool responses without a trusted operation receipt", async () => {
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        content: [{ type: "text", text: JSON.stringify({ concepts: ["forecast"] }) }],
+        structuredContent: {},
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(body, { status: 200, headers: { "mcp-session-id": "missing-receipt-s1" } }),
+      ),
+    );
+
+    await expect(
+      callManagedTool(ctx, "kn-managed", "search_schema", {
+        query: "6月份需求预测",
+      }),
+    ).rejects.toThrow("Context-loader managed tool response did not include bkn_receipt");
+  });
+
+  it("returns the business value together with the trusted operation receipt", async () => {
+    const receipt = {
+      receipt_id: "receipt-1",
+      schema_version: "3.0.0",
+      conversation_id: "conversation_supply_chain",
+      interaction_id: "interaction_june_forecast",
+      operation_id: "operation-1",
+      attempt: 1,
+      operation_key: "search-schema",
+      tool_name: "search_schema",
+      normalized_input_hash: "sha256:input",
+      receipt_status: "completed",
+      evidence_durability: "pending",
+      required: true,
+      request_id: "request-1",
+      trace_id: "1234567890abcdef1234567890abcdef",
+      causation_event_ids: [],
+      observed_evidence_refs: [],
+      business_refs: [],
+      artifact_refs: [],
+      partial_reasons: [],
+      row_version: 2,
+      issued_at: "2026-08-02T06:00:00Z",
+      payload_hash: "sha256:payload",
+      owner: {
+        tenant_id: "tenant-1",
+        business_domain_id: "bd_public",
+        application_principal_id: "openbkn-sdk",
+        effective_subject_type: "user",
+        effective_subject_id: "user-1",
+      },
+    };
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {
+        content: [{ type: "text", text: JSON.stringify({ concepts: ["forecast"] }) }],
+        structuredContent: { bkn_receipt: receipt },
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(body, { status: 200, headers: { "mcp-session-id": "managed-s1" } }),
+      ),
+    );
+
+    const result = await callManagedTool(ctx, "kn-managed", "search_schema", {
+      query: "6月份需求预测",
+      bkn_context: {
+        conversation_id: "conversation_supply_chain",
+        interaction_id: "interaction_june_forecast",
+        operation_key: "search-schema",
+      },
+    });
+
+    expect(result.value).toEqual({ concepts: ["forecast"] });
+    expect(result.receipt).toEqual(receipt);
   });
 });

--- a/test/unit/trace.test.ts
+++ b/test/unit/trace.test.ts
@@ -218,16 +218,16 @@ describe("BKN Trace 2.2 business runs and artifacts", () => {
     const [listCall, summaryCall, tracesCall] = calls(f);
     if (!listCall || !summaryCall || !tracesCall) throw new Error("missing calls");
     const listURL = new URL(listCall[0]);
-    expect(listURL.pathname).toBe("/api/agent-observability/v1/requests");
+    expect(listURL.pathname).toBe("/api/agent-observability/v1/business-provenance/requests");
     expect(listURL.searchParams.get("keyword")).toBe("客户 A");
     expect(listURL.searchParams.get("status")).toBe("completed");
     expect(listURL.searchParams.get("knowledge_network")).toBe("customer-risk-network");
     expect(listURL.searchParams.get("evidence_completeness")).toBe("complete");
     expect(new URL(summaryCall[0]).pathname).toBe(
-      "/api/agent-observability/v1/requests/req_business_001",
+      "/api/agent-observability/v1/business-provenance/requests/req_business_001",
     );
     expect(new URL(tracesCall[0]).pathname).toBe(
-      "/api/agent-observability/v1/requests/req_business_001/traces",
+      "/api/agent-observability/v1/business-provenance/requests/req_business_001/traces",
     );
     expect(page.entries[0]?.request_id).toBe("req_business_001");
     expect(summary.request_id).toBe("req_business_001");
@@ -280,7 +280,7 @@ describe("BKN Trace 2.2 business runs and artifacts", () => {
     expect(listURL.searchParams.get("conversation_id")).toBe("conversation_supply_chain");
     expect(listURL.searchParams.get("interaction_id")).toBe("interaction_june_forecast");
     expect(new URL(interactionCall[0]).pathname).toBe(
-      "/api/agent-observability/v1/interactions/interaction_june_forecast",
+      "/api/agent-observability/v1/business-provenance/interactions/interaction_june_forecast",
     );
     expect(interaction.conversation_id).toBe("conversation_supply_chain");
     expect(interaction.requests[0]?.interaction_id).toBe("interaction_june_forecast");


### PR DESCRIPTION
## 概要
- 补齐 Context Loader 受管 Conversation / Interaction 调用参数和响应合同
- 暴露 Operation Receipt 与业务溯源查询资源
- 增加真实多轮、多 Operation E2E 脚本，验证 1 会话 / 2 轮次 / 至少 4 次调用
- 第三方 Agent 无需感知 Attempt；Request/Trace 保持技术关联语义

## 验证
- npm test（36 files / 318 tests，1 个 live test skipped）
- npm run lint
- npm run build
- git diff --check origin/main...HEAD

关联：openbkn-ai/bkn-foundry#545
设计文档：openbkn-ai/bkn-docs#29