### PR TITLE
feat(trace): 补齐受管交互 SDK 合同

### DIFF
--- a/skills/openbkn/SKILL.md
+++ b/skills/openbkn/SKILL.md
@@ -7,7 +7,8 @@ description: >-
   索引构建任务、Context Loader（MCP 检索）、Decision Agent（CRUD、流式对话、
   会话、挂载技能）、模型工厂（大模型/小模型 CRUD、OpenAI 兼容对话/embedding/
   rerank）、Skill 注册（zip 注册/下载/安装 + 生命周期）、Toolbox/Tool（上传、
-  导入导出、调用）、Dataflow 文档流程（+模板）、BKN Trace（拉取 spans、用符号
+  导入导出、调用）、Dataflow 文档流程（+模板）、BKN Trace（第三方 Agent 受管
+  Conversation / Interaction / Operation、拉取 spans、用符号
   规则 + LLM rubric 判定诊断一条 trace、scan、eval-set 构建/测试、schema 校验）、
   以及运营面（`openbkn admin`：组织/用户/角色 CRUD、审计、模型管理）与认证
   （token + OAuth 密码/浏览器）。
@@ -25,6 +26,16 @@ argument-hint: [自然语言指令]
 
 BKN 平台的统一命令行工具 —— 一个二进制，运维面收进 `openbkn admin` 子命令。
 纯后端，无 Web UI。
+
+## 第三方 Agent 业务问答硬门禁
+
+- **业务问答必须受管**：每轮先调用 `bkn_start_interaction`；首轮可声明 `agent_name`，后续轮次复用上一轮返回的 `conversation_id` 且不得变更名称。
+- **只用权威 ID**：业务工具逐字使用 start 返回的 `conversation_id` 和 `interaction_id`，不得虚构、猜测或沿用示例值。
+- **业务调用保持受管**：只通过携带上述 ID 的 Context Loader 工具访问 OpenBKN，Operation、重试和证据闭包由平台管理。
+- **提交本轮结果**：回答生成后调用 `bkn_finish_interaction`；它只提交当前 Interaction 的结果，不关闭 Conversation。
+- **错误即停止**：返回原始错误并遵循 `required_action`，不得降级到 CLI、Vega、ontology-query 或无受管上下文的调用。
+
+详细合同见 [context.md](references/context.md)。
 
 ## 安装
 
@@ -72,7 +83,7 @@ openbkn auth status | whoami | token | list | use <url> | switch <url> <user> | 
 | `bkn` | 知识网络 + Schema + 查询 + 本地包 | `list`/`get`/`search`/`stats`/`export`、`object-type/relation-type/action-type list/get/create/update/delete`、`action-type query/execute/inputs`、`metric …`、`concept-group …`、`action-log/action-schedule …`、`subgraph`、`relation-type-paths`、`resources`、`push <dir>`/`pull <kn> [dir]`、`validate <dir>`、`create-from-catalog <catalog> --name …`、`create-from-csv <catalog> --files <glob> --name …`（`--build`、`--pk-map t:col`） |
 | `resource` | Vega-backend 资源 | `list`/`get`/`find --name`/`query`/`delete` |
 | `vega` | Catalog + 索引构建 + SQL | `catalog list/get`、`catalog resources`、`connector-types`、`sql --resource-type <t> --query "<sql>"`（直连 MySQL/PG/OpenSearch，SQL 用 `{{resource-id}}` 占位）、`build`（索引 BuildTask）+ 状态 |
-| `context` | MCP 检索 | `info`（全局 tool 目录，无需 KN）、`search-schema`、`query-object-instance`、`find-skills`、`kn-detail <kn> [--detail-level summary\|full]`（渐进式：先 summary 骨架）、`object-types <kn> <ids...>`/`relation-types <kn> <ids...>`（下钻，未匹配走 `missing`）、`tools <kn>`、`tool-call <name> [--arg k=v]`、`call-method <method>`、`resources/templates/prompts`、`query-instance-subgraph`/`get-logic-properties`/`get-action-info`；新工具用 `info`/`tools` 发现 + `tool-call` 调用，无需改 CLI |
+| `context` | MCP 检索 | 业务对话通过 MCP 工具 `bkn_start_interaction` / `bkn_finish_interaction` 管理；CLI 沿用 `tool-call` 透传，不另设生命周期命令 |
 | `agent` | **[已废弃]** Decision Agent（agent-factory，逐步淘汰，勿用于新集成） | `list`/`personal-list`/`template-list`/`get`/`create`/`update`/`delete`/`publish`、`chat <id> -m "…" [--stream]`、`sessions`、`history`、`trace`、`skill list/add/remove`（运行会向 stderr 打废弃警告） |
 | `model` | 模型工厂 | `llm/small list/get/add/edit/delete/test`、`llm chat <name\|id> -m "…" [--stream]`（id 自动解析成 name）、`small embeddings/rerank <name>`（只收 name，填数字 id 会 400；与 chat 不同，暂不解析 id）、`llm set-default/unset-default <id>`、`small set-default/unset-default <id>`、`small get-default [--type embedding\|reranker]` |
 | `skill` | Skill 注册/市场/生命周期 | `list`/`market`/`get`/`content`/`read-file`/`history`/`set-status`、`register <dir>`/`download`/`install`、`update-metadata`/`update-package`、`republish`/`publish-history` |

