### PR TITLE
chore: declare the Node version this package actually needs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
 
+# Lint and test read the checkout and nothing else. Declared at the top so both
+# jobs inherit it — the default token is broader than either needs, and
+# `release.yml` / `automation-claude-review.yml` already scope theirs.
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,19 @@ jobs:
       - run: npm run lint
       - run: npm test
       - run: npm run build
+
+  # The declared `engines.node` floor, actually exercised. `node-version: 22`
+  # above resolves to the newest 22.x, so without this the floor would be a
+  # number nothing runs — the exact claim-without-evidence this repo's engines
+  # declaration was fixed to stop making. Kept as a separate job so the required
+  # `ci` check keeps its name.
+  engines-floor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.19.0
+          cache: npm
+      - run: npm ci
+      - run: npm test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Unified TypeScript SDK + CLI for the **BKN** (Business Knowledge Network) platfo
 
 | Concern | Choice |
 | ------- | ------ |
-| Language | TypeScript (ESM), Node ≥ 22 |
+| Language | TypeScript (ESM), Node ≥ 22.19 |
 | CLI | `commander` + `@clack/prompts` (prompts) + `chalk`/`cli-table3` (output); no TUI |
 | Validation | `zod` at IO boundaries |
 | HTTP | native `fetch` |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install -g @openbkn/bkn-sdk   # CLI: `openbkn`
 npm install @openbkn/bkn-sdk
 ```
 
-Requires Node ≥ 22.
+Requires Node ≥ 22.19.
 
 ## CLI
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -15,7 +15,7 @@ npm install -g @openbkn/bkn-sdk   # CLI：openbkn
 npm install @openbkn/bkn-sdk
 ```
 
-需要 Node ≥ 22。
+需要 Node ≥ 22.19。
 
 ## CLI
 

--- a/docs/design-docs/tech-stack.md
+++ b/docs/design-docs/tech-stack.md
@@ -7,7 +7,7 @@ tools; this records what the rewrite picks and why. Update here if a choice chan
 
 | Concern | Choice | Why |
 | ------- | ------ | --- |
-| Language | TypeScript (ESM), Node ≥ 22 | Both legacy repos are TS; ≥22 (the legacy SDK's floor) for stable native fetch / test runner |
+| Language | TypeScript (ESM), Node ≥ 22.19 | Both legacy repos are TS; ≥22 (the legacy SDK's floor) for stable native fetch / test runner, and undici — the only dependency that names a floor — requires 22.19 |
 | CLI framework | **commander** | Mature, 0 runtime deps, clean command tree, biggest ecosystem. Needs a custom grouped-help renderer (see below) |
 | Interactive prompts | **@clack/prompts** | Pretty modern prompts for login / business-domain selection. Replaces `ink`/`inquirer` — lighter, no TUI |
 | Pretty output | **chalk** + **cli-table3** | Color + aligned tables for human output |

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@biomejs/biome": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18"
+    "node": ">=22.19.0"
   },
   "bin": {
     "openbkn": "./dist/cli.js"

--- a/src/utils/csv-import.ts
+++ b/src/utils/csv-import.ts
@@ -103,7 +103,7 @@ export function buildImportDag(opts: DagBodyOptions): Record<string, unknown> {
   };
 }
 
-/** Single-level glob (`dir/*.csv`) — readdir + basename match. Node 18 safe. */
+/** Single-level glob (`dir/*.csv`) — readdir + basename match. */
 function globOne(pattern: string): string[] {
   const dir = dirname(pattern);
   const re = new RegExp(


### PR DESCRIPTION
Follow-up to the finding in #40. Ahead of an rc release, `engines.node` was `">=18"` — a claim nothing in the repo supports and nothing tests:

| where | says |
|---|---|
| `undici@8.10.0` `engines.node` | `>=22.19.0` |
| `tsup.config.ts` `target` | `node22` |
| `ci.yml` `node-version` | `22` |
| `README.md` | "Requires Node ≥ 22." |
| `package.json` `engines.node` | **`>=18`** |

`package.json` contradicted its own README.

## The floor

undici is the binding constraint. Every other runtime dependency asks for less or nothing:

```
@clack/prompts   (none)
chalk            ^12.17.0 || ^14.13 || >=16.0.0
commander        >=18
csv-parse        (none)
js-yaml          (none)
jszip            (none)
undici           >=22.19.0      <- binding
zod              (none)
```

So `>=22.19.0`. The READMEs move from "≥ 22" to "≥ 22.19" too, because 22.0.0 would still fail the check — the human-readable claim should be exact, not approximately right. `AGENTS.md` and `docs/design-docs/tech-stack.md` follow.

## What actually changes for a Node 18/20 user

**Not a hard refusal.** npm's `engine-strict` defaults to false and this repo ships no `.npmrc`, so an unmet `engines` prints `npm warn EBADENGINE` and installs anyway. Such a user already had a package that fails at undici's import; that does not change.

What changes is *who the warning names*. Before, npm reported undici as incompatible — a transitive dependency the user never chose. Now it reports `@openbkn/bkn-sdk`, which is the thing they asked for. Same outcome, a diagnostic that points at the right project. A hard refusal requires the user to set `engine-strict=true` themselves.

This still narrows what the package claims to support, so it belongs in the rc's release notes — as a documentation correction, not as a new install barrier.

## The floor is now exercised

`node-version: 22` resolves to the newest 22.x, so declaring 22.19.0 without more would have left the floor as a number nothing runs — the same claim-without-evidence this PR is about. A separate `engines-floor` job pins 22.19.0 and runs the test suite there.

Separate job rather than a matrix on purpose: a matrix renames the check to `ci (22)`, and the required status check `ci` would never report again.

## Verification

- `npm run ci`: **402 passed, 1 skipped**.
- `npm install --dry-run`: no `EBADENGINE` — the floor is consistent with the resolved tree.
- `package-lock.json` `packages[""].engines` synced; npm mirrors the root `engines` there and `npm ci` does not validate it, so a one-sided edit would have drifted silently into a later unrelated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)