### PR TITLE
fix(vega): align build task list summary

### DIFF
--- a/src/api/vega.ts
+++ b/src/api/vega.ts
@@ -126,6 +126,44 @@ export const BuildTask = z
   .passthrough();
 export type BuildTask = z.infer<typeof BuildTask>;
 
+/** Lightweight BuildTask representation returned by list APIs. */
+export const BuildTaskSummary = z.object({
+  id: z.string(),
+  resource_id: z.string(),
+  resource_name: z.string().optional(),
+  catalog_id: z.string(),
+  catalog_name: z.string().optional(),
+  status: BuildTaskStatus,
+  mode: BuildMode,
+  execute_type: BuildTaskExecuteType.optional(),
+  total_count: z.number(),
+  synced_count: z.number(),
+  vectorized_count: z.number(),
+  synced_mark: z.string(),
+  error_msg: z.string().optional(),
+  creator: z.object({
+    id: z.string(),
+    name: z.string().optional(),
+    type: z.string(),
+  }),
+  create_time: z.number(),
+  update_time: z.number(),
+  index_health: z
+    .object({
+      embedding: z.string(),
+      fulltext: z.string(),
+      usable: z.boolean(),
+    })
+    .optional(),
+});
+export type BuildTaskSummary = z.infer<typeof BuildTaskSummary>;
+
+export const ListBuildTasksResponse = z.object({
+  entries: z.array(BuildTaskSummary),
+  total_count: z.number(),
+});
+export type ListBuildTasksResponse = z.infer<typeof ListBuildTasksResponse>;
+
 /** Create an index BuildTask for a resource. Returns the task (with its id). */
 export async function createBuildTask(
   ctx: RequestContext,
@@ -149,15 +187,15 @@ export interface ListBuildTasksOptions {
   status?: BuildTaskStatus | BuildTaskStatus[];
   active?: boolean;
   mode?: BuildMode;
-  orderBy?: "default" | "created_at" | "updated_at";
+  orderBy?: "created_at" | "updated_at";
   order?: "asc" | "desc";
 }
 
-export function listBuildTasks(
+export async function listBuildTasks(
   ctx: RequestContext,
   opts: ListBuildTasksOptions = {},
-): Promise<unknown> {
-  return request(ctx, `${VEGA_BASE}/build-tasks`, {
+): Promise<ListBuildTasksResponse> {
+  const res = await request<unknown>(ctx, `${VEGA_BASE}/build-tasks`, {
     query: {
       limit: opts.limit,
       offset: opts.offset,
@@ -170,6 +208,7 @@ export function listBuildTasks(
       order: opts.order,
     },
   });
+  return ListBuildTasksResponse.parse(res);
 }
 
 /** Fetch a BuildTask's progress/state. */

--- a/src/api/vega.ts
+++ b/src/api/vega.ts
@@ -8,6 +8,7 @@
  */
 import { z } from "zod";
 import type { RequestContext } from "../types.js";
+import { InputError } from "../utils/errors.js";
 import { request } from "./http.js";
 
 // Vega backend base path.
@@ -127,41 +128,46 @@ export const BuildTask = z
 export type BuildTask = z.infer<typeof BuildTask>;
 
 /** Lightweight BuildTask representation returned by list APIs. */
-export const BuildTaskSummary = z.object({
-  id: z.string(),
-  resource_id: z.string(),
-  resource_name: z.string().optional(),
-  catalog_id: z.string(),
-  catalog_name: z.string().optional(),
-  status: BuildTaskStatus,
-  mode: BuildMode,
-  execute_type: BuildTaskExecuteType.optional(),
-  total_count: z.number(),
-  synced_count: z.number(),
-  vectorized_count: z.number(),
-  synced_mark: z.string(),
-  error_msg: z.string().optional(),
-  creator: z.object({
+export const BuildTaskSummary = z
+  .object({
     id: z.string(),
-    name: z.string().optional(),
-    type: z.string(),
-  }),
-  create_time: z.number(),
-  update_time: z.number(),
-  index_health: z
-    .object({
-      embedding: z.string(),
-      fulltext: z.string(),
-      usable: z.boolean(),
-    })
-    .optional(),
-});
+    resource_id: z.string(),
+    resource_name: z.string().optional(),
+    catalog_id: z.string(),
+    catalog_name: z.string().optional(),
+    status: BuildTaskStatus,
+    mode: BuildMode,
+    execute_type: BuildTaskExecuteType.optional(),
+    total_count: z.number(),
+    synced_count: z.number(),
+    vectorized_count: z.number(),
+    synced_mark: z.string(),
+    error_msg: z.string().optional(),
+    creator: z.object({
+      id: z.string(),
+      name: z.string().optional(),
+      type: z.string(),
+    }),
+    create_time: z.number(),
+    update_time: z.number(),
+    index_health: z
+      .object({
+        embedding: z.string(),
+        fulltext: z.string(),
+        usable: z.boolean(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
 export type BuildTaskSummary = z.infer<typeof BuildTaskSummary>;
 
-export const ListBuildTasksResponse = z.object({
-  entries: z.array(BuildTaskSummary),
-  total_count: z.number(),
-});
+export const ListBuildTasksResponse = z
+  .object({
+    entries: z.array(BuildTaskSummary),
+    total_count: z.number(),
+  })
+  .passthrough();
 export type ListBuildTasksResponse = z.infer<typeof ListBuildTasksResponse>;
 
 /** Create an index BuildTask for a resource. Returns the task (with its id). */
@@ -195,6 +201,11 @@ export async function listBuildTasks(
   ctx: RequestContext,
   opts: ListBuildTasksOptions = {},
 ): Promise<ListBuildTasksResponse> {
+  if ((opts as { orderBy?: unknown }).orderBy === "default") {
+    throw new InputError(
+      'orderBy "default" is no longer supported; use "created_at" or "updated_at"',
+    );
+  }
   const res = await request<unknown>(ctx, `${VEGA_BASE}/build-tasks`, {
     query: {
       limit: opts.limit,

--- a/src/commands/vega.ts
+++ b/src/commands/vega.ts
@@ -490,9 +490,14 @@ export function vegaCommand(): Command {
     .option("--status <status>", "comma-separated statuses")
     .option("--active", "only running/init tasks")
     .option("--mode <mode>", "filter by mode: batch | streaming")
-    .option("--order-by <field>", "default | created_at | updated_at")
+    .option("--order-by <field>", "created_at | updated_at")
     .option("--order <dir>", "asc | desc")
     .action(async (opts, cmd: Command) => {
+      if (opts.orderBy === "default") {
+        throw new InputError(
+          '--order-by default is no longer supported; use "created_at" or "updated_at"',
+        );
+      }
       printJson(
         await clientFrom(cmd).vega.buildTasks({
           limit: opts.limit,

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,7 @@ export type { SkillChild, SkillDirChild, SkillFileChild } from "./utils/skill-tr
 export type {
   BuildMode,
   BuildTask,
+  BuildTaskSummary,
   CatalogConnectionTestRequest,
   CatalogConnectionTestResult,
   CatalogHealthCheckSchedule,
@@ -119,6 +120,8 @@ export type {
   CreateCatalogRequest,
   DslRawQueryRequest,
   QueryPagingMode,
+  ListBuildTasksOptions,
+  ListBuildTasksResponse,
   RawQueryContinuationRequest,
   RawQueryPaging,
   RawQueryRequest,

--- a/test/unit/vega-command.test.ts
+++ b/test/unit/vega-command.test.ts
@@ -1,0 +1,34 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+
+import { vegaCommand } from "../../src/commands/vega.js";
+
+function cli(): Command {
+  const root = new Command("openbkn")
+    .exitOverride()
+    .option("--base-url <url>")
+    .option("--token <t>");
+  root.addCommand(vegaCommand());
+  return root;
+}
+
+describe("vega dataset build-list", () => {
+  it("rejects the removed default ordering before issuing a request", async () => {
+    await expect(
+      cli().parseAsync(
+        [
+          "--base-url",
+          "https://demo.example.com",
+          "--token",
+          "t",
+          "vega",
+          "dataset",
+          "build-list",
+          "--order-by",
+          "default",
+        ],
+        { from: "user" },
+      ),
+    ).rejects.toThrow(/--order-by default is no longer supported/);
+  });
+});

--- a/test/unit/vega-command.test.ts
+++ b/test/unit/vega-command.test.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { vegaCommand } from "../../src/commands/vega.js";
 
@@ -12,8 +12,13 @@ function cli(): Command {
   return root;
 }
 
+afterEach(() => vi.unstubAllGlobals());
+
 describe("vega dataset build-list", () => {
   it("rejects the removed default ordering before issuing a request", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
     await expect(
       cli().parseAsync(
         [
@@ -30,5 +35,6 @@ describe("vega dataset build-list", () => {
         { from: "user" },
       ),
     ).rejects.toThrow(/--order-by default is no longer supported/);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/vega.test.ts
+++ b/test/unit/vega.test.ts
@@ -162,7 +162,7 @@ describe("createBuildTask", () => {
   });
 
   it("lists build tasks with server-side filters", async () => {
-    const f = mockFetch({ entries: [] });
+    const f = mockFetch({ entries: [], total_count: 0 });
     await listBuildTasks(ctx, {
       resourceId: "r-1",
       catalogId: "c-1",
@@ -185,6 +185,50 @@ describe("createBuildTask", () => {
     expect(u.searchParams.get("order")).toBe("asc");
     expect(u.searchParams.get("limit")).toBe("5");
     expect(u.searchParams.get("offset")).toBe("10");
+  });
+
+  it("parses list entries as summaries without detail fields", async () => {
+    mockFetch({
+      entries: [
+        {
+          id: "t-1",
+          resource_id: "r-1",
+          catalog_id: "c-1",
+          status: "completed",
+          mode: "batch",
+          total_count: 10,
+          synced_count: 10,
+          vectorized_count: 8,
+          synced_mark: "mark-1",
+          creator: { id: "u-1", type: "user" },
+          create_time: 100,
+          update_time: 200,
+          failure_detail: "detail-only",
+          index_config: { features: [{ vector: {} }] },
+        },
+      ],
+      total_count: 1,
+    });
+
+    await expect(listBuildTasks(ctx)).resolves.toEqual({
+      entries: [
+        {
+          id: "t-1",
+          resource_id: "r-1",
+          catalog_id: "c-1",
+          status: "completed",
+          mode: "batch",
+          total_count: 10,
+          synced_count: 10,
+          vectorized_count: 8,
+          synced_mark: "mark-1",
+          creator: { id: "u-1", type: "user" },
+          create_time: 100,
+          update_time: 200,
+        },
+      ],
+      total_count: 1,
+    });
   });
 
   it("exposes the persisted batch execute_type on task responses", async () => {

--- a/test/unit/vega.test.ts
+++ b/test/unit/vega.test.ts
@@ -187,7 +187,7 @@ describe("createBuildTask", () => {
     expect(u.searchParams.get("offset")).toBe("10");
   });
 
-  it("parses list entries as summaries without detail fields", async () => {
+  it("parses list entries as typed summaries while preserving forward-compatible fields", async () => {
     mockFetch({
       entries: [
         {
@@ -225,10 +225,20 @@ describe("createBuildTask", () => {
           creator: { id: "u-1", type: "user" },
           create_time: 100,
           update_time: 200,
+          failure_detail: "detail-only",
+          index_config: { features: [{ vector: {} }] },
         },
       ],
       total_count: 1,
     });
+  });
+
+  it("rejects the removed default ordering before making a request", async () => {
+    const f = mockFetch();
+    await expect(listBuildTasks(ctx, { orderBy: "default" as never })).rejects.toThrow(
+      /no longer supported/,
+    );
+    expect(f).not.toHaveBeenCalled();
   });
 
   it("exposes the persisted batch execute_type on task responses", async () => {


### PR DESCRIPTION
## What Changed

- [x] 移除 BuildTask List 的废弃 `default` 排序值，仅支持 `created_at` 和 `updated_at`。
- [x] CLI help 同步移除 `default`；CLI 与 SDK API 均会在请求前拒绝该旧值并给出替代提示。
- [x] 为构建任务列表新增 `BuildTaskSummary` 与 `ListBuildTasksResponse`，在 API 边界解析 Foundry 的固定 List 契约。
- [x] Summary 保留未知字段以支持前向兼容；详情接口继续返回完整 `BuildTask`。
- [x] 导出 List 参数和响应类型，并补充 API 与 CLI 回归测试。

---

## Why

- Related Issue: openbkn-ai/bkn-foundry#752
- Related Feature: [Foundry PR #754](https://github.com/openbkn-ai/bkn-foundry/pull/754)
- Background: Foundry 的构建任务 List 已改为摘要响应并移除 `default` 排序值；SDK 需同步该 API 契约，避免调用方发送无效排序参数，并为列表响应提供明确类型。

---

## How

- Key implementation points: `listBuildTasks` 使用 Zod 解析 `{ entries, total_count }` 与其必返 Summary 字段，同时 `.passthrough()` 未知字段；`getBuildTask` 保持现有完整 `BuildTask` 行为。
- Breaking changes (API, config, database, etc.): `ListBuildTasksOptions.orderBy` 不再接受 `default`；JS/CLI 调用传入该值会在发送请求前收到输入错误；`listBuildTasks` 的返回类型从 `Promise<unknown>` 收紧为 `Promise<ListBuildTasksResponse>`。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable; unit tests fully mock HTTP)
- [ ] Verified in test environment (not run)

Test notes:

- `npm run lint`
- `npm test` — 405 passed, 1 skipped
- `npm run build`

---

## Risk & Rollback

- Potential risks: 使用 TypeScript SDK 或 CLI 且显式传入 `default` 的调用方需要改用 `created_at` 或 `updated_at`；后端若违反已定义的 List 响应契约，SDK 会在解析时明确失败。
- Rollback plan: Revert commits `32ceb55` and `fd5f622`.

---

## Additional Notes

- 与 Foundry PR #754 共同发布，以保持构建任务 List 的排序与响应契约一致。