### PR TITLE
fix(kn): align validateMetric with OpenAPI validation path

### DIFF
--- a/src/api/knowledge-networks.ts
+++ b/src/api/knowledge-networks.ts
@@ -404,7 +404,7 @@ export function searchMetrics(ctx: RequestContext, knId: string, body: unknown):
   });
 }
 export function validateMetric(ctx: RequestContext, knId: string, body: unknown): Promise<unknown> {
-  return request(ctx, `${ONTOLOGY_BASE}/${encodeURIComponent(knId)}/metrics/validate`, {
+  return request(ctx, `${ONTOLOGY_BASE}/${encodeURIComponent(knId)}/metrics/validation`, {
     method: "POST",
     body,
   });

--- a/test/unit/knowledge-networks.test.ts
+++ b/test/unit/knowledge-networks.test.ts
@@ -161,3 +161,16 @@ describe("semanticSearch", () => {
     });
   });
 });
+
+describe("validateMetric", () => {
+  it("POSTs to metrics/validation (OpenAPI path)", async () => {
+    const { validateMetric } = await import("../../src/api/knowledge-networks.js");
+    const fetchMock = mockFetch();
+    await validateMetric(ctx, "kn-1", { entries: [] });
+    const call = firstCall(fetchMock);
+    expect(new URL(call[0]).pathname).toBe(
+      "/api/ontology-manager/v1/knowledge-networks/kn-1/metrics/validation",
+    );
+    expect(call[1].method).toBe("POST");
+  });
+});


### PR DESCRIPTION
## Summary

- Fix `validateMetric()` to POST to OpenAPI path `.../metrics/validation` instead of non-existent `.../metrics/validate`.
- Add unit test asserting the request pathname.

Related: [openbkn-ai/bkn-foundry#593](https://github.com/openbkn-ai/bkn-foundry/issues/593)

Companion backend PR adds `/metrics/validate` alias for backward compatibility with already-published SDK versions.

## What Changed

- [x] `src/api/knowledge-networks.ts`: path fix
- [x] `test/unit/knowledge-networks.test.ts`: pathname assertion

## Why

`openbkn bkn metric validate` returned HTTP 404 because the SDK URL did not match bkn-backend / OpenAPI route.

## Testing

- [x] Unit tests passed locally

```bash
npm test -- test/unit/knowledge-networks.test.ts
```

## Risk & Rollback

- **Risk:** Low — single URL segment change; CLI command name unchanged.
- **Rollback:** Revert to `/metrics/validate` (requires backend alias from foundry PR).