--- a/skills/openbkn/references/context.md
+++ b/skills/openbkn/references/context.md
@@ -5,6 +5,97 @@ positional arg on KN-scoped commands — there is no `--kn-id` flag, and the glo
 `-k` means `--insecure`, not the KN. The MCP endpoint is derived as
 `<base-url>/api/agent-retrieval/v1/mcp`.
 
+## Managed business conversation (required)
+
+For a third-party Agent such as Cursor, one Agent chat is one BKN Trace
+Conversation, one user question is one Interaction, and every OpenBKN business
+tool call is one Operation. Do not call a business tool outside this lifecycle.
+
+1. For the first business question in a chat, call `bkn_start_interaction` with
+   the complete `question`, optional display-only `agent_name`, and no
+   `conversation_id`. Context Loader creates or
+   resolves the managed Conversation internally and returns the authoritative
+   `conversation_id` and `interaction_id`. The name is fixed for that
+   Conversation; later turns omit it or repeat the same value.
+2. For every later question in the same chat, call `bkn_start_interaction` with
+   the complete question and the previously returned `conversation_id`. Retain
+   both returned IDs exactly as provided. A Conversation may stay active across
+   turns, reconnects, and days.
+3. Call each business tool with:
+
+   ```json
+   {
+     "bkn_context": {
+       "conversation_id": "conv_...",
+       "interaction_id": "int_..."
+     }
+   }
+   ```
+
+   Do not add guessed operation or business-reference fields. Context Loader
+   observes the selected knowledge network, schema and data resources from the
+   authoritative request and response, and returns the authoritative
+   `bkn_receipt`.
+4. After forming the final answer, call `bkn_finish_interaction` with the
+   `interaction_id`, `outcome: "completed"`, and the exact final answer. This
+   submits the current Interaction result; it does not close the Conversation.
+   Use `failed`, `cancelled`, or `handed_off` with a reason when applicable.
+   OpenBKN manages leases, idempotency, Operation/Receipt closure, and the
+   result Artifact.
+5. Do not start the next Interaction until the current one is terminal. Do not
+   use raw `openbkn call`, direct ontology-query, or direct Vega calls as a
+   substitute for managed Context Loader tools when business provenance is
+   required.
+
+Tool input schemas returned by MCP are authoritative. When a lifecycle call is
+rejected, stop before any business query, surface the original error, and follow
+its `required_action`. Never invent IDs, retry the business operation blindly,
+or silently fall back to raw CLI, ontology-query, or Vega calls; those paths
+cannot produce a complete managed business conversation.
+
+The MCP connection itself must carry a trusted tenant and business domain. For
+an AppKey-based local Cursor connection, configure both `Authorization` and the
+authorized `x-business-domain` header. A missing domain is an authorization
+configuration error, not a reason to bypass the managed lifecycle.
+
+A host adapter may attach an opaque host conversation key and a per-call client
+invocation ID using `X-OpenBKN-Host-Conversation-Key` /
+`X-OpenBKN-Client-Invocation-Id`, or the corresponding
+`openbkn.ai/host-conversation-key` / `openbkn.ai/client-invocation-id` MCP
+metadata. These are adapter hints for continuity and retry idempotency inside the already
+authenticated owner scope; they are not model arguments and never establish
+tenant, user, application, business-domain, or data permissions. A generic MCP
+client needs only to retain and reuse the returned `conversation_id`. MCP
+transport session IDs are not business Conversation IDs.
+
+The TypeScript SDK exposes these hints as an optional fourth argument to
+`context.toolCall` / `context.managedToolCall`; the SDK writes them to MCP
+`_meta`, never to the model-visible tool arguments:
+
+```ts
+await client.context.toolCall(
+  knId,
+  "bkn_start_interaction",
+  {
+    question,
+    ...(conversationId ? { conversation_id: conversationId } : { agent_name: agentName }),
+  },
+  {
+    hostConversationKey: hostChatId,
+    clientInvocationId: hostTurnId,
+  },
+);
+```
+
+Reuse `clientInvocationId` only when retrying the same start call. Generate a
+new value for the next user turn.
+
+Do not fabricate internal headers such as `bkn-event-observed-at`. Third-party
+Agents propagate only the two returned IDs; host adapters may supply their
+opaque continuity hints outside the model-visible schema. Trusted OpenBKN
+services derive operation identity, concurrency, closure, and lifecycle
+timestamps from Core resources.
+
 ## Discover first
 
 | Command | Notes |

--- a/src/api/context-loader.ts
+++ b/src/api/context-loader.ts
@@ -117,6 +117,12 @@ export interface ManagedToolResult<T = unknown> {
   receipt: OperationReceipt;
 }
 
+/** Adapter-owned MCP metadata for lifecycle-safe host retries. */
+export interface ToolCallOptions {
+  hostConversationKey?: string;
+  clientInvocationId?: string;
+}
+
 interface UnwrappedToolResult {
   value: unknown;
   receipt?: OperationReceipt;
@@ -152,19 +158,40 @@ function unwrapToolResult(parsed: unknown): UnwrappedToolResult {
   return { value: result, receipt };
 }
 
+function toolCallParams(
+  name: string,
+  args: Record<string, unknown>,
+  options?: ToolCallOptions,
+): Record<string, unknown> {
+  const meta = {
+    ...(options?.hostConversationKey
+      ? { "openbkn.ai/host-conversation-key": options.hostConversationKey }
+      : {}),
+    ...(options?.clientInvocationId
+      ? { "openbkn.ai/client-invocation-id": options.clientInvocationId }
+      : {}),
+  };
+  return {
+    name,
+    arguments: args,
+    ...(Object.keys(meta).length > 0 ? { _meta: meta } : {}),
+  };
+}
+
 /** Call any MCP tool by name. */
 export async function callTool(
   ctx: RequestContext,
   knId: string,
   name: string,
   args: Record<string, unknown>,
+  options?: ToolCallOptions,
 ): Promise<unknown> {
   const operationCtx = operationContext(ctx);
   const sessionId = await ensureSession(operationCtx, knId);
   const { text } = await post(operationCtx, knId, sessionId, {
     jsonrpc: "2.0",
     method: "tools/call",
-    params: { name, arguments: args },
+    params: toolCallParams(name, args, options),
     id: nextId(),
   });
   return unwrapToolResult(parseBody(text)).value;
@@ -176,13 +203,14 @@ export async function callManagedTool<T = unknown>(
   knId: string,
   name: string,
   args: Record<string, unknown>,
+  options?: ToolCallOptions,
 ): Promise<ManagedToolResult<T>> {
   const operationCtx = operationContext(ctx);
   const sessionId = await ensureSession(operationCtx, knId);
   const { text } = await post(operationCtx, knId, sessionId, {
     jsonrpc: "2.0",
     method: "tools/call",
-    params: { name, arguments: args },
+    params: toolCallParams(name, args, options),
     id: nextId(),
   });
   const result = unwrapToolResult(parseBody(text));

--- a/src/api/trace-lifecycle.ts
+++ b/src/api/trace-lifecycle.ts
@@ -67,6 +67,7 @@ export interface LifecycleOwner {
 
 export interface ManagedConversation {
   conversation_id: string;
+  agent_name?: string;
   owner: LifecycleOwner;
   external_conversation_key: string;
   generation: number;
@@ -255,6 +256,7 @@ export interface CloseConversationInput {
 
 export interface StartInteractionInput {
   idempotency_key: string;
+  agent_name?: string;
   lease_seconds?: number;
 }
 

--- a/src/commands/trace.ts
+++ b/src/commands/trace.ts
@@ -104,6 +104,7 @@ export function traceCommand(): Command {
     .command("start <conversation-id>")
     .description("Start one managed interaction")
     .requiredOption("--idempotency-key <key>", "stable idempotency key")
+    .option("--agent-name <name>", "conversation-level Agent display name")
     .option("--lease-seconds <n>", "interaction lease duration", (value) =>
       Number.parseInt(value, 10),
     )
@@ -111,6 +112,7 @@ export function traceCommand(): Command {
       printJson(
         await clientFrom(cmd).trace.lifecycle.startInteraction(conversationId, {
           idempotency_key: opts.idempotencyKey,
+          agent_name: opts.agentName,
           lease_seconds: opts.leaseSeconds,
         }),
         outputOptions(cmd),

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ export {
 export { admin } from "./resources/admin.js";
 export { agents } from "./resources/agents.js";
 export { context } from "./resources/context-loader.js";
+export type { ManagedToolResult, ToolCallOptions } from "./api/context-loader.js";
 export { dataflows } from "./resources/dataflows.js";
 export { kn } from "./resources/knowledge-networks.js";
 export { models } from "./resources/models.js";

--- a/src/resources/context-loader.ts
+++ b/src/resources/context-loader.ts
@@ -5,6 +5,7 @@
 import {
   type DetailLevel,
   type SearchSchemaOptions,
+  type ToolCallOptions,
   callManagedTool,
   callMethod,
   callTool,
@@ -41,10 +42,18 @@ export function context(ctx: RequestContext) {
     relationTypes: (knId: string, ids: string[]) => getRelationTypes(ctx, knId, ids),
     info: () => mcpInfo(ctx),
     tools: (knId: string) => listTools(ctx, knId),
-    toolCall: (knId: string, name: string, args: Record<string, unknown>) =>
-      callTool(ctx, knId, name, args),
-    managedToolCall: <T = unknown>(knId: string, name: string, args: Record<string, unknown>) =>
-      callManagedTool<T>(ctx, knId, name, args),
+    toolCall: (
+      knId: string,
+      name: string,
+      args: Record<string, unknown>,
+      options?: ToolCallOptions,
+    ) => callTool(ctx, knId, name, args, options),
+    managedToolCall: <T = unknown>(
+      knId: string,
+      name: string,
+      args: Record<string, unknown>,
+      options?: ToolCallOptions,
+    ) => callManagedTool<T>(ctx, knId, name, args, options),
     // Generic MCP method passthrough — covers methods not yet wrapped, so the
     // surface doesn't have to grow every time the server adds one.
     callMethod: (knId: string, method: string, params?: Record<string, unknown>) =>

--- a/test/e2e/bkn-trace-managed-business-interaction.mjs
+++ b/test/e2e/bkn-trace-managed-business-interaction.mjs
@@ -1,19 +1,15 @@
 #!/usr/bin/env node
 
-import { randomBytes } from "node:crypto";
 import { createClient } from "../../dist/index.js";
 
 const baseUrl = process.env.BKN_BASE_URL ?? "http://localhost";
 const businessDomain = process.env.BKN_BUSINESS_DOMAIN ?? "bd_public";
 const knId = process.env.BKN_KN_ID ?? "supplychain_hd0202";
-const runId = randomBytes(8).toString("hex");
+const agentName = process.env.BKN_AGENT_NAME ?? "供应链分析助手";
 const client = createClient({ baseUrl, businessDomain });
+const hostConversationKey = `sdk-e2e:${Date.now()}`;
 
-const conversation = await client.context.toolCall(knId, "bkn_create_conversation", {
-  external_conversation_key: `sdk-supply-chain-${runId}`,
-  idempotency_key: `create-${runId}`,
-});
-assertString(conversation?.conversation_id, "conversation_id");
+let conversationId;
 
 const juneQuestion = "6月份有哪些需求预测单，列出来，需求总量是多少？";
 const june = await runInteraction({
@@ -52,20 +48,86 @@ const comparison = await runInteraction({
   },
 });
 
-const interactions = [june, comparison];
+const salesOrders = await runSalesOrderInteraction();
+
+const interactions = [june, comparison, salesOrders];
 const operations = interactions.flatMap((item) => item.operations);
-if (interactions.length !== 2 || operations.length < 4) {
+if (interactions.length !== 3 || operations.length < 7) {
   throw new Error(
     `invalid provenance hierarchy: interactions=${interactions.length}, operations=${operations.length}`,
   );
+}
+
+async function runSalesOrderInteraction() {
+  const question = "迄今为止有多少销售订单，分别属于哪些产品？";
+  const interaction = await startInteraction("sales-orders", question);
+  assertString(interaction?.interaction_id, "interaction_id");
+  rememberConversation(interaction);
+
+  const schemaCall = await managedOperation(
+    interaction.interaction_id,
+    "sales-orders:schema",
+    "search_schema",
+    {
+      query: "销售订单 产品 签约数量",
+      response_format: "json",
+      include_columns: true,
+      max_concepts: 20,
+      bkn_context: businessContext(interaction.interaction_id),
+    },
+  );
+  const binding = extractSalesOrderBinding(schemaCall.value);
+  const rejectedCall = await managedRejectedOperation(
+    interaction.interaction_id,
+    "sales-orders:read-only-rejection",
+    "run_sql",
+    {
+      sql: "DELETE FROM forbidden",
+      response_format: "json",
+      bkn_context: businessContext(interaction.interaction_id),
+    },
+  );
+  const dataCall = await managedOperation(
+    interaction.interaction_id,
+    "sales-orders:data",
+    "run_sql",
+    {
+      sql: buildSalesOrderSql(binding),
+      response_format: "json",
+      bkn_context: businessContext(interaction.interaction_id),
+    },
+  );
+  const rows = extractRows(dataCall.value);
+  const orderCount = rows.reduce((sum, row) => sum + Number(row.order_count ?? 0), 0);
+  const signingQuantity = rows.reduce((sum, row) => sum + Number(row.signing_quantity ?? 0), 0);
+  if (rows.length !== 10 || orderCount !== 1_441 || signingQuantity !== 15_991) {
+    throw new Error(
+      `unexpected sales order result: products=${rows.length}, orders=${orderCount}, quantity=${signingQuantity}`,
+    );
+  }
+  const answer = `共有 ${orderCount} 张销售订单，涉及 ${rows.length} 个产品，签约数量合计 ${signingQuantity}。`;
+  const receipts = [schemaCall.receipt, rejectedCall.receipt, dataCall.receipt];
+  const completed = await client.context.toolCall(knId, "bkn_finish_interaction", {
+    interaction_id: interaction.interaction_id,
+    outcome: "completed",
+    answer,
+  });
+  return {
+    interaction_id: interaction.interaction_id,
+    question,
+    answer,
+    execution_status: completed.execution_status,
+    evidence_status: completed.evidence_status,
+    operations: summarizeReceipts(receipts),
+  };
 }
 
 console.log(
   JSON.stringify(
     {
       passed: true,
-      conversation_id: conversation.conversation_id,
-      expected_view_counts: { conversations: 1, interactions: 2, openbkn_calls: operations.length },
+      conversation_id: conversationId,
+      expected_view_counts: { conversations: 1, interactions: 3, openbkn_calls: operations.length },
       interactions,
     },
     null,
@@ -74,48 +136,37 @@ console.log(
 );
 
 async function runInteraction({ key, question, start, end, answerFor }) {
-  const interaction = await client.context.toolCall(knId, "bkn_start_interaction", {
-    conversation_id: conversation.conversation_id,
-    idempotency_key: `interaction-${key}-${runId}`,
-    question,
-  });
+  const interaction = await startInteraction(key, question);
   assertString(interaction?.interaction_id, "interaction_id");
-  assertString(interaction?.lease_token, "lease_token");
+  rememberConversation(interaction);
 
-  const schemaCall = await operationClient().context.managedToolCall(knId, "search_schema", {
-    query: question,
-    response_format: "json",
-    include_columns: true,
-    max_concepts: 20,
-    bkn_context: businessContext(interaction.interaction_id, `${key}-schema-search`),
-  });
+  const schemaCall = await managedOperation(
+    interaction.interaction_id,
+    `${key}:schema`,
+    "search_schema",
+    {
+      query: question,
+      response_format: "json",
+      include_columns: true,
+      max_concepts: 20,
+      bkn_context: businessContext(interaction.interaction_id),
+    },
+  );
   const binding = extractForecastBinding(schemaCall.value);
-  const dataCall = await operationClient().context.managedToolCall(knId, "run_sql", {
+  const dataCall = await managedOperation(interaction.interaction_id, `${key}:data`, "run_sql", {
     sql: buildForecastSql(binding, start, end),
     response_format: "json",
-    bkn_context: businessContext(interaction.interaction_id, `${key}-forecast-query`),
+    bkn_context: businessContext(interaction.interaction_id),
   });
   const rows = extractRows(dataCall.value);
   if (rows.length === 0) throw new Error(`run_sql returned no rows for ${key}`);
 
   const answer = answerFor(rows, binding);
   const receipts = [schemaCall.receipt, dataCall.receipt];
-  const completed = await client.context.toolCall(knId, "bkn_complete_interaction", {
+  const completed = await client.context.toolCall(knId, "bkn_finish_interaction", {
     interaction_id: interaction.interaction_id,
-    terminal_idempotency_key: `complete-${key}-${runId}`,
-    lease_token: interaction.lease_token,
-    lease_epoch: interaction.lease_epoch,
-    completion_manifest_version: "3.0.0",
-    completion_reason: "answered",
+    outcome: "completed",
     answer,
-    expected_operations: receipts.map((receipt) => ({
-      operation_id: receipt.operation_id,
-      required: true,
-    })),
-    expected_receipts: receipts.map((receipt) => ({
-      receipt_id: receipt.receipt_id,
-      required: true,
-    })),
   });
   return {
     interaction_id: interaction.interaction_id,
@@ -123,29 +174,82 @@ async function runInteraction({ key, question, start, end, answerFor }) {
     answer,
     execution_status: completed.execution_status,
     evidence_status: completed.evidence_status,
-    operations: receipts.map((receipt) => ({
-      operation_id: receipt.operation_id,
-      operation_key: receipt.operation_key,
-      tool_name: receipt.tool_name,
-      receipt_id: receipt.receipt_id,
-      trace_id: receipt.trace_id,
-      request_id: receipt.request_id,
-      evidence_durability: receipt.evidence_durability,
-      business_refs: receipt.business_refs,
-    })),
+    operations: summarizeReceipts(receipts),
   };
+}
+
+function summarizeReceipts(receipts) {
+  return receipts.map((receipt) => ({
+    operation_id: receipt.operation_id,
+    operation_key: receipt.operation_key,
+    tool_name: receipt.tool_name,
+    receipt_id: receipt.receipt_id,
+    trace_id: receipt.trace_id,
+    request_id: receipt.request_id,
+    evidence_durability: receipt.evidence_durability,
+    business_refs: receipt.business_refs,
+  }));
 }
 
 function operationClient() {
   return createClient({ baseUrl, businessDomain });
 }
 
-function businessContext(interactionId, operationKey) {
+function managedOperation(interactionId, invocationSuffix, toolName, args) {
+  return operationClient().context.managedToolCall(knId, toolName, args, {
+    clientInvocationId: `operation:${interactionId}:${invocationSuffix}`,
+  });
+}
+
+async function managedRejectedOperation(interactionId, invocationSuffix, toolName, args) {
+  const result = await operationClient().context.callMethod(knId, "tools/call", {
+    name: toolName,
+    arguments: args,
+    _meta: {
+      "openbkn.ai/client-invocation-id": `operation:${interactionId}:${invocationSuffix}`,
+    },
+  });
+  if (result?.isError !== true) {
+    throw new Error(`${toolName} rejection scenario unexpectedly succeeded`);
+  }
+  const receipt = result?.structuredContent?.bkn_receipt;
+  if (receipt?.receipt_status !== "failed") {
+    throw new Error(`${toolName} rejection scenario did not return a failed durable receipt`);
+  }
+  return { value: result, receipt };
+}
+
+function businessContext(interactionId) {
   return {
-    conversation_id: conversation.conversation_id,
+    conversation_id: conversationId,
     interaction_id: interactionId,
-    operation_key: operationKey,
   };
+}
+
+function rememberConversation(interaction) {
+  assertString(interaction?.conversation_id, "conversation_id");
+  if (conversationId && conversationId !== interaction.conversation_id) {
+    throw new Error(
+      `conversation changed across turns: ${conversationId} != ${interaction.conversation_id}`,
+    );
+  }
+  conversationId = interaction.conversation_id;
+}
+
+function startInteraction(key, question) {
+  return client.context.toolCall(
+    knId,
+    "bkn_start_interaction",
+    {
+      ...(conversationId ? { conversation_id: conversationId } : {}),
+      ...(!conversationId ? { agent_name: agentName } : {}),
+      question,
+    },
+    {
+      hostConversationKey,
+      clientInvocationId: `interaction:${key}`,
+    },
+  );
 }
 
 function extractForecastBinding(value) {
@@ -187,7 +291,50 @@ function extractForecastBinding(value) {
   const product = propertyBinding(selected.properties, ["product_code", "material_number"]);
   const order = propertyBinding(selected.properties, ["confirmed_order", "billno", "id"]);
   if (!resourceId) throw new Error("forecast schema binding is missing its data resource");
-  return { resourceId, month, demand, product, order };
+  return {
+    resourceId,
+    month,
+    demand,
+    product,
+    order,
+  };
+}
+
+function extractSalesOrderBinding(value) {
+  let selected;
+  walk(value, (item) => {
+    if (
+      !selected &&
+      `${item.concept_id ?? ""} ${item.concept_name ?? ""}`.match(/salesorder|销售订单/i) &&
+      Array.isArray(item.data_properties) &&
+      item.data_source
+    ) {
+      selected = item;
+    }
+  });
+  if (!selected) throw new Error("search_schema did not return the sales order binding");
+  const resourceId = selected.data_source.id ?? selected.data_source.resource_id;
+  if (!resourceId) throw new Error("sales order schema binding is missing its data resource");
+  return {
+    resourceId,
+    productCode: propertyBinding(selected.data_properties, ["product_code"]),
+    productName: propertyBinding(selected.data_properties, ["product_name"]),
+    signingQuantity: propertyBinding(selected.data_properties, ["signing_quantity"]),
+  };
+}
+
+function buildSalesOrderSql(binding) {
+  const productCode = quoteIdentifier(binding.productCode.column);
+  const productName = quoteIdentifier(binding.productName.column);
+  const signingQuantity = quoteIdentifier(binding.signingQuantity.column);
+  return [
+    `SELECT ${productCode}, MAX(${productName}) AS product_name,`,
+    "COUNT(*) AS order_count,",
+    `SUM(CAST(${signingQuantity} AS DOUBLE)) AS signing_quantity`,
+    `FROM {{.${binding.resourceId}}}`,
+    `GROUP BY ${productCode}`,
+    "ORDER BY signing_quantity DESC",
+  ].join(" ");
 }
 
 function hasProperty(properties, logicalNames) {

--- a/test/unit/context-loader.test.ts
+++ b/test/unit/context-loader.test.ts
@@ -42,12 +42,20 @@ function mockMcp(): typeof fetch {
 }
 
 /** The `tools/call` request body among all the MCP POSTs (skips initialize etc.). */
-function toolCallBody(f: typeof fetch): { name: string; arguments: Record<string, unknown> } {
+function toolCallBody(f: typeof fetch): {
+  name: string;
+  arguments: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
+} {
   const calls = (f as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls;
   for (const [, init] of calls) {
     const b = JSON.parse(init.body as string) as {
       method?: string;
-      params?: { name: string; arguments: Record<string, unknown> };
+      params?: {
+        name: string;
+        arguments: Record<string, unknown>;
+        _meta?: Record<string, unknown>;
+      };
     };
     if (b.method === "tools/call" && b.params) return b.params;
   }
@@ -149,18 +157,50 @@ describe("drill-down (get_object_types / get_relation_types)", () => {
 });
 
 describe("managed MCP tool calls", () => {
-  it("returns structured lifecycle output when the text content is descriptive", async () => {
-    const conversation = {
+  it("sends host lifecycle hints as MCP metadata, never as model tool arguments", async () => {
+    const f = mockMcp();
+
+    await callTool(
+      ctx,
+      "kn-host-hints",
+      "bkn_start_interaction",
+      { question: "查询供应链库存" },
+      {
+        hostConversationKey: "cursor-chat-42",
+        clientInvocationId: "cursor-turn-7",
+      },
+    );
+
+    const params = toolCallBody(f);
+    expect(params.arguments).toEqual({ question: "查询供应链库存" });
+    expect(params._meta).toEqual({
+      "openbkn.ai/host-conversation-key": "cursor-chat-42",
+      "openbkn.ai/client-invocation-id": "cursor-turn-7",
+    });
+  });
+
+  it("omits MCP metadata when the host does not provide lifecycle hints", async () => {
+    const f = mockMcp();
+
+    await callTool(ctx, "kn-no-host-hints", "bkn_start_interaction", {
+      question: "查询供应链库存",
+    });
+
+    expect(toolCallBody(f)._meta).toBeUndefined();
+  });
+
+  it("returns structured start output when the text content is descriptive", async () => {
+    const interaction = {
       conversation_id: "conversation_supply_chain",
-      external_conversation_key: "cursor-supply-chain",
-      status: "active",
+      interaction_id: "interaction_supply_chain",
+      execution_status: "active",
     };
     const body = JSON.stringify({
       jsonrpc: "2.0",
       id: 1,
       result: {
         content: [{ type: "text", text: "managed lifecycle state updated" }],
-        structuredContent: conversation,
+        structuredContent: interaction,
       },
     });
     vi.stubGlobal(
@@ -172,10 +212,10 @@ describe("managed MCP tool calls", () => {
     );
 
     await expect(
-      callTool(ctx, "kn-lifecycle", "bkn_create_conversation", {
-        external_conversation_key: "cursor-supply-chain",
+      callTool(ctx, "kn-lifecycle", "bkn_start_interaction", {
+        question: "查询供应链库存",
       }),
-    ).resolves.toEqual(conversation);
+    ).resolves.toEqual(interaction);
   });
 
   it("rejects MCP tool errors instead of returning them as business values", async () => {
@@ -187,7 +227,7 @@ describe("managed MCP tool calls", () => {
         content: [
           {
             type: "text",
-            text: "conversation_required: call bkn_create_conversation first",
+            text: "conversation_required: call bkn_start_interaction first",
           },
         ],
       },
@@ -204,7 +244,7 @@ describe("managed MCP tool calls", () => {
         query: "6月份需求预测",
       }),
     ).rejects.toThrow(
-      "Context-loader error: conversation_required: call bkn_create_conversation first",
+      "Context-loader error: conversation_required: call bkn_start_interaction first",
     );
   });
 

--- a/test/unit/openbkn-skill-contract.test.ts
+++ b/test/unit/openbkn-skill-contract.test.ts
@@ -1,0 +1,28 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("OpenBKN third-party Agent contract", () => {
+  it("keeps the managed lifecycle gate concise in the first partial read", async () => {
+    const skill = await readFile(new URL("../../skills/openbkn/SKILL.md", import.meta.url), "utf8");
+    const first80Lines = skill.split("\n").slice(0, 80).join("\n");
+    const gate = first80Lines.match(
+      /## 第三方 Agent 业务问答硬门禁\n\n([\s\S]*?)\n\n详细合同/,
+    )?.[1];
+
+    expect(gate).toBeDefined();
+    expect(gate?.split("\n")).toHaveLength(5);
+    expect(first80Lines).toContain("业务问答必须受管");
+    expect(first80Lines).toContain("不得虚构");
+    expect(first80Lines).toContain("不得降级");
+    expect(first80Lines).toContain("bkn_start_interaction");
+    expect(first80Lines).toContain("bkn_finish_interaction");
+    expect(first80Lines).toContain("提交本轮结果");
+    expect(first80Lines).toContain("不关闭 Conversation");
+    expect(first80Lines).toContain("首轮");
+    expect(first80Lines).not.toContain("claims");
+    expect(first80Lines).not.toContain("bkn_ensure_conversation");
+    expect(first80Lines).not.toContain("external_conversation_key");
+    expect(first80Lines).not.toContain("lease_token");
+    expect(first80Lines).not.toContain("bkn_complete_interaction");
+  });
+});

--- a/test/unit/trace-command.test.ts
+++ b/test/unit/trace-command.test.ts
@@ -41,6 +41,14 @@ describe("trace lifecycle CLI contract", () => {
         .find((child) => child.name() === "interactions")
         ?.commands.map((c) => c.name()),
     ).toEqual(expect.arrayContaining(["start", "get", "complete", "fail", "cancel", "handoff"]));
+    const start = command.commands
+      .find((child) => child.name() === "interactions")
+      ?.commands.find((child) => child.name() === "start");
+    expect(start?.options.map((option) => option.long)).toEqual([
+      "--idempotency-key",
+      "--agent-name",
+      "--lease-seconds",
+    ]);
     for (const name of ["complete", "fail", "cancel", "handoff"]) {
       const terminal = command.commands
         .find((child) => child.name() === "interactions")

--- a/test/unit/trace-lifecycle.test.ts
+++ b/test/unit/trace-lifecycle.test.ts
@@ -166,6 +166,7 @@ describe("traceLifecycleApi interactions", () => {
 
     await api.startInteraction("conversation-1", {
       idempotency_key: "interaction-1",
+      agent_name: "供应链分析助手",
       lease_seconds: 60,
     });
     await api.getInteraction("interaction-1");
@@ -185,6 +186,7 @@ describe("traceLifecycleApi interactions", () => {
     ]);
     expect(jsonBody(interactionCalls[0]!)).toEqual({
       idempotency_key: "interaction-1",
+      agent_name: "供应链分析助手",
       lease_seconds: 60,
     });
     for (const call of interactionCalls.slice(2)) {


### PR DESCRIPTION
## What Changed

- [x] SDK/CLI 透传默认受管生命周期上下文，并对齐 Context Loader 最小 `start / finish` 合同。
- [x] 收敛 OpenBKN Skill，明确失败停止、禁止编造 ID 与禁止降级绕过。
- [x] 增加合同、命令和真实 E2E 覆盖。

---

## Why

- Related Feature: [openbkn-ai/bkn-foundry#545](https://github.com/openbkn-ai/bkn-foundry/issues/545)
- Background: 让第三方 Agent 的多轮业务问答稳定形成 Conversation -> Interaction -> Operation 业务溯源链。

---

## How

- Key implementation points: 复用既有 Context Loader 入口，不新增客户端初始化 API 或 MCP 工具；调用方只消费服务端实际返回的受管 ID。
- Breaking changes (API, config, database, etc.): 对齐 0.1.3 未发布合同；不兼容未跑通的旧可选生命周期用法。

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [x] Verified in test environment

Test notes:

- Biome、TypeScript 通过。
- Vitest：322 通过，1 个 live 测试按设计跳过。
- tsup 构建通过；与本地 Cursor/MCP 真实多轮场景联调。

---

## Risk & Rollback

- Potential risks: 接入方需要遵循受管生命周期，否则业务工具会按合同拒绝。
- Rollback plan: 回滚 SDK 版本；Core 保持历史会话与证据不删除。

---

## Additional Notes

- 配套 PR：Foundry、Studio、bkn-docs。
- 不关闭 #545 发布门。