### PR TITLE
fix(bkn): surface the real cause when create-from-* fails

### DIFF
--- a/docs/product-specs/knowledge-networks.md
+++ b/docs/product-specs/knowledge-networks.md
@@ -23,7 +23,7 @@ There is **no KN-level build**. The legacy `bkn build` (a `job_type:"full"` job 
 
 A KN is the schema/ontology layer; it **references** already-built Catalog resources and does not own a build lifecycle. Rationale: KN→Catalog is one-to-many and the data layer must build independently of the schema layer — driving builds from a KN verb would invert the layering and be ambiguous.
 
-`bkn create-from-catalog` creates Vega resources (one per table), the KN, and its object types (each OT bound to a resource). With `--build` it then **fans out a BuildTask per created resource** (`vega dataset build` semantics) and polls each — replacing the legacy single KN-level job. Build granularity = the resources this KN uses, not the whole catalog.
+`bkn create-from-catalog` binds each catalog table to the Vega resource discovery already created for it (physical resources are no longer created through REST), then creates the KN and its object types (each OT bound to a resource). With `--build` it then **fans out a BuildTask per created resource** (`vega dataset build` semantics) and polls each — replacing the legacy single KN-level job. Build granularity = the resources this KN uses, not the whole catalog.
 
 ## SDK touchpoints
 

--- a/skills/openbkn/references/bkn.md
+++ b/skills/openbkn/references/bkn.md
@@ -6,11 +6,15 @@
 | Schema | `object-type|relation-type|action-type list/get/create/update/delete` (create/update take `--body`/`--body-file`); `action-type query/execute/inputs`. |
 | Metric / concept-group / schedules | `metric …`, `concept-group …`, `action-log …`, `action-schedule …`. (No KN-level build jobs — index builds are Vega build tasks, see [vega.md](vega.md).) |
 | Paths / resources | `relation-type-paths <kn> --body`, `resources`. Both `relation-type-paths` and `subgraph` need `source_object_type_id` + `direction` (`forward` \| `backward` \| `bidirectional`) + `path_length` (1–3) in the body — omit any of them and the backend 400s. |
-| Local package | `push <dir>` (tar → import) `[--build] [--embedding-model <id>]`, `pull <kn> [dir]` (export → extract), `validate <dir>` (offline structural check). |
-| Build a KN | `create-from-catalog <catalog> --name <n> [--tables a,b] [--pk-map t:col] [--build] [--embedding-fields t:col+col] [--embedding-model <id>]`; `create-from-csv <catalog> --files <glob> --name <n> [--table-prefix p] [--build] [--embedding-fields …]`. |
+| Local package | `push <dir>` (tar → import) `[--build] [--embedding-model <name-or-id>]`, `pull <kn> [dir]` (export → extract), `validate <dir>` (offline structural check). |
+| Build a KN | `create-from-catalog <catalog> --name <n> [--tables a,b] [--pk-map t:col] [--build] [--embedding-fields t:col+col] [--embedding-model <name-or-id>]`; `create-from-csv <catalog> --files <glob> --name <n> [--table-prefix p] [--build] [--embedding-fields …]`. |
 
 object-type query strategy (LLM): always pass a small `limit`, paginate with `search_after`, filter with `condition` — wide tables truncate JSON otherwise.
 
 PK detection (create-from-*): `--pk-map t:col` override → schema PK → sample cardinality; a composite schema PK is reported ambiguous (pick one with `--pk-map`) rather than guessed — guards silent data loss.
+
+Table keys in `--tables` / `--pk-map` / `--embedding-fields` take the catalog's table name or a schema-qualified one (`yanfeng_kb.document` matches `document`); an unmatched key errors with the catalog's actual table list. `--embedding-model` takes the model **name** or a numeric model id (resolved to its name before it reaches the resource).
+
+`create-from-csv` needs the dataflow service (it imports one DAG per batch) and says so before Phase 1 if the deploy has no route to it — fall back to loading the CSVs into the catalog's database and running `create-from-catalog`.
 
 Index build is NOT automatic. `push`/`CreateKN` never builds an OpenSearch index; the index lives on the Vega resource. `push --build` reads each object type's `vector` index declaration (`### Property Overrides` / `属性覆盖` `索引配置` cell = `… + vector`, or an `索引`/`Index` column saying `vector`) plus its `### Data Source` resource binding, and submits one batch BuildTask per resource (`build_key_fields` = Incremental Key → Primary Key; `vector(<model>)` or `--embedding-model` pins the model). Object types with no vector field, or an unrendered `{{placeholder}}` resource id, are skipped. For the catalog path, declare fields with `--embedding-fields <table>:<col>[+<col>]`. See [vega.md](vega.md).

--- a/skills/openbkn/references/vega.md
+++ b/skills/openbkn/references/vega.md
@@ -9,7 +9,7 @@
 | `connector-type list` / `connector-type get <type>` | Available connector types. |
 | `sql --query "<sql>"` / `sql -d <json>` | Run SQL or OpenSearch DSL directly against a data source. SQL uses a `{{<resource-id>}}` table placeholder; DSL identifies its resource with top-level `resource_id`. See [§ vega sql](#vega-sql--run-sql--dsl-against-a-data-source). |
 | `resource …` | Vega-backend resources (mirror of top-level `resource`). |
-| `dataset build <resource-id> --mode batch\|streaming [--embedding-fields a,b] [--build-key-fields k] [--embedding-model <id>] [--fulltext-fields a,b] [--fulltext-analyzer <n>] [--execute-type incremental\|full] [--wait] [--timeout <s>]` | Create an index BuildTask. **Index build lives on the resource (one resource = one table); there is no KN-level build.** `batch` requires `--build-key-fields` (else `400 build_key_fields is required for batch mode`). |
+| `dataset build <resource-id> --mode batch\|streaming [--embedding-fields a,b] [--build-key-fields k] [--embedding-model <name-or-id>] [--fulltext-fields a,b] [--fulltext-analyzer <n>] [--execute-type incremental\|full] [--wait] [--timeout <s>]` | Create an index BuildTask. **Index build lives on the resource (one resource = one table); there is no KN-level build.** `batch` requires `--build-key-fields` (else `400 build_key_fields is required for batch mode`). `--embedding-model` takes the model name or a numeric id (resolved to the name — the index config only accepts names). |
 | `dataset build-status <task-id>` | BuildTask status + progress. |
 | `dataset build-list [--status pending,running]` | List BuildTasks. Multiple statuses are OR filters; valid states include `cancelled`. |
 
@@ -91,7 +91,7 @@ Build a `name` field on a MySQL table:
 ```bash
 openbkn resource find --name <table> --exact          # → resource_id
 openbkn vega dataset build <resource-id> --mode batch \
-  --embedding-fields name --build-key-fields <pk-or-time-col> [--embedding-model <id>] --wait
+  --embedding-fields name --build-key-fields <pk-or-time-col> [--embedding-model <name-or-id>] --wait
 ```
 
 ## index is NOT auto-built on `bkn push`

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -7,7 +7,7 @@
  */
 import { refreshAccessToken } from "../auth/oauth.js";
 import type { RequestContext } from "../types.js";
-import { HttpError } from "../utils/errors.js";
+import { HttpError, NonJsonResponseError } from "../utils/errors.js";
 import { stringifyBigIntJSON } from "../utils/json-bigint.js";
 import { buildHeaders } from "./headers.js";
 import { tlsFetch } from "./tls.js";
@@ -78,13 +78,58 @@ export async function request<T = unknown>(
       res = await send();
     }
     const text = await res.text();
+    const contentType = res.headers.get("content-type") ?? "";
     if (!res.ok) {
-      throw new HttpError(res.status, res.statusText, text, hintFor(ctx, res.status, text));
+      // Both hints can apply at once — an auth proxy answers a revoked AppKey
+      // with an HTML 401 — so join them rather than letting either win.
+      const gateway = gatewayHint(url, contentType, text);
+      const hints = [gateway, hintFor(ctx, res.status, text)].filter(Boolean);
+      throw new HttpError(
+        res.status,
+        res.statusText,
+        text,
+        hints.join(" ") || undefined,
+        gateway !== undefined,
+      );
     }
-    return (text ? (init.responseParser ?? JSON.parse)(text) : undefined) as T;
+    if (!text) return undefined as T;
+    try {
+      return (init.responseParser ?? JSON.parse)(text) as T;
+    } catch {
+      // A 2xx can mean either "the service answered in something other than
+      // JSON" or "a proxy answered instead of the service" — an SSO gateway
+      // serves a 200 login page for a dead session. Carry which one it was
+      // rather than flattening it into the message: callers act on it.
+      const gateway = gatewayHint(url, contentType, text);
+      throw new NonJsonResponseError(
+        res.status,
+        contentType,
+        text,
+        gateway ??
+          `${url.pathname} answered HTTP ${res.status} with a non-JSON body (${contentType || "no content-type"}).`,
+        gateway !== undefined,
+      );
+    }
   } finally {
     clearTimeout(timer);
   }
+}
+
+/**
+ * Recognise a reverse-proxy error page. Every backend here speaks JSON, so an
+ * HTML body means the request died at the gateway — usually the service is not
+ * deployed or not routed on this cluster. Without this the caller sees a bare
+ * `HTTP 404` and reads it as "this record does not exist".
+ */
+function gatewayHint(url: URL, contentType: string, body: string): string | undefined {
+  const looksHtml =
+    contentType.includes("html") || /^\s*(<!doctype html|<html)/i.test(body.slice(0, 200));
+  if (!looksHtml) return undefined;
+  return [
+    "The response is an HTML error page, not JSON — the request did not reach the service",
+    `behind ${url.pathname}. That backend is likely not deployed or not routed on this`,
+    "cluster; check with your platform operator.",
+  ].join(" ");
 }
 
 /**

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -6,7 +6,7 @@ import type { RequestContext } from "../types.js";
  * Model-factory client: management reads (mf-model-manager) + runtime
  * invocation (mf-model-api). Passed through as JSON.
  */
-import { HttpError } from "../utils/errors.js";
+import { HttpError, InputError } from "../utils/errors.js";
 import { authFetch } from "./auth-fetch.js";
 import { buildHeaders } from "./headers.js";
 import { request } from "./http.js";
@@ -46,6 +46,40 @@ export function listSmallModels(
 }
 export function getSmallModel(ctx: RequestContext, modelId: string): Promise<unknown> {
   return request(ctx, `${MANAGER}/small-model/get`, { query: { model_id: modelId } });
+}
+
+/**
+ * Resolve a small-model reference to the NAME the rest of the platform expects.
+ *
+ * Every consumer of a small model (`--embedding-model`, `small embeddings`)
+ * keys off `model_name`, but `small list` / `small get-default` lead with the
+ * numeric `model_id` — so the first value a user copies is the one that fails,
+ * downstream and unhelpfully (`embedding model "…" not found`). Mirror
+ * `resolveLlmModelName`: a numeric arg is an id to look up, anything else is
+ * already a name.
+ */
+export async function resolveSmallModelName(ctx: RequestContext, model: string): Promise<string> {
+  if (!/^\d+$/.test(model)) return model;
+  // Only a genuine "no such id" may fall through to the InputError below. An
+  // expired token, a 5xx, or a deploy without model-factory must keep its own
+  // cause — collapsing those into "you typed a bad id" is the exact failure
+  // mode this resolver exists to remove. A gateway 404 is that last case
+  // wearing the status of the first: nothing behind the route saw the id.
+  const detail = (await getSmallModel(ctx, model).catch((e: unknown) => {
+    if (e instanceof HttpError && e.status === 404 && !e.gateway) return undefined;
+    throw e;
+  })) as { model_name?: string; data?: { model_name?: string } } | undefined;
+  const name = detail?.model_name ?? detail?.data?.model_name;
+  if (!name) {
+    throw new InputError(
+      [
+        `No small model found with id ${model}.`,
+        "This flag takes the model name (`model_name`) or a valid model id —",
+        "list them with `openbkn model small list`.",
+      ].join(" "),
+    );
+  }
+  return name;
 }
 
 export interface ChatMessage {

--- a/src/api/resources.ts
+++ b/src/api/resources.ts
@@ -8,6 +8,7 @@
 import type { RequestContext } from "../types.js";
 import { parseBigIntJSON } from "../utils/json-bigint.js";
 import { request } from "./http.js";
+import { resolveSmallModelName } from "./models.js";
 
 const BASE = "/api/vega-backend/v1/resources";
 
@@ -154,17 +155,32 @@ export interface ConfigureResourceIndexOptions {
   fulltextAnalyzer?: string;
 }
 
+/**
+ * Write index intent onto a resource: build keys, vector/fulltext features, and
+ * the analyzer/model defaults.
+ *
+ * Deliberately reaches into mf-model-manager to resolve `embeddingModel`, which
+ * ARCHITECTURE.md would place in `resources/`. The exception is intentional:
+ * all four build entry points (`bkn push --build`, `create-from-catalog
+ * --build`, `create-from-csv --build`, `vega dataset build`) funnel through
+ * here, so resolving once beats four call sites drifting apart. Keep it here.
+ */
 export async function configureResourceIndex(
   ctx: RequestContext,
   id: string,
   opts: ConfigureResourceIndexOptions,
 ): Promise<unknown> {
   const current = firstResource(await getResource(ctx, id));
+  // The index config stores a model NAME; an id gets rejected at build time with
+  // `embedding model "…" not found`, so resolve before it reaches the resource.
+  const embeddingModel = opts.embeddingModel
+    ? await resolveSmallModelName(ctx, opts.embeddingModel)
+    : undefined;
   const schema = (current.schema_definition ?? []).map((prop) => ({ ...prop }));
   const indexConfig: ResourceIndexConfig = {
     ...(current.index_config ?? {}),
     ...(opts.buildKeyFields?.length ? { build_key_fields: opts.buildKeyFields } : {}),
-    ...(opts.embeddingModel ? { default_embedding_model: opts.embeddingModel } : {}),
+    ...(embeddingModel ? { default_embedding_model: embeddingModel } : {}),
     ...(opts.fulltextAnalyzer ? { default_fulltext_analyzer: opts.fulltextAnalyzer } : {}),
   };
 
@@ -173,7 +189,7 @@ export async function configureResourceIndex(
       schema,
       field,
       "vector",
-      opts.embeddingModel ? { embedding_model: opts.embeddingModel } : undefined,
+      embeddingModel ? { embedding_model: embeddingModel } : undefined,
     );
   }
   for (const field of opts.fulltextFields ?? []) {
@@ -246,13 +262,19 @@ function ensureFeature(
   prop.features = features;
 }
 
-function firstResource(result: unknown): ResourceLike {
+/**
+ * Unwrap a single-resource response. `GET /resources/{id}` answers with the same
+ * `{entries:[…]}` envelope as the list endpoint, so reading the response as the
+ * resource itself silently yields a nameless, column-less object — callers must
+ * go through here.
+ */
+export function firstResource<T extends object = ResourceLike>(result: unknown): T {
   if (result && typeof result === "object") {
     const o = result as Record<string, unknown>;
-    if (Array.isArray(o.entries)) return (o.entries[0] ?? {}) as ResourceLike;
-    return o as ResourceLike;
+    if (Array.isArray(o.entries)) return (o.entries[0] ?? {}) as T;
+    return o as T;
   }
-  return {};
+  return {} as T;
 }
 
 export interface DeleteResourceOptions {

--- a/src/commands/bkn.ts
+++ b/src/commands/bkn.ts
@@ -446,7 +446,10 @@ export function bknCommand(): Command {
     .description("Pack a BKN directory into a tar and import it as a knowledge network")
     .option("--branch <name>", "target branch", "main")
     .option("--build", "submit a Vega build task for each object type declaring a vector index")
-    .option("--embedding-model <id>", "small-model ID for declared vector indexes (with --build)")
+    .option(
+      "--embedding-model <name-or-id>",
+      "small-model name (or numeric ID, resolved to its name) for declared vector indexes (with --build)",
+    )
     .action(async (dir: string, opts, cmd: Command) => {
       printJson(
         await clientFrom(cmd).kn.push(dir, {
@@ -498,7 +501,10 @@ export function bknCommand(): Command {
       "--embedding-fields <map>",
       "columns to vectorize per table (with --build): '<table>:<col>[+<col>...][,...]'",
     )
-    .option("--embedding-model <id>", "small-model ID for the vector index (with --build)")
+    .option(
+      "--embedding-model <name-or-id>",
+      "small-model name (or numeric ID, resolved to its name) for the vector index (with --build)",
+    )
     .option("--no-rollback", "keep a partially-created KN on failure")
     .action(async (catalogId: string, opts, cmd: Command) => {
       printJson(
@@ -542,7 +548,10 @@ export function bknCommand(): Command {
       "--embedding-fields <map>",
       "columns to vectorize per table (with --build): '<table>:<col>[+<col>...][,...]'",
     )
-    .option("--embedding-model <id>", "small-model ID for the vector index (with --build)")
+    .option(
+      "--embedding-model <name-or-id>",
+      "small-model name (or numeric ID, resolved to its name) for the vector index (with --build)",
+    )
     .option("--no-rollback", "keep a partially-created KN on failure")
     .action(async (catalogId: string, opts, cmd: Command) => {
       printJson(

--- a/src/commands/vega.ts
+++ b/src/commands/vega.ts
@@ -485,7 +485,10 @@ export function vegaCommand(): Command {
       "--build-key-fields <list>",
       "comma-separated key fields (batch: time; streaming: row id)",
     )
-    .option("--embedding-model <id>", "small-model ID for the vector index")
+    .option(
+      "--embedding-model <name-or-id>",
+      "default small-model name (a numeric ID is resolved to its name)",
+    )
     .option("--fulltext-fields <list>", "comma-separated fields for fulltext index")
     .option("--fulltext-analyzer <name>", "fulltext analyzer")
     .option("--execute-type <type>", "batch execution type: incremental | full")

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,11 @@ export {
   DEFAULT_LIST_LIMIT,
   DEFAULT_QUERY_LIMIT,
 } from "./types.js";
-export { HttpError, InputError, ToolError } from "./utils/errors.js";
+export { HttpError, InputError, NonJsonResponseError, ToolError } from "./utils/errors.js";
+// The shape `kn.createFromCatalog` / `kn.createFromCsv` stamp onto a failure
+// that left a knowledge network behind. Documented as part of what they throw,
+// so it has to be nameable from the package, not just inside it.
+export type { PartialKnMarked } from "./resources/bkn-create.js";
 export { parseBigIntJSON, stringifyBigIntJSON } from "./utils/json-bigint.js";
 // A long-lived embedder opens managed interactions the same way the CLI does,
 // and needs the same way to hand them back.

--- a/src/resources/bkn-create.ts
+++ b/src/resources/bkn-create.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenBKN. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See the LICENSE file in the project root.
 
-import { executeDataflow } from "../api/dataflow.js";
+import { executeDataflow, listDataflows } from "../api/dataflow.js";
 /**
  * `bkn create-from-catalog` orchestration. Build a knowledge network from a
  * Vega catalog's tables:
@@ -21,9 +21,10 @@ import {
   createObjectTypes,
   deleteKnowledgeNetwork,
 } from "../api/knowledge-networks.js";
+import { resolveSmallModelName } from "../api/models.js";
 import {
   configureResourceIndex,
-  findResource,
+  firstResource,
   getResource,
   listResources,
   queryResource,
@@ -38,6 +39,7 @@ import {
   resolveFiles,
   splitBatches,
 } from "../utils/csv-import.js";
+import { HttpError, InputError, NonJsonResponseError, formatError } from "../utils/errors.js";
 import {
   type TableColumn,
   type TableInfo,
@@ -50,6 +52,26 @@ export interface CreateFromCatalogOptions {
   catalogId: string;
   name: string;
   tables?: string[];
+  /**
+   * What an unmatched `tables` entry means. `error` (the default) suits a
+   * user-typed `--tables`; `skip` suits a list this SDK derived itself, where a
+   * missing table means catalog discovery lagged rather than a wrong name.
+   *
+   * The names skipped this way also become the only `pkMap` / `embeddingFields`
+   * keys allowed to be dropped — every other unresolvable key stays fatal, so a
+   * typo can never quietly turn a PK override back into a guess.
+   */
+  missingTables?: "error" | "skip";
+  /**
+   * Table names the caller knows are absent from the catalog for a reason it
+   * already reported — a CSV whose import failed.
+   *
+   * Unlike `missingTables`, these are forgiven regardless of that setting: an
+   * entry naming one is dropped from `tables`, `pkMap` and `embeddingFields`
+   * alike, even when `tables` was typed by hand. Failing on a name this run
+   * just reported would strand whatever it did manage to write.
+   */
+  absentTables?: string[];
   pkMap?: Record<string, string>;
   build?: boolean;
   /** Per-table resource columns to vectorize (sets resource schema index features). */
@@ -61,11 +83,44 @@ export interface CreateFromCatalogOptions {
   onProgress?: (msg: string) => void;
 }
 
+/**
+ * Stamped onto the error `createFromCatalog` throws when the run left a
+ * knowledge network behind — either because `noRollback` was set or because the
+ * rollback delete was refused for a reason that leaves it standing.
+ *
+ * Absent means no *network* was left, and only that: every input check runs
+ * before the network is created, so most failures create nothing at all. It
+ * says nothing about the `build` loop, whose per-table index config and build
+ * tasks live on Vega resources outside the network and are never rolled back.
+ *
+ * Part of what this function throws, so callers may read it to tell the user
+ * what to clean up (`createFromCsv` does). Deliberately a plain property rather
+ * than a new error class: it is one fact about one call, and wrapping the error
+ * would cost its type — an `HttpError` here still has to arrive as one.
+ */
+export interface PartialKnMarked {
+  partialKnId?: string;
+}
+
 interface ResourceDetail {
   id?: string;
   name?: string;
   source_metadata?: { columns?: Array<Record<string, unknown>> };
+  schema_definition?: Array<{ name?: unknown }>;
   primary_keys?: unknown;
+}
+
+/**
+ * Property names a resource's index features may reference.
+ *
+ * Deliberately read off `schema_definition`, not `source_metadata.columns`:
+ * those are two different lists, and `ensureFeature` matches against the former.
+ * Validating against the latter would pass names the write then rejects.
+ */
+function featureFields(detail: ResourceDetail): string[] {
+  return (detail.schema_definition ?? [])
+    .map((p) => String(p?.name ?? ""))
+    .filter((n) => n.length > 0);
 }
 
 function columnIsPk(col: Record<string, unknown>): boolean {
@@ -96,6 +151,123 @@ function toTableInfo(detail: ResourceDetail): TableInfo {
   };
 }
 
+/**
+ * Resource details read at once. Matches the backend's own default page size —
+ * the bound this fan-out used to inherit from it, before the listing started
+ * asking for every table.
+ */
+const DETAIL_READ_BATCH = 20;
+
+const bareName = (n: string) => n.slice(n.lastIndexOf(".") + 1);
+const sameTable = (a: string, b: string) => bareName(a).toLowerCase() === bareName(b).toLowerCase();
+
+/**
+ * Why a table key did not resolve. Only `unknown` is ever forgiven: an absent
+ * name can be one the run already reported, but a name matching two catalog
+ * entries is a condition no retry or re-discover clears, and dropping it would
+ * silently leave a table out of the network.
+ *
+ * An `InputError` because that is what it is — the user's flag naming something
+ * that is not there — which also gives it the exit code every other bad-input
+ * failure on this path uses.
+ */
+class TableKeyError extends InputError {
+  readonly kind: "unknown" | "ambiguous" | "duplicate";
+
+  constructor(kind: "unknown" | "ambiguous" | "duplicate", message: string) {
+    super(message);
+    this.name = "TableKeyError";
+    this.kind = kind;
+  }
+}
+
+/**
+ * Canonical catalog table name for a user-supplied key, or a throw naming the
+ * tables that actually exist. Vega may list a bare table name or a
+ * schema-qualified one, and users copy whichever their database shows them
+ * (`yanfeng_kb.document` vs `document`), so match on the bare name in both
+ * directions — case-insensitively, since PG/Oracle fold identifiers on
+ * read-back. An exact hit always wins, and an ambiguous loose hit is reported
+ * rather than picked. Never fail with an "unknown table" that lists no known
+ * tables.
+ */
+function resolveTableKey(names: string[], key: string, flag: string, catalog?: string[]): string {
+  const exact = names.filter((n) => n === key);
+  if (exact.length === 1) return exact[0] as string;
+  const hits = exact.length > 0 ? exact : names.filter((n) => sameTable(n, key));
+  if (hits.length === 1) return hits[0] as string;
+  if (hits.length > 1) {
+    throw new TableKeyError(
+      "ambiguous",
+      `${flag} '${key}' matches several tables (${hits.join(", ")}). Use the exact name.`,
+    );
+  }
+  // When the run is narrower than the catalog, say so: naming only the selected
+  // tables reads as "your table does not exist" for one that plainly does.
+  const unselected = (catalog ?? []).filter((n) => !names.includes(n));
+  const also = unselected.length
+    ? ` The catalog also has ${unselected.join(", ")} — add it with --tables to use it here.`
+    : "";
+  throw new TableKeyError(
+    "unknown",
+    `${flag} references unknown table '${key}'. Tables in this run: ${names.join(", ") || "(none)"}.${also}`,
+  );
+}
+
+/**
+ * Re-key a per-table option map onto canonical table names. Two keys that
+ * normalize to the same table are reported, not silently collapsed — last-write
+ * wins would drop a value the caller can see no trace of.
+ *
+ * `skippable` names the keys allowed to be dropped (through `onSkip`) instead
+ * of throwing — the tables a caller-derived list knows were imported but not
+ * yet registered. Everything else still fails the run: a misspelled
+ * `--pk-map documnet:id` must not quietly become "no override", or PK detection
+ * goes back to guessing the key it exists to never guess (see pk-detection).
+ * `"any"` is for genuinely best-effort maps, where a miss costs a fallback.
+ */
+function canonicalizeTableMap<T>(
+  map: Record<string, T> | undefined,
+  names: string[],
+  flag: string,
+  opts: {
+    skippable?: string[] | "any";
+    catalog?: string[];
+    onSkip?: (key: string, reason: string) => void;
+  } = {},
+): Record<string, T> {
+  const skippable = opts.skippable;
+  const maySkip = (key: string, e: unknown) => {
+    if (skippable === "any") return true;
+    // A name the run already reported may be dropped; ambiguity and duplicates
+    // are conditions the caller must resolve, whatever the table's state.
+    if (!(e instanceof TableKeyError) || e.kind !== "unknown") return false;
+    return (skippable ?? []).some((n) => sameTable(n, key));
+  };
+  const out: Record<string, T> = {};
+  const origin: Record<string, string> = {};
+  for (const [key, value] of Object.entries(map ?? {})) {
+    let canonical: string;
+    try {
+      canonical = resolveTableKey(names, key, flag, opts.catalog);
+      const prev = origin[canonical];
+      if (prev !== undefined && prev !== key) {
+        throw new TableKeyError(
+          "duplicate",
+          `${flag} has two entries for table '${canonical}' ('${prev}' and '${key}') — keep one.`,
+        );
+      }
+    } catch (e) {
+      if (!maySkip(key, e)) throw e;
+      opts.onSkip?.(key, e instanceof Error ? e.message : String(e));
+      continue;
+    }
+    origin[canonical] = key;
+    out[canonical] = value;
+  }
+  return out;
+}
+
 function asArray(v: unknown): unknown[] {
   if (Array.isArray(v)) return v;
   if (v && typeof v === "object") {
@@ -124,11 +296,26 @@ export async function createFromCatalog(
   opts: CreateFromCatalogOptions,
 ): Promise<unknown> {
   const log = opts.onProgress ?? (() => {});
-  const pkMap = opts.pkMap ?? {};
+  // Validate the embedding model before anything is written. Resolution lives
+  // inside `configureResourceIndex`, i.e. step 5 — after the KN and its object
+  // types exist, and after `create-from-csv` has written every row — so a bad
+  // id used to cost a full import plus a rollback. Doing it here also means the
+  // build loop resolves once rather than once per table (a resolved name is not
+  // numeric, so the inner call short-circuits).
+  const embeddingModel =
+    opts.build && opts.embeddingModel
+      ? await resolveSmallModelName(ctx, opts.embeddingModel)
+      : opts.embeddingModel;
 
   // 1. List catalog tables, scanning once if the catalog is empty.
+  //    `limit: -1` (NO_LIMIT), not the backend's default page of 20: this list
+  //    decides which tables become object types AND is the source of every
+  //    "tables in this run" message below, so a truncated page would drop the
+  //    21st table from the network without a word and then deny it exists.
   const listTables = () =>
-    listResources(ctx, { datasourceId: opts.catalogId, category: "table" }).then(asArray);
+    listResources(ctx, { datasourceId: opts.catalogId, category: "table", limit: -1 }).then(
+      asArray,
+    );
   let summaries = await listTables();
   if (summaries.length === 0) {
     log("No tables found; scanning catalog metadata...");
@@ -137,47 +324,162 @@ export async function createFromCatalog(
   }
   if (summaries.length === 0) throw new Error("No tables available in catalog after scan.");
 
-  // Resolve full column metadata per summary; filter to --tables if given.
-  const details = await Promise.all(
-    summaries.map(async (s) => {
-      const id = (s as { id?: string }).id;
-      const detail = id ? await getResource(ctx, id) : s;
-      return toTableInfo(detail as ResourceDetail);
-    }),
-  );
-  const targets =
-    opts.tables && opts.tables.length > 0
-      ? details.filter((t) => opts.tables?.includes(t.name))
-      : details;
-  if (targets.length === 0) throw new Error("No matching tables to build from.");
+  // Resolve full column metadata per summary. The detail response carries the
+  // same `{entries:[…]}` envelope as the list — unwrap it, or every table ends
+  // up nameless and column-less and only fails much later, in PK detection.
+  //
+  // In batches, not one `Promise.all` over the catalog: the default page of 20
+  // dropped above was also what kept this fan-out small, and a few hundred
+  // simultaneous reads earn a rate-limit or a pool timeout whose message says
+  // nothing about how many tables were asked for at once.
+  const readDetail = async (s: unknown) => {
+    const summary = s as { id?: string; name?: string };
+    const detail = summary.id
+      ? firstResource<ResourceDetail>(await getResource(ctx, summary.id))
+      : (summary as ResourceDetail);
+    const info = toTableInfo(detail);
+    return {
+      ...info,
+      name: info.name || String(summary.name ?? ""),
+      resourceId: summary.id,
+      featureFields: featureFields(detail),
+    };
+  };
+  const details: Array<Awaited<ReturnType<typeof readDetail>>> = [];
+  for (const batch of splitBatches(summaries, DETAIL_READ_BATCH)) {
+    details.push(...(await Promise.all(batch.map(readDetail))));
+  }
+  // An empty identifier must not travel any further: everything downstream keys
+  // off the table name, and a blank one poisons --tables, --pk-map and PK
+  // detection alike with errors that never mention the real cause. Drop those
+  // resources with a warning rather than aborting — one half-discovered row in
+  // a catalog should not block every other table from becoming a KN.
+  const named = details.filter((t) => t.name);
+  const unnamedIds = details.filter((t) => !t.name).map((t) => t.resourceId ?? "?");
+  const unnamedNote = unnamedIds.length
+    ? ` ${unnamedIds.length} nameless table resource(s) were ignored (ids: ${unnamedIds.join(", ")}); re-run \`openbkn vega catalog discover\` if a table you need is missing.`
+    : "";
+  if (unnamedIds.length > 0) log(`Ignoring nameless table resource(s): ${unnamedIds.join(", ")}.`);
+  if (named.length === 0) {
+    throw new Error(
+      [
+        `Catalog ${opts.catalogId} returned ${details.length} table resource(s), none with a name`,
+        `(ids: ${unnamedIds.join(", ")}).`,
+        "Re-run `openbkn vega catalog discover` for this catalog and retry.",
+      ].join(" "),
+    );
+  }
+  const allNames = named.map((t) => t.name);
 
-  // Validate --pk-map references and resolve a PK per table BEFORE side effects.
-  for (const name of Object.keys(pkMap)) {
-    if (!targets.some((t) => t.name === name)) {
-      throw new Error(`--pk-map references unknown table '${name}'.`);
+  // Filter to --tables if given; accept schema-qualified names. Two kinds of
+  // miss are forgiven: any miss under a caller-derived list (the CSV path,
+  // where a table the catalog has not registered yet is a lagging scan rather
+  // than a typo), and — even for a hand-typed --tables — a name this run has
+  // already reported as absent, since failing on it would strand rows already
+  // written over something the user was told about. Ambiguity is never
+  // forgiven: no retry clears it, and dropping it loses a table in silence.
+  const absent = opts.absentTables ?? [];
+  const missing: string[] = [];
+  const selected = new Set<string>();
+  for (const key of opts.tables ?? []) {
+    try {
+      selected.add(resolveTableKey(allNames, key, "--tables", undefined));
+    } catch (e) {
+      const forgivable =
+        e instanceof TableKeyError &&
+        e.kind === "unknown" &&
+        (opts.missingTables === "skip" || absent.some((n) => sameTable(n, key)));
+      if (!forgivable) throw e;
+      missing.push(key);
     }
   }
-  const tablePk: Record<string, string> = {};
+  if (missing.length > 0) {
+    log(`Skipping ${missing.length} table(s) not in the catalog: ${missing.join(", ")}.`);
+  }
+  const targets = opts.tables?.length ? named.filter((t) => selected.has(t.name)) : named;
+  if (targets.length === 0) {
+    throw new Error(
+      `No matching tables to build from.${missing.length ? ` Not in the catalog: ${missing.join(", ")}.` : ""}${unnamedNote}`,
+    );
+  }
+  const targetNames = targets.map((t) => t.name);
+
+  // Validate --pk-map / --embedding-fields references BEFORE any side effect.
+  // Only the names already skipped above may be dropped here: those tables are
+  // imported-but-not-yet-registered, and failing on them would strand rows
+  // already written. A key naming anything else is a typo and stays fatal —
+  // silently dropping a PK override hands the key back to detection, which is
+  // the guess this whole path exists to avoid.
+  const dropKey = (flag: string) => (key: string, reason: string) =>
+    log(`Dropping ${flag} entry '${key}': ${reason}`);
+  const skippable = [...missing, ...absent];
+  const pkMap = canonicalizeTableMap(opts.pkMap, targetNames, "--pk-map", {
+    skippable,
+    catalog: allNames,
+    onSkip: dropKey("--pk-map"),
+  });
+  const embeddingFields = canonicalizeTableMap(
+    opts.embeddingFields,
+    targetNames,
+    "--embedding-fields",
+    { skippable, catalog: allNames, onSkip: dropKey("--embedding-fields") },
+  );
+  // Its column names too: `ensureFeature` is the only thing that checks them,
+  // and it runs in step 5 — so a typo used to surface after the import, the KN
+  // and its object types, with the earlier tables' writes already landed and
+  // not rolled back. Compare against `schema_definition`, which is what
+  // `ensureFeature` matches; `columns` is a different list.
+  if (opts.build) {
+    for (const t of targets) {
+      const fields = embeddingFields[t.name];
+      if (!fields?.length || t.featureFields.length === 0) continue;
+      const unknown = fields.filter((f) => !t.featureFields.includes(f));
+      if (unknown.length > 0) {
+        throw new InputError(
+          [
+            `--embedding-fields names ${unknown.join(", ")} on table '${t.name}',`,
+            "which its Vega resource does not expose.",
+            `Indexable fields: ${t.featureFields.join(", ")}.`,
+          ].join(" "),
+        );
+      }
+    }
+  }
+  // Always best-effort: a sample keyed off a name the catalog does not use
+  // falls back to a live query rather than failing the run.
+  const providedSamples = canonicalizeTableMap(opts.sampleRows, targetNames, "sampleRows", {
+    skippable: "any",
+  });
+  // Keyed by resource id, not name: two schemas may hold the same table name,
+  // and a name-keyed map would hand the second table the first one's key.
+  const tablePk = new Map<string, string>();
   for (const t of targets) {
+    // No columns means the resource carries no introspected schema — say that,
+    // rather than letting detection report it as a sampling problem.
+    if (t.columns.length === 0) {
+      throw new Error(
+        [
+          `Table '${t.name}' has no column metadata on its Vega resource (${t.resourceId ?? "?"}).`,
+          "Re-run `openbkn vega catalog discover` for this catalog and retry.",
+        ].join(" "),
+      );
+    }
     const override = pkMap[t.name];
     if (override && !t.columns.some((c) => c.name === override)) {
-      throw new Error(
+      throw new InputError(
         `--pk-map '${override}' for table '${t.name}' is not a column. ` +
           `Columns: ${t.columns.map((c) => c.name).join(", ")}`,
       );
     }
     // Prefer caller-supplied samples (CSV import) for cardinality detection.
-    let res = resolvePrimaryKey(t, opts.sampleRows?.[t.name], override);
+    let res = resolvePrimaryKey(t, providedSamples[t.name], override);
     if (res.pk === null && res.source === "sample") {
       // Fall back to a live row sample.
-      const summary = summaries.find((s) => (s as { name?: string }).name === t.name) as
-        | { id?: string }
-        | undefined;
-      const rows = summary?.id ? await sampleRows(ctx, summary.id) : [];
+      const rows = t.resourceId ? await sampleRows(ctx, t.resourceId) : [];
       res = resolvePrimaryKey(t, rows, override);
     }
     if (res.source === "ambiguous") {
-      throw new Error(
+      throw new InputError(
         `Table '${t.name}' has a composite primary key (${(res.ambiguous ?? []).join(", ")}). ` +
           `BKN object types take one key — pick with --pk-map ${t.name}:<column>.`,
       );
@@ -190,20 +492,16 @@ export async function createFromCatalog(
         }),
       );
     }
-    tablePk[t.name] = res.pk;
+    tablePk.set(t.resourceId ?? t.name, res.pk);
   }
 
-  // 2. Create a vega resource per table (idempotent).
+  // 2. Bind each table to the vega resource it was listed from (physical
+  //    resources are not created through REST anymore). Read the id off the
+  //    table itself, never through a name-keyed map: two schemas may hold the
+  //    same table name, and one binding would then silently serve both.
   log(`Resolving discovered resources for ${targets.length} table(s)...`);
-  const viewMap: Record<string, string> = {};
   for (const t of targets) {
-    const found = asArray(
-      await findResource(ctx, t.name, { datasourceId: opts.catalogId, exact: true }),
-    );
-    const existingId = (found[0] as { id?: string } | undefined)?.id;
-    if (existingId) {
-      viewMap[t.name] = existingId;
-    } else {
+    if (!t.resourceId) {
       throw new Error(
         `Table '${t.name}' has no discovered Vega resource. Run catalog discover and retry.`,
       );
@@ -222,11 +520,11 @@ export async function createFromCatalog(
   try {
     // 4. Batch-create object types (all-or-nothing).
     const entries = targets.map((t) => {
-      const pk = tablePk[t.name] as string;
+      const pk = tablePk.get(t.resourceId ?? t.name) as string;
       return {
         branch: "main",
         name: t.name,
-        data_source: { type: "resource", id: viewMap[t.name] },
+        data_source: { type: "resource", id: t.resourceId },
         primary_keys: [pk],
         display_key: detectDisplayKey(t, pk),
         data_properties: t.columns.map((c) => ({
@@ -245,14 +543,14 @@ export async function createFromCatalog(
     if (opts.build) {
       log("Submitting build tasks...");
       for (const t of targets) {
-        const embedding = opts.embeddingFields?.[t.name];
-        await configureResourceIndex(ctx, viewMap[t.name] as string, {
-          buildKeyFields: [tablePk[t.name] as string],
+        const embedding = embeddingFields[t.name];
+        await configureResourceIndex(ctx, t.resourceId as string, {
+          buildKeyFields: [tablePk.get(t.resourceId ?? t.name) as string],
           ...(embedding && embedding.length > 0 ? { embeddingFields: embedding } : {}),
-          ...(opts.embeddingModel ? { embeddingModel: opts.embeddingModel } : {}),
+          ...(embeddingModel ? { embeddingModel } : {}),
         });
         const task = (await createBuildTask(ctx, {
-          resource_id: viewMap[t.name] as string,
+          resource_id: t.resourceId as string,
           mode: "batch",
         })) as { id?: string };
         builds.push({ table: t.name, taskId: String(task.id ?? "") });
@@ -263,10 +561,16 @@ export async function createFromCatalog(
     return {
       kn_id: knId,
       kn_name: opts.name,
-      object_types: targets.map((t) => ({ name: t.name, pk: tablePk[t.name] })),
+      object_types: targets.map((t) => ({ name: t.name, pk: tablePk.get(t.resourceId ?? t.name) })),
       build_tasks: builds,
     };
-  } finally {
+  } catch (e) {
+    // Roll back here rather than in a `finally`, so the outcome is known before
+    // the error leaves: a rollback that fails leaves the network behind just as
+    // surely as `--no-rollback` does, and the caller is told which happened
+    // instead of inferring it from the flag. With every input check now ahead
+    // of the KN, most failures never create one at all.
+    let leftBehind: string | undefined = rollbackKn;
     if (rollbackKn !== undefined) {
       if (opts.noRollback) {
         log(`Leaving partial KN ${rollbackKn} in place (--no-rollback).`);
@@ -274,11 +578,46 @@ export async function createFromCatalog(
         log(`Rolling back KN ${rollbackKn}...`);
         try {
           await deleteKnowledgeNetwork(ctx, rollbackKn);
-        } catch {
-          /* surface the original error, not the rollback failure */
+          leftBehind = undefined;
+        } catch (rollbackError) {
+          // Surface the original error, not this one — but a bare `catch {}`
+          // throws away the two things that decide what to say next.
+          //
+          // A plain 404 means the network is not there, so there is nothing to
+          // report cleaning up (the same reading of a bare-vs-gateway 404 this
+          // path already applies to model ids). Any other reason leaves it
+          // standing, and which reason it was decides what the user can do —
+          // 403 says the key cannot delete it either, 5xx says try later — so
+          // log that rather than drop it. Explaining the rollback and
+          // preserving the original failure are not in conflict.
+          // A 2xx that simply was not JSON (`200 text/plain "OK"` is a common
+          // way to answer a DELETE) means the delete went through: this path
+          // raises `NonJsonResponseError` for it, and reading that as "still
+          // there" would send the user after a network that is gone. Same
+          // caveat as the 404 above, and for the same reason: a proxy's 200
+          // login page never reached the service, so the network is still
+          // standing — and staying quiet about that is worse than fussing.
+          const gone =
+            (rollbackError instanceof HttpError &&
+              rollbackError.status === 404 &&
+              !rollbackError.gateway) ||
+            (rollbackError instanceof NonJsonResponseError &&
+              rollbackError.status < 300 &&
+              !rollbackError.gateway);
+          if (gone) {
+            leftBehind = undefined;
+          } else {
+            log(
+              `Rollback of KN ${rollbackKn} failed (${formatError(rollbackError)}); it is still there.`,
+            );
+          }
         }
       }
     }
+    if (leftBehind !== undefined && e && typeof e === "object") {
+      (e as PartialKnMarked).partialKnId = leftBehind;
+    }
+    throw e;
   }
 }
 
@@ -286,6 +625,60 @@ export interface ImportCsvResult {
   tables: string[];
   failed: string[];
   sampleRows: Record<string, Array<Record<string, string | null>>>;
+}
+
+/**
+ * Fail before Phase 1 when the deploy has no dataflow backend.
+ *
+ * CSV import runs one dataflow DAG per batch, so a missing service turns into
+ * one identical 404 per table, hundreds of rows in — long past the point where
+ * the user can tell "this deploy can't do that" from "my data is wrong".
+ *
+ * Only a gateway page or a 5xx counts as "no service": the probe reads
+ * `automation/v2`, while the import runs on `v1`, so a plain JSON 404 means the
+ * service answered — it just does not serve this listing. Blocking on that
+ * would ground an import whose own endpoints are fine, so the probe steps
+ * aside and lets the real call speak (see the same rule in `models.ts`).
+ */
+async function ensureDataflowAvailable(
+  ctx: RequestContext,
+  log: (m: string) => void,
+): Promise<void> {
+  try {
+    await listDataflows(ctx);
+  } catch (e) {
+    // Both halves ask the same question — was it the service that answered?
+    // `request()` raises `NonJsonResponseError` only for a 2xx, so here it
+    // splits into a proxy page (nothing is deployed) and a service replying in
+    // something other than JSON (it is there; this listing just is not JSON).
+    // Treating the second as an absent service is the JSON-404 false positive
+    // again, wearing a different body.
+    const missing =
+      (e instanceof NonJsonResponseError && e.gateway) ||
+      (e instanceof HttpError && (e.gateway || [501, 502, 503].includes(e.status)));
+    if (!missing) {
+      // An auth refusal is as conclusive as an absent service and just as
+      // wasteful to discover per batch — surface it now, with its own cause and
+      // exit code, rather than after reading every CSV. Name the refuser first:
+      // the error alone reads as a platform-wide auth problem, when the token
+      // may be fine everywhere except automation.
+      if (e instanceof HttpError && (e.status === 401 || e.status === 403)) {
+        log(`The dataflow service refused the preflight (HTTP ${e.status}); nothing was imported.`);
+        throw e;
+      }
+      log(`Dataflow preflight inconclusive (${formatError(e)}); continuing.`);
+      return;
+    }
+    throw new Error(
+      [
+        `The dataflow service is not available on this deploy (${formatError(e)}).`,
+        "`create-from-csv` imports through it, so it cannot run here.",
+        "Alternative: load the CSVs into the catalog's database directly, run",
+        "`openbkn vega catalog discover <catalog-id>`, then",
+        "`openbkn bkn create-from-catalog <catalog-id>`.",
+      ].join(" "),
+    );
+  }
 }
 
 /**
@@ -306,6 +699,7 @@ export async function importCsvToCatalog(
 ): Promise<ImportCsvResult> {
   const log = opts.onProgress ?? (() => {});
   const batchSize = opts.batchSize ?? 500;
+  await ensureDataflowAvailable(ctx, log);
   const paths = await resolveFiles(opts.files);
 
   // The database-write step needs the catalog's connector type.
@@ -347,7 +741,9 @@ export async function importCsvToCatalog(
       tables.push(tableName);
       sampleRows[tableName] = rows.slice(0, 100);
     } catch (e) {
-      log(`[${tableName}] import failed: ${e instanceof Error ? e.message : String(e)}`);
+      // `formatError`, not `e.message`: the message alone is a bare `HTTP 404`,
+      // dropping both the server body and any next-step hint that came with it.
+      log(`[${tableName}] import failed: ${formatError(e)}`);
       failed.push(tableName);
     }
   }
@@ -377,6 +773,12 @@ export async function createFromCsv(
   opts: CreateFromCsvOptions,
 ): Promise<unknown> {
   const log = opts.onProgress ?? (() => {});
+  // Before Phase 1, not inside Phase 2's build step: a bad model id must not
+  // cost a full CSV import whose rows then sit in the database with no KN.
+  const embeddingModel =
+    opts.build && opts.embeddingModel
+      ? await resolveSmallModelName(ctx, opts.embeddingModel)
+      : opts.embeddingModel;
   log("Phase 1: importing CSVs...");
   const imported = await importCsvToCatalog(ctx, {
     catalogId: opts.catalogId,
@@ -393,13 +795,40 @@ export async function createFromCsv(
     catalogId: opts.catalogId,
     name: opts.name,
     tables: opts.tables && opts.tables.length > 0 ? opts.tables : imported.tables,
+    // The derived list comes from `importCsvToCatalog`, whose closing discover
+    // is best-effort — a table it has not registered yet must not sink a run
+    // whose rows are already in the database. A file whose import failed is
+    // already reported above, so an option keyed to it costs its own entry too.
+    absentTables: imported.failed,
+    ...(opts.tables && opts.tables.length > 0 ? {} : { missingTables: "skip" as const }),
     pkMap: opts.pkMap,
     build: opts.build,
     embeddingFields: opts.embeddingFields,
-    embeddingModel: opts.embeddingModel,
+    embeddingModel,
     noRollback: opts.noRollback,
     sampleRows: imported.sampleRows,
     onProgress: log,
+  }).catch((e: unknown) => {
+    // Past this line the rows are in the database, so no Phase 2 failure may
+    // read as "fix the flag and run this again" — that would import them a
+    // second time. Only this function knows that; `createFromCatalog` cannot
+    // tell a CSV import from any other caller, so the guidance is added here
+    // rather than guessed there, and every failure gets it, not a chosen few.
+    //
+    // Said as a log line, with the error rethrown untouched. Rewrapping cost an
+    // HttpError its status, hint and `gateway` flag, and turned exit code 3
+    // (auth) into 1 — the message would have been worth less than what it took.
+    const partialKn = (e as PartialKnMarked | null)?.partialKnId;
+    log(
+      [
+        "The CSV rows are already imported — re-running `create-from-csv` would duplicate them.",
+        partialKn
+          ? `Delete the partial knowledge network ${partialKn}, fix the problem, then continue with`
+          : "Fix the problem and continue with",
+        `\`openbkn bkn create-from-catalog ${opts.catalogId}\`.`,
+      ].join(" "),
+    );
+    throw e;
   });
   return {
     imported_tables: imported.tables,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -10,14 +10,61 @@ export class HttpError extends Error {
   readonly body: string;
   /** Optional next-step guidance, overriding the status default (e.g. AppKey re-issue). */
   readonly hint?: string;
+  /**
+   * The response was a proxy error page, so the status describes the gateway,
+   * not the service. Callers that special-case a status — a 404 read as "no
+   * such record" — must not do so when this is set: nothing behind the route
+   * ever saw the request.
+   *
+   * Only `request()` sets it. The handful of sites that construct this error
+   * around a raw `fetch` (streaming chat, uploads, MCP transports) leave it
+   * `false`, so a false value means "not detected", never "definitely not a
+   * gateway" — treat it as a positive signal only.
+   */
+  readonly gateway: boolean;
 
-  constructor(status: number, statusText: string, body: string, hint?: string) {
+  constructor(status: number, statusText: string, body: string, hint?: string, gateway = false) {
     super(`HTTP ${status} ${statusText}`);
     this.name = "HttpError";
     this.status = status;
     this.statusText = statusText;
     this.body = body;
     this.hint = hint;
+    this.gateway = gateway;
+  }
+}
+
+/**
+ * Raised when a response body is not the JSON the API contract promises.
+ *
+ * Usually a gateway/proxy page — the request never reached the service — but
+ * not always: a service may answer a DELETE with `200 text/plain "OK"`. Which
+ * one it was decides whether the status describes anything the service did, so
+ * read {@link NonJsonResponseError.gateway} before acting on it.
+ */
+export class NonJsonResponseError extends Error {
+  readonly status: number;
+  readonly contentType: string;
+  readonly body: string;
+  /**
+   * The body is a proxy error page, so the request never reached the service.
+   * The complement is a service that answered in something other than JSON —
+   * `200 text/plain "OK"` to a DELETE, say — where the status still describes
+   * what the service did. Callers reading a 2xx as "it worked" must check this
+   * first: an SSO proxy answers a dead session with a `200` login page.
+   *
+   * Set by `request()`, the only place with the response in hand; see
+   * {@link HttpError.gateway} for why `false` means "not detected".
+   */
+  readonly gateway: boolean;
+
+  constructor(status: number, contentType: string, body: string, message: string, gateway = false) {
+    super(message);
+    this.name = "NonJsonResponseError";
+    this.status = status;
+    this.contentType = contentType;
+    this.body = body;
+    this.gateway = gateway;
   }
 }
 
@@ -38,8 +85,8 @@ export class ToolError extends Error {
 
 /** Raised for bad CLI/SDK input before any request is made. */
 export class InputError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = "InputError";
   }
 }
@@ -56,6 +103,9 @@ export function toExitCode(err: unknown): number {
 
 /** A short, actionable message for the user. Never leak tokens. */
 export function formatError(err: unknown): string {
+  if (err instanceof NonJsonResponseError) {
+    return `${err.message} Body: ${truncate(err.body.replace(/\s+/g, " ").trim(), 200)}`;
+  }
   if (err instanceof HttpError) {
     const serverMsg = serverError(err.body);
     if (err.status === 401) {
@@ -63,8 +113,11 @@ export function formatError(err: unknown): string {
       return `Not authorized (HTTP 401)${serverMsg ? `: ${serverMsg}` : ""}. ${next}`;
     }
     if (err.status === 403) {
-      // Surface the server reason (e.g. "not an admin", "built-in role read-only").
-      return `Forbidden (HTTP 403)${serverMsg ? `: ${serverMsg}` : " — admin privileges required"}.`;
+      // Surface the server reason (e.g. "not an admin", "built-in role read-only")
+      // — plus any hint, or an HTML 403 from a proxy reads as "you lack rights"
+      // when the truth is that the route never reached a service at all.
+      const next = err.hint ? ` ${err.hint}` : "";
+      return `Forbidden (HTTP 403)${serverMsg ? `: ${serverMsg}` : " — admin privileges required"}.${next}`;
     }
     const detail = err.body ? `: ${truncate(err.body, 500)}` : "";
     // A hint on any other status is the actionable half of the message — a bare

--- a/test/unit/bkn-create.test.ts
+++ b/test/unit/bkn-create.test.ts
@@ -1,0 +1,932 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createFromCatalog, createFromCsv } from "../../src/resources/bkn-create.js";
+import type { RequestContext } from "../../src/types.js";
+import { HttpError, InputError } from "../../src/utils/errors.js";
+
+const ctx: RequestContext = {
+  baseUrl: "https://demo.example.com",
+  token: "t",
+  businessDomain: "bd_public",
+  insecure: false,
+};
+
+type Route = (url: URL, init: RequestInit) => unknown | undefined;
+
+/** Route by pathname; an unmatched request fails the test loudly. */
+function mockFetch(routes: Array<[RegExp, Route]>): typeof fetch {
+  const fn = vi.fn(async (input: string, init: RequestInit = {}) => {
+    const url = new URL(input);
+    for (const [pattern, handler] of routes) {
+      if (!pattern.test(url.pathname)) continue;
+      const body = handler(url, init);
+      if (body instanceof Response) return body;
+      return new Response(JSON.stringify(body ?? {}), { status: 200 });
+    }
+    throw new Error(`unrouted request: ${url.pathname}`);
+  });
+  vi.stubGlobal("fetch", fn);
+  return fn as unknown as typeof fetch;
+}
+
+function paths(fetchMock: typeof fetch): string[] {
+  const calls = (fetchMock as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls;
+  return calls.map(([u]) => new URL(u).pathname);
+}
+
+/** A catalog whose detail responses use the `{entries:[…]}` envelope. */
+function catalogRoutes(
+  tables: Array<{ id: string; name: string; columns: string[]; pk?: string }>,
+): Array<[RegExp, Route]> {
+  return [
+    [
+      /^\/api\/vega-backend\/v1\/resources$/,
+      () => ({ entries: tables.map((t) => ({ id: t.id, name: t.name })) }),
+    ],
+    [
+      /^\/api\/vega-backend\/v1\/resources\/[^/]+$/,
+      (url) => {
+        const id = url.pathname.split("/").pop();
+        const t = tables.find((x) => x.id === id);
+        return {
+          entries: [
+            {
+              id: t?.id,
+              name: t?.name,
+              category: "table",
+              source_metadata: { columns: t?.columns.map((c) => ({ name: c, type: "varchar" })) },
+              schema_definition: t?.columns.map((c) => ({ name: c, type: "varchar" })),
+              ...(t?.pk ? { primary_keys: [t.pk] } : {}),
+            },
+          ],
+        };
+      },
+    ],
+    [/^\/api\/ontology-manager\/v1\/knowledge-networks$/, () => ({ id: "kn-1" })],
+    [/^\/api\/ontology-manager\/v1\/knowledge-networks\/[^/]+\/object-types$/, () => ({})],
+    [/^\/api\/ontology-manager\/v1\/knowledge-networks\/[^/]+$/, () => ({})],
+  ];
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("createFromCatalog table identifiers", () => {
+  it("unwraps the resource detail envelope instead of building nameless tables", async () => {
+    const f = mockFetch(catalogRoutes([{ id: "r-1", name: "document", columns: ["id", "body"] }]));
+    const out = (await createFromCatalog(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      pkMap: { document: "id" },
+    })) as { object_types: Array<{ name: string; pk: string }> };
+    expect(out.object_types).toEqual([{ name: "document", pk: "id" }]);
+    // No rollback DELETE — the run succeeded.
+    expect(paths(f)).not.toContain("/api/ontology-manager/v1/knowledge-networks/kn-1");
+  });
+
+  it("asks for every table, not the backend's default page", async () => {
+    const f = mockFetch(
+      catalogRoutes([{ id: "r-1", name: "document", columns: ["id"], pk: "id" }]),
+    );
+    await createFromCatalog(ctx, { catalogId: "c-1", name: "kn" });
+    // A default page of 20 would drop the 21st table from the network and then
+    // report it as one the catalog does not have.
+    const list = (f as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls.find(
+      ([u]) => new URL(String(u)).pathname === "/api/vega-backend/v1/resources",
+    );
+    expect(new URL(String(list?.[0])).searchParams.get("limit")).toBe("-1");
+  });
+
+  it("accepts a schema-qualified --pk-map key for a bare catalog table name", async () => {
+    mockFetch(catalogRoutes([{ id: "r-1", name: "document", columns: ["doc_id", "body"] }]));
+    const out = (await createFromCatalog(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      pkMap: { "yanfeng_kb.document": "doc_id" },
+    })) as { object_types: Array<{ name: string; pk: string }> };
+    expect(out.object_types).toEqual([{ name: "document", pk: "doc_id" }]);
+  });
+
+  it("names the catalog's actual tables when --pk-map misses", async () => {
+    mockFetch(
+      catalogRoutes([
+        { id: "r-1", name: "document", columns: ["id"] },
+        { id: "r-2", name: "chunk", columns: ["id"] },
+      ]),
+    );
+    await expect(
+      createFromCatalog(ctx, { catalogId: "c-1", name: "kn", pkMap: { orders: "id" } }),
+    ).rejects.toThrow(/unknown table 'orders'\. Tables in this run: document, chunk/);
+  });
+
+  it("resolves --tables and --embedding-fields through the same matching", async () => {
+    const f = mockFetch(
+      catalogRoutes([
+        { id: "r-1", name: "document", columns: ["id", "body"] },
+        { id: "r-2", name: "chunk", columns: ["id"] },
+      ]).concat([[/^\/api\/vega-backend\/v1\/build-tasks$/, () => ({ id: "task-1" })]]),
+    );
+    const out = (await createFromCatalog(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      tables: ["yanfeng_kb.document"],
+      pkMap: { "yanfeng_kb.document": "id" },
+      embeddingFields: { "yanfeng_kb.document": ["body"] },
+      build: true,
+    })) as { object_types: Array<{ name: string }>; build_tasks: Array<{ table: string }> };
+    expect(out.object_types.map((o) => o.name)).toEqual(["document"]);
+    expect(out.build_tasks).toEqual([{ table: "document", taskId: "task-1" }]);
+    // The vector feature landed on the resource before the build task ran.
+    const put = (f as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls.find(
+      ([, init]) => init.method === "PUT",
+    );
+    const schema = (
+      JSON.parse(String(put?.[1]?.body)) as {
+        schema_definition: Array<{ name: string; features?: Array<{ feature_type: string }> }>;
+      }
+    ).schema_definition;
+    expect(schema.find((p) => p.name === "body")?.features?.[0]?.feature_type).toBe("vector");
+  });
+
+  it("matches a table key case-insensitively and with the qualifier on either side", async () => {
+    mockFetch(catalogRoutes([{ id: "r-1", name: "yanfeng_kb.Document", columns: ["id"] }]));
+    const out = (await createFromCatalog(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      // Catalog carries the schema qualifier and folds case; the user does not.
+      pkMap: { document: "id" },
+    })) as { object_types: Array<{ name: string; pk: string }> };
+    expect(out.object_types).toEqual([{ name: "yanfeng_kb.Document", pk: "id" }]);
+  });
+
+  it("reports two keys that normalize onto one table instead of dropping one", async () => {
+    mockFetch(catalogRoutes([{ id: "r-1", name: "document", columns: ["id", "doc_id"] }]));
+    await expect(
+      createFromCatalog(ctx, {
+        catalogId: "c-1",
+        name: "kn",
+        pkMap: { document: "id", "yanfeng_kb.document": "doc_id" },
+      }),
+    ).rejects.toThrow(/--pk-map has two entries for table 'document'/);
+  });
+
+  it("ignores a nameless resource instead of blocking every other table", async () => {
+    const logs: string[] = [];
+    mockFetch([
+      [
+        /^\/api\/vega-backend\/v1\/resources$/,
+        () => ({ entries: [{ id: "r-1", name: "document" }, { id: "r-2" }] }),
+      ],
+      [
+        /^\/api\/vega-backend\/v1\/resources\/[^/]+$/,
+        (url) =>
+          url.pathname.endsWith("r-1")
+            ? {
+                entries: [
+                  {
+                    id: "r-1",
+                    name: "document",
+                    source_metadata: { columns: [{ name: "id", type: "varchar" }] },
+                    primary_keys: ["id"],
+                  },
+                ],
+              }
+            : { entries: [{ id: "r-2" }] },
+      ],
+      [/^\/api\/ontology-manager\/v1\/knowledge-networks$/, () => ({ id: "kn-1" })],
+      [/^\/api\/ontology-manager\/v1\/knowledge-networks\/[^/]+\/object-types$/, () => ({})],
+    ]);
+    const out = (await createFromCatalog(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      onProgress: (m) => logs.push(m),
+    })) as { object_types: Array<{ name: string }> };
+    expect(out.object_types.map((o) => o.name)).toEqual(["document"]);
+    expect(logs.join("\n")).toMatch(/Ignoring nameless table resource\(s\): r-2/);
+  });
+
+  it("still fails when no table resource has a name, naming the ids", async () => {
+    mockFetch([
+      [/^\/api\/vega-backend\/v1\/resources$/, () => ({ entries: [{ id: "r-1" }] })],
+      // A deploy that answers the detail read with a bare, nameless resource.
+      [/^\/api\/vega-backend\/v1\/resources\/[^/]+$/, () => ({ entries: [{ id: "r-1" }] })],
+    ]);
+    await expect(createFromCatalog(ctx, { catalogId: "c-1", name: "kn" })).rejects.toThrow(
+      /none with a name \(ids: r-1\)/,
+    );
+  });
+
+  it("drops a --pk-map entry for an undiscovered table under skip, keeps it fatal otherwise", async () => {
+    const logs: string[] = [];
+    const routes = catalogRoutes([{ id: "r-1", name: "document", columns: ["id"], pk: "id" }]);
+    mockFetch(routes);
+    // Same lag as --tables: the pk-map names a table the catalog has not
+    // registered. Failing here would strand rows already in the database.
+    const out = (await createFromCatalog(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      tables: ["document", "chunk"],
+      pkMap: { document: "id", chunk: "id" },
+      missingTables: "skip",
+      onProgress: (m) => logs.push(m),
+    })) as { object_types: Array<{ name: string }> };
+    expect(out.object_types.map((o) => o.name)).toEqual(["document"]);
+    expect(logs.join("\n")).toMatch(/Dropping --pk-map entry 'chunk'/);
+
+    mockFetch(routes);
+    await expect(
+      createFromCatalog(ctx, { catalogId: "c-1", name: "kn", pkMap: { chunk: "id" } }),
+    ).rejects.toThrow(/--pk-map references unknown table 'chunk'/);
+  });
+
+  it("forgives an option keyed to a table whose import failed", async () => {
+    const logs: string[] = [];
+    mockFetch(catalogRoutes([{ id: "r-1", name: "document", columns: ["id"], pk: "id" }]));
+    // `chunk` never reached the catalog because its CSV failed — that is
+    // already reported, so its --pk-map entry must not sink the other table.
+    const out = (await createFromCatalog(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      tables: ["document"],
+      absentTables: ["chunk"],
+      pkMap: { document: "id", chunk: "id" },
+      onProgress: (m) => logs.push(m),
+    })) as { object_types: Array<{ name: string }> };
+    expect(out.object_types.map((o) => o.name)).toEqual(["document"]);
+    expect(logs.join("\n")).toMatch(/Dropping --pk-map entry 'chunk'/);
+  });
+
+  it("forgives a --tables entry the run already reported as absent", async () => {
+    const logs: string[] = [];
+    mockFetch(catalogRoutes([{ id: "r-1", name: "document", columns: ["id"], pk: "id" }]));
+    // A hand-typed --tables stays strict about typos, but `chunk` is a name
+    // this run has already reported — failing on it would strand the rows
+    // written for `document`.
+    const out = (await createFromCatalog(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      tables: ["document", "chunk"],
+      absentTables: ["chunk"],
+      onProgress: (m) => logs.push(m),
+    })) as { object_types: Array<{ name: string }> };
+    expect(out.object_types.map((o) => o.name)).toEqual(["document"]);
+    expect(logs.join("\n")).toMatch(/Skipping 1 table\(s\) not in the catalog.*chunk/);
+  });
+
+  it("rejects an unknown --embedding-fields column before it can write anything", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "bkn-csv-"));
+    writeFileSync(join(dir, "document.csv"), "id,body\n1,alpha\n");
+    const f = mockFetch([
+      [/^\/api\/automation\/v2\/dags$/, () => ({ entries: [] })],
+      [/^\/api\/automation\/v1\/data-flow\/flow$/, () => ({ id: "dag-1" })],
+      [/^\/api\/automation\/v1\/run-instance\/[^/]+$/, () => ({})],
+      [
+        /^\/api\/automation\/v1\/dag\/[^/]+\/results$/,
+        () => ({ results: [{ status: "success" }] }),
+      ],
+      [/^\/api\/automation\/v1\/data-flow\/flow\/[^/]+$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+\/discover$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+$/, () => ({ connector_type: "mysql" })],
+      ...catalogRoutes([{ id: "r-1", name: "document", columns: ["id", "body"], pk: "id" }]),
+    ]);
+    // The check runs in Phase 2, so the CSV rows are written by the time it
+    // fires — that is the bound. What it buys: left to `ensureFeature` this
+    // surfaces in step 5, after the KN and its object types exist and with
+    // earlier tables' PUTs and build tasks already landed and never rolled back.
+    await expect(
+      createFromCsv(ctx, {
+        catalogId: "c-1",
+        name: "kn",
+        files: `${dir}/*.csv`,
+        build: true,
+        embeddingFields: { document: ["bdy"] },
+      }),
+    ).rejects.toThrow(
+      /--embedding-fields names bdy on table 'document'.*Indexable fields: id, body/,
+    );
+    // Rows went in — that is why the check is reachable at all; nothing else did.
+    expect(paths(f)).toContain("/api/automation/v1/data-flow/flow");
+    expect(paths(f)).not.toContain("/api/ontology-manager/v1/knowledge-networks");
+    expect(paths(f)).not.toContain("/api/vega-backend/v1/build-tasks");
+  });
+
+  it("tells a Phase 2 failure that the rows are already in the database", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "bkn-csv-"));
+    writeFileSync(join(dir, "document.csv"), "id,body\n1,alpha\n");
+    mockFetch([
+      [/^\/api\/automation\/v2\/dags$/, () => ({ entries: [] })],
+      [/^\/api\/automation\/v1\/data-flow\/flow$/, () => ({ id: "dag-1" })],
+      [/^\/api\/automation\/v1\/run-instance\/[^/]+$/, () => ({})],
+      [
+        /^\/api\/automation\/v1\/dag\/[^/]+\/results$/,
+        () => ({ results: [{ status: "success" }] }),
+      ],
+      [/^\/api\/automation\/v1\/data-flow\/flow\/[^/]+$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+\/discover$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+$/, () => ({ connector_type: "mysql" })],
+      ...catalogRoutes([{ id: "r-1", name: "document", columns: ["id", "body"], pk: "id" }]),
+    ]);
+    // Every Phase 2 failure, not a chosen few: once the rows are in, "fix it
+    // and run this again" is the wrong next step.
+    const logs: string[] = [];
+    const err = await createFromCsv(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      files: `${dir}/*.csv`,
+      pkMap: { document: "nope" },
+      onProgress: (m) => logs.push(m),
+    }).catch((e) => e);
+    expect(String(err)).toMatch(/is not a column/);
+    expect(logs.join("\n")).toMatch(/already imported.*create-from-catalog c-1/s);
+    // Bad input stays bad input — the guidance must not cost the error's type.
+    expect(err).toBeInstanceOf(InputError);
+  });
+
+  it("names the partial network only when the run actually left one", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "bkn-csv-"));
+    writeFileSync(join(dir, "document.csv"), "id,body\n1,alpha\n");
+    const csvRoutes: Array<[RegExp, Route]> = [
+      [/^\/api\/automation\/v2\/dags$/, () => ({ entries: [] })],
+      [/^\/api\/automation\/v1\/data-flow\/flow$/, () => ({ id: "dag-1" })],
+      [/^\/api\/automation\/v1\/run-instance\/[^/]+$/, () => ({})],
+      [
+        /^\/api\/automation\/v1\/dag\/[^/]+\/results$/,
+        () => ({ results: [{ status: "success" }] }),
+      ],
+      [/^\/api\/automation\/v1\/data-flow\/flow\/[^/]+$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+\/discover$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+$/, () => ({ connector_type: "mysql" })],
+    ];
+    const table = { id: "r-1", name: "document", columns: ["id", "body"], pk: "id" };
+
+    // Fails after the network exists: object-type creation is the first write
+    // past it, so `--no-rollback` really does leave one behind.
+    const late: string[] = [];
+    mockFetch([
+      ...csvRoutes,
+      ...catalogRoutes([table]).filter(
+        ([re]) => !re.test("/api/ontology-manager/v1/knowledge-networks/kn-1/object-types"),
+      ),
+      [
+        /^\/api\/ontology-manager\/v1\/knowledge-networks\/[^/]+\/object-types$/,
+        () => new Response(JSON.stringify({ error: "nope" }), { status: 500 }),
+      ],
+    ]);
+    await createFromCsv(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      files: `${dir}/*.csv`,
+      noRollback: true,
+      onProgress: (m) => late.push(m),
+    }).catch(() => {});
+    expect(late.join("\n")).toMatch(/Delete the partial knowledge network kn-1/);
+
+    // Fails before it exists — every input check now runs ahead of the KN, so
+    // there is nothing to delete and the guidance must not invent one.
+    const early: string[] = [];
+    mockFetch([...csvRoutes, ...catalogRoutes([table])]);
+    await createFromCsv(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      files: `${dir}/*.csv`,
+      noRollback: true,
+      pkMap: { document: "nope" },
+      onProgress: (m) => early.push(m),
+    }).catch(() => {});
+    expect(early.join("\n")).toMatch(/already imported/);
+    // Case-insensitive on purpose: the wording this replaced was lower-case,
+    // and a case-sensitive assertion would pass against it.
+    expect(early.join("\n")).not.toMatch(/partial knowledge network/i);
+  });
+
+  it("names the network a failed rollback left behind", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "bkn-csv-"));
+    writeFileSync(join(dir, "document.csv"), "id,body\n1,alpha\n");
+    const logs: string[] = [];
+    mockFetch([
+      [/^\/api\/automation\/v2\/dags$/, () => ({ entries: [] })],
+      [/^\/api\/automation\/v1\/data-flow\/flow$/, () => ({ id: "dag-1" })],
+      [/^\/api\/automation\/v1\/run-instance\/[^/]+$/, () => ({})],
+      [
+        /^\/api\/automation\/v1\/dag\/[^/]+\/results$/,
+        () => ({ results: [{ status: "success" }] }),
+      ],
+      [/^\/api\/automation\/v1\/data-flow\/flow\/[^/]+$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+\/discover$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+$/, () => ({ connector_type: "mysql" })],
+      // Object-type creation fails, and the rollback DELETE is refused too, so
+      // the network survives even though --no-rollback was never passed.
+      [
+        /^\/api\/ontology-manager\/v1\/knowledge-networks\/[^/]+\/object-types$/,
+        () => new Response(JSON.stringify({ error: "nope" }), { status: 500 }),
+      ],
+      [
+        /^\/api\/ontology-manager\/v1\/knowledge-networks\/[^/]+$/,
+        () => new Response(JSON.stringify({ error: "nope" }), { status: 500 }),
+      ],
+      ...catalogRoutes([{ id: "r-1", name: "document", columns: ["id", "body"], pk: "id" }]),
+    ]);
+    await createFromCsv(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      files: `${dir}/*.csv`,
+      onProgress: (m) => logs.push(m),
+    }).catch(() => {});
+    // The reason decides what the user can do about it, so it must survive.
+    expect(logs.join("\n")).toMatch(/Rollback of KN kn-1 failed \(.*nope.*\); it is still there/);
+    expect(logs.join("\n")).toMatch(/Delete the partial knowledge network kn-1/);
+  });
+
+  it("treats a 404 from the rollback as the network being gone", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "bkn-csv-"));
+    writeFileSync(join(dir, "document.csv"), "id,body\n1,alpha\n");
+    const logs: string[] = [];
+    const f = mockFetch([
+      [/^\/api\/automation\/v2\/dags$/, () => ({ entries: [] })],
+      [/^\/api\/automation\/v1\/data-flow\/flow$/, () => ({ id: "dag-1" })],
+      [/^\/api\/automation\/v1\/run-instance\/[^/]+$/, () => ({})],
+      [
+        /^\/api\/automation\/v1\/dag\/[^/]+\/results$/,
+        () => ({ results: [{ status: "success" }] }),
+      ],
+      [/^\/api\/automation\/v1\/data-flow\/flow\/[^/]+$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+\/discover$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+$/, () => ({ connector_type: "mysql" })],
+      [
+        /^\/api\/ontology-manager\/v1\/knowledge-networks\/[^/]+\/object-types$/,
+        () => new Response(JSON.stringify({ error: "nope" }), { status: 500 }),
+      ],
+      // The rollback DELETE says the network is not there. It is gone, so the
+      // user must not be sent to delete it.
+      [
+        /^\/api\/ontology-manager\/v1\/knowledge-networks\/[^/]+$/,
+        () => new Response(JSON.stringify({ error: "not found" }), { status: 404 }),
+      ],
+      ...catalogRoutes([{ id: "r-1", name: "document", columns: ["id", "body"], pk: "id" }]),
+    ]);
+    await createFromCsv(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      files: `${dir}/*.csv`,
+      onProgress: (m) => logs.push(m),
+    }).catch(() => {});
+    // Both assertions below are negative, so pin that the rollback really ran:
+    // otherwise a change that never reaches it would keep this test green.
+    expect(logs.join("\n")).toMatch(/Rolling back KN kn-1/);
+    expect(paths(f)).toContain("/api/ontology-manager/v1/knowledge-networks/kn-1");
+    expect(logs.join("\n")).not.toMatch(/still there/);
+    expect(logs.join("\n")).not.toMatch(/partial knowledge network/i);
+  });
+
+  it("treats a non-JSON 2xx from the rollback as the delete having worked", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "bkn-csv-"));
+    writeFileSync(join(dir, "document.csv"), "id,body\n1,alpha\n");
+    const logs: string[] = [];
+    const f = mockFetch([
+      [/^\/api\/automation\/v2\/dags$/, () => ({ entries: [] })],
+      [/^\/api\/automation\/v1\/data-flow\/flow$/, () => ({ id: "dag-1" })],
+      [/^\/api\/automation\/v1\/run-instance\/[^/]+$/, () => ({})],
+      [
+        /^\/api\/automation\/v1\/dag\/[^/]+\/results$/,
+        () => ({ results: [{ status: "success" }] }),
+      ],
+      [/^\/api\/automation\/v1\/data-flow\/flow\/[^/]+$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+\/discover$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+$/, () => ({ connector_type: "mysql" })],
+      [
+        /^\/api\/ontology-manager\/v1\/knowledge-networks\/[^/]+\/object-types$/,
+        () => new Response(JSON.stringify({ error: "nope" }), { status: 500 }),
+      ],
+      // `200 text/plain "OK"` is a common way to answer a DELETE. It raises
+      // NonJsonResponseError here, but the network is gone all the same.
+      [
+        /^\/api\/ontology-manager\/v1\/knowledge-networks\/[^/]+$/,
+        () => new Response("OK", { status: 200, headers: { "content-type": "text/plain" } }),
+      ],
+      ...catalogRoutes([{ id: "r-1", name: "document", columns: ["id", "body"], pk: "id" }]),
+    ]);
+    await createFromCsv(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      files: `${dir}/*.csv`,
+      onProgress: (m) => logs.push(m),
+    }).catch(() => {});
+    expect(paths(f)).toContain("/api/ontology-manager/v1/knowledge-networks/kn-1");
+    expect(logs.join("\n")).not.toMatch(/still there/);
+    expect(logs.join("\n")).not.toMatch(/partial knowledge network/i);
+  });
+
+  it("keeps quiet only when the service itself answered the rollback", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "bkn-csv-"));
+    writeFileSync(join(dir, "document.csv"), "id,body\n1,alpha\n");
+    const logs: string[] = [];
+    mockFetch([
+      [/^\/api\/automation\/v2\/dags$/, () => ({ entries: [] })],
+      [/^\/api\/automation\/v1\/data-flow\/flow$/, () => ({ id: "dag-1" })],
+      [/^\/api\/automation\/v1\/run-instance\/[^/]+$/, () => ({})],
+      [
+        /^\/api\/automation\/v1\/dag\/[^/]+\/results$/,
+        () => ({ results: [{ status: "success" }] }),
+      ],
+      [/^\/api\/automation\/v1\/data-flow\/flow\/[^/]+$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+\/discover$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+$/, () => ({ connector_type: "mysql" })],
+      [
+        /^\/api\/ontology-manager\/v1\/knowledge-networks\/[^/]+\/object-types$/,
+        () => new Response(JSON.stringify({ error: "nope" }), { status: 500 }),
+      ],
+      // An SSO proxy answers a dead session with a 200 login page. The delete
+      // never reached the service, so the network is still standing.
+      [
+        /^\/api\/ontology-manager\/v1\/knowledge-networks\/[^/]+$/,
+        () =>
+          new Response("<html><body>Sign in</body></html>", {
+            status: 200,
+            headers: { "content-type": "text/html" },
+          }),
+      ],
+      ...catalogRoutes([{ id: "r-1", name: "document", columns: ["id", "body"], pk: "id" }]),
+    ]);
+    await createFromCsv(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      files: `${dir}/*.csv`,
+      onProgress: (m) => logs.push(m),
+    }).catch(() => {});
+    // Saying nothing here would leave the network orphaned with no trace.
+    expect(logs.join("\n")).toMatch(/Rollback of KN kn-1 failed.*it is still there/);
+    expect(logs.join("\n")).toMatch(/Delete the partial knowledge network kn-1/);
+  });
+
+  it("reads catalog details in batches rather than all at once", async () => {
+    const tables = Array.from({ length: 25 }, (_, i) => ({
+      id: `r-${i}`,
+      name: `t${i}`,
+      columns: ["id"],
+      pk: "id",
+    }));
+    let inFlight = 0;
+    let peak = 0;
+    const f = mockFetch(catalogRoutes(tables));
+    // Count at the fetch boundary, across a real suspension. A route handler
+    // runs to completion synchronously, so counting inside one can never see
+    // two reads at once — `peak` would be 1 however many go out together.
+    const inner = f as unknown as (i: string, r?: RequestInit) => Promise<Response>;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string, init: RequestInit = {}) => {
+        if (!/\/resources\/r-\d+$/.test(new URL(String(input)).pathname)) {
+          return inner(input, init);
+        }
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await new Promise((r) => setTimeout(r, 0));
+        try {
+          return await inner(input, init);
+        } finally {
+          inFlight -= 1;
+        }
+      }),
+    );
+    await createFromCatalog(ctx, { catalogId: "c-1", name: "kn" });
+    // Every table is still read — the cap is on how many at a time.
+    expect(paths(f).filter((p) => /\/resources\/r-\d+$/.test(p))).toHaveLength(25);
+    // Above 1 proves the harness sees concurrency at all; at most 20 is the cap.
+    // One `Promise.all` over the catalog would peak at 25.
+    expect(peak).toBeGreaterThan(1);
+    expect(peak).toBeLessThanOrEqual(20);
+  });
+
+  it("keeps a Phase 2 HTTP failure typed, guidance or not", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "bkn-csv-"));
+    writeFileSync(join(dir, "document.csv"), "id,body\n1,alpha\n");
+    const logs: string[] = [];
+    mockFetch([
+      [/^\/api\/automation\/v2\/dags$/, () => ({ entries: [] })],
+      [/^\/api\/automation\/v1\/data-flow\/flow$/, () => ({ id: "dag-1" })],
+      [/^\/api\/automation\/v1\/run-instance\/[^/]+$/, () => ({})],
+      [
+        /^\/api\/automation\/v1\/dag\/[^/]+\/results$/,
+        () => ({ results: [{ status: "success" }] }),
+      ],
+      [/^\/api\/automation\/v1\/data-flow\/flow\/[^/]+$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+\/discover$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+$/, () => ({ connector_type: "mysql" })],
+      // Phase 2 is HTTP end to end; this is the shape the guidance must not eat.
+      [
+        /^\/api\/vega-backend\/v1\/resources$/,
+        () => new Response(JSON.stringify({ error: "token expired" }), { status: 401 }),
+      ],
+    ]);
+    const err = await createFromCsv(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      files: `${dir}/*.csv`,
+      onProgress: (m) => logs.push(m),
+    }).catch((e) => e);
+    // Rewrapping would have cost status, hint and exit code 3.
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(401);
+    expect(logs.join("\n")).toMatch(/already imported/);
+  });
+
+  it("never forgives an ambiguous table key, even under skip", async () => {
+    // The same table name registered under two schemas: no retry and no
+    // re-discover clears this, so dropping it would lose a table in silence.
+    mockFetch(
+      catalogRoutes([
+        { id: "r-1", name: "a.document", columns: ["id"], pk: "id" },
+        { id: "r-2", name: "b.document", columns: ["id"], pk: "id" },
+      ]),
+    );
+    await expect(
+      createFromCatalog(ctx, {
+        catalogId: "c-1",
+        name: "kn",
+        tables: ["document"],
+        missingTables: "skip",
+      }),
+    ).rejects.toThrow(/--tables 'document' matches several tables \(a\.document, b\.document\)/);
+  });
+
+  it("gives each same-named table its own primary key", async () => {
+    // The names must be *identical* for this to bite: a name-keyed map is what
+    // hands the second table the first one's key, and `a.document` /
+    // `b.document` would be distinct keys in that map too.
+    const f = mockFetch(
+      catalogRoutes([
+        { id: "r-1", name: "document", columns: ["doc_id"], pk: "doc_id" },
+        { id: "r-2", name: "document", columns: ["uid"], pk: "uid" },
+      ]),
+    );
+    const out = (await createFromCatalog(ctx, { catalogId: "c-1", name: "kn" })) as {
+      object_types: Array<{ name: string; pk: string }>;
+    };
+    expect(out.object_types).toEqual([
+      { name: "document", pk: "doc_id" },
+      { name: "document", pk: "uid" },
+    ]);
+    // Each object type binds to its own resource, with its own key.
+    const post = (f as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls.find(
+      ([u]) => String(u).includes("/object-types"),
+    );
+    expect(JSON.parse(String(post?.[1]?.body)).entries).toMatchObject([
+      { data_source: { id: "r-1" }, primary_keys: ["doc_id"] },
+      { data_source: { id: "r-2" }, primary_keys: ["uid"] },
+    ]);
+  });
+
+  it("names the tables the catalog has but the run left out", async () => {
+    mockFetch(
+      catalogRoutes([
+        { id: "r-1", name: "document", columns: ["id"], pk: "id" },
+        { id: "r-2", name: "chunk", columns: ["id"], pk: "id" },
+      ]),
+    );
+    await expect(
+      createFromCatalog(ctx, {
+        catalogId: "c-1",
+        name: "kn",
+        tables: ["document"],
+        pkMap: { chunk: "id" },
+      }),
+    ).rejects.toThrow(/Tables in this run: document\. The catalog also has chunk/);
+  });
+
+  it("keeps a misspelled --pk-map key fatal even under skip", async () => {
+    mockFetch(catalogRoutes([{ id: "r-1", name: "document", columns: ["id"], pk: "id" }]));
+    // 'documnet' is not a table the import left undiscovered — it is a typo.
+    // Dropping it would silently hand the primary key back to detection.
+    await expect(
+      createFromCatalog(ctx, {
+        catalogId: "c-1",
+        name: "kn",
+        tables: ["document", "chunk"],
+        pkMap: { documnet: "id" },
+        missingTables: "skip",
+      }),
+    ).rejects.toThrow(/--pk-map references unknown table 'documnet'/);
+  });
+
+  it("skips an undiscovered table for a derived list, but not for a typed --tables", async () => {
+    const logs: string[] = [];
+    const routes = catalogRoutes([{ id: "r-1", name: "document", columns: ["id"], pk: "id" }]);
+    mockFetch(routes);
+    const out = (await createFromCatalog(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      tables: ["document", "chunk"],
+      missingTables: "skip",
+      onProgress: (m) => logs.push(m),
+    })) as { object_types: Array<{ name: string }> };
+    expect(out.object_types.map((o) => o.name)).toEqual(["document"]);
+    expect(logs.join("\n")).toMatch(/Skipping 1 table\(s\) not in the catalog.*chunk/);
+
+    mockFetch(routes);
+    await expect(
+      createFromCatalog(ctx, { catalogId: "c-1", name: "kn", tables: ["document", "chunk"] }),
+    ).rejects.toThrow(/--tables references unknown table 'chunk'/);
+  });
+});
+
+describe("createFromCsv table discovery lag", () => {
+  it("builds the KN from the tables the catalog did register", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "bkn-csv-"));
+    writeFileSync(join(dir, "document.csv"), "id,body\n1,alpha\n2,beta\n");
+    writeFileSync(join(dir, "chunk.csv"), "id,text\n1,x\n");
+    const logs: string[] = [];
+    // The catalog registered `document` but not `chunk` — the closing discover
+    // in importCsvToCatalog is best-effort and may lag or fail outright.
+    mockFetch([
+      [/^\/api\/automation\/v2\/dags$/, () => ({ entries: [] })],
+      [/^\/api\/automation\/v1\/data-flow\/flow$/, () => ({ id: "dag-1" })],
+      [/^\/api\/automation\/v1\/run-instance\/[^/]+$/, () => ({})],
+      [
+        /^\/api\/automation\/v1\/dag\/[^/]+\/results$/,
+        () => ({ results: [{ status: "success" }] }),
+      ],
+      [/^\/api\/automation\/v1\/data-flow\/flow\/[^/]+$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+\/discover$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+$/, () => ({ connector_type: "mysql" })],
+      ...catalogRoutes([{ id: "r-1", name: "document", columns: ["id", "body"], pk: "id" }]),
+    ]);
+    const out = (await createFromCsv(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      files: `${dir}/*.csv`,
+      onProgress: (m) => logs.push(m),
+    })) as { imported_tables: string[]; object_types: Array<{ name: string }> };
+    expect(out.imported_tables.sort()).toEqual(["chunk", "document"]);
+    // Rows for both files are already in the database — the KN must still get built.
+    expect(out.object_types.map((o) => o.name)).toEqual(["document"]);
+    expect(logs.join("\n")).toMatch(/Skipping 1 table\(s\) not in the catalog.*chunk/);
+  });
+});
+
+describe("createFromCsv input validation order", () => {
+  it("rejects a bad embedding model before importing anything", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "bkn-csv-"));
+    writeFileSync(join(dir, "document.csv"), "id,body\n1,alpha\n");
+    const f = mockFetch([
+      [/^\/api\/automation\/v2\/dags$/, () => ({ entries: [] })],
+      [
+        /^\/api\/mf-model-manager\/v1\/small-model\/get$/,
+        () => new Response("{}", { status: 404 }),
+      ],
+    ]);
+    // Resolving inside the build step would mean a full import, a KN, its
+    // object types, and a rollback — with the rows left in the database.
+    await expect(
+      createFromCsv(ctx, {
+        catalogId: "c-1",
+        name: "kn",
+        files: `${dir}/*.csv`,
+        build: true,
+        embeddingModel: "2064382281006583808",
+      }),
+    ).rejects.toThrow(/No small model found with id 2064382281006583808/);
+    expect(paths(f)).not.toContain("/api/automation/v1/data-flow/flow");
+  });
+});
+
+describe("createFromCsv dependency preflight", () => {
+  it("stops before importing when the dataflow service is missing", async () => {
+    const f = mockFetch([
+      [
+        /^\/api\/automation\/v2\/dags$/,
+        () =>
+          new Response("<html><body><center>404 Not Found</center></body></html>", {
+            status: 404,
+            headers: { "content-type": "text/html" },
+          }),
+      ],
+    ]);
+    await expect(
+      createFromCsv(ctx, { catalogId: "c-1", name: "kn", files: "/tmp/none.csv" }),
+    ).rejects.toThrow(/dataflow service is not available.*create-from-catalog/s);
+    // Preflight only — no DAG was created, no CSV was read.
+    expect(paths(f)).toEqual(["/api/automation/v2/dags"]);
+  });
+
+  it("proceeds when the v2 listing 404s in JSON — the import runs on v1", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "bkn-csv-"));
+    writeFileSync(join(dir, "document.csv"), "id,body\n1,alpha\n");
+    const logs: string[] = [];
+    mockFetch([
+      // Service is up and routed; it just does not serve this v2 listing.
+      [
+        /^\/api\/automation\/v2\/dags$/,
+        () => new Response(JSON.stringify({ error: "not found" }), { status: 404 }),
+      ],
+      [/^\/api\/automation\/v1\/data-flow\/flow$/, () => ({ id: "dag-1" })],
+      [/^\/api\/automation\/v1\/run-instance\/[^/]+$/, () => ({})],
+      [
+        /^\/api\/automation\/v1\/dag\/[^/]+\/results$/,
+        () => ({ results: [{ status: "success" }] }),
+      ],
+      [/^\/api\/automation\/v1\/data-flow\/flow\/[^/]+$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+\/discover$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+$/, () => ({ connector_type: "mysql" })],
+      ...catalogRoutes([{ id: "r-1", name: "document", columns: ["id", "body"], pk: "id" }]),
+    ]);
+    const out = (await createFromCsv(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      files: `${dir}/*.csv`,
+      onProgress: (m) => logs.push(m),
+    })) as { object_types: Array<{ name: string }> };
+    expect(out.object_types.map((o) => o.name)).toEqual(["document"]);
+    expect(logs.join("\n")).toMatch(/preflight inconclusive/);
+  });
+
+  it("stops on an auth refusal instead of reading every CSV first", async () => {
+    const f = mockFetch([
+      [
+        /^\/api\/automation\/v2\/dags$/,
+        () => new Response(JSON.stringify({ error: "token expired" }), { status: 401 }),
+      ],
+    ]);
+    const logs: string[] = [];
+    const err = await createFromCsv(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      files: "/tmp/none.csv",
+      onProgress: (m) => logs.push(m),
+    }).catch((e) => e);
+    // The auth cause survives — not reworded into "the service is unavailable".
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(401);
+    expect(paths(f)).toEqual(["/api/automation/v2/dags"]);
+    // A bare 401 reads as a platform-wide auth problem; name who refused.
+    expect(logs.join("\n")).toMatch(/dataflow service refused the preflight \(HTTP 401\)/);
+  });
+
+  it("proceeds when the v2 listing answers 2xx in something other than JSON", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "bkn-csv-"));
+    writeFileSync(join(dir, "document.csv"), "id,body\n1,alpha\n");
+    const logs: string[] = [];
+    mockFetch([
+      // The service answered; this listing just is not JSON. It is there, so
+      // the import must not be grounded before it reads a single row.
+      [
+        /^\/api\/automation\/v2\/dags$/,
+        () => new Response("OK", { status: 200, headers: { "content-type": "text/plain" } }),
+      ],
+      [/^\/api\/automation\/v1\/data-flow\/flow$/, () => ({ id: "dag-1" })],
+      [/^\/api\/automation\/v1\/run-instance\/[^/]+$/, () => ({})],
+      [
+        /^\/api\/automation\/v1\/dag\/[^/]+\/results$/,
+        () => ({ results: [{ status: "success" }] }),
+      ],
+      [/^\/api\/automation\/v1\/data-flow\/flow\/[^/]+$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+\/discover$/, () => ({})],
+      [/^\/api\/vega-backend\/v1\/catalogs\/[^/]+$/, () => ({ connector_type: "mysql" })],
+      ...catalogRoutes([{ id: "r-1", name: "document", columns: ["id", "body"], pk: "id" }]),
+    ]);
+    const out = (await createFromCsv(ctx, {
+      catalogId: "c-1",
+      name: "kn",
+      files: `${dir}/*.csv`,
+      onProgress: (m) => logs.push(m),
+    })) as { object_types: Array<{ name: string }> };
+    expect(out.object_types.map((o) => o.name)).toEqual(["document"]);
+    expect(logs.join("\n")).toMatch(/preflight inconclusive/);
+  });
+
+  it("stops when a proxy answers the probe with a 200 login page", async () => {
+    const f = mockFetch([
+      // Session expired: an SSO proxy replies 200 with a sign-in page. The
+      // status describes the proxy, so nothing behind the route was reached —
+      // the same reading as its HTML 404 sibling, one status code apart.
+      [
+        /^\/api\/automation\/v2\/dags$/,
+        () =>
+          new Response("<html><body>Sign in</body></html>", {
+            status: 200,
+            headers: { "content-type": "text/html" },
+          }),
+      ],
+    ]);
+    await expect(
+      createFromCsv(ctx, { catalogId: "c-1", name: "kn", files: "/tmp/none.csv" }),
+    ).rejects.toThrow(/dataflow service is not available.*create-from-catalog/s);
+    expect(paths(f)).toEqual(["/api/automation/v2/dags"]);
+  });
+
+  it("reports an HTML gateway page as a routing failure, not a business error", async () => {
+    mockFetch([
+      [
+        /^\/api\/automation\/v2\/dags$/,
+        () =>
+          new Response("<html><body>404</body></html>", {
+            status: 404,
+            headers: { "content-type": "text/html" },
+          }),
+      ],
+    ]);
+    await expect(
+      createFromCsv(ctx, { catalogId: "c-1", name: "kn", files: "/tmp/none.csv" }),
+    ).rejects.toThrow(/did not reach the service behind \/api\/automation\/v2\/dags/);
+  });
+});

--- a/test/unit/http.test.ts
+++ b/test/unit/http.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { request } from "../../src/api/http.js";
+import type { RequestContext } from "../../src/types.js";
+import { HttpError, NonJsonResponseError, formatError } from "../../src/utils/errors.js";
+
+const ctx: RequestContext = {
+  baseUrl: "https://demo.example.com",
+  token: "t",
+  businessDomain: "bd_public",
+  insecure: false,
+};
+
+function respond(body: string, init: ResponseInit): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => new Response(body, init)),
+  );
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("non-JSON responses", () => {
+  it("hints that an HTML error page never reached the service", async () => {
+    respond("<html><body><center>404 Not Found</center></body></html>", {
+      status: 404,
+      headers: { "content-type": "text/html" },
+    });
+    const err = await request(ctx, "/api/automation/v1/data-flow/flow", { body: {} }).catch(
+      (e) => e,
+    );
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).hint).toMatch(
+      /did not reach the service behind \/api\/automation\/v1\/data-flow\/flow/,
+    );
+    // The user-facing line carries the hint, not just "HTTP 404".
+    expect(formatError(err)).toMatch(/not deployed or not routed/);
+  });
+
+  it("keeps the AppKey guidance when an auth proxy answers 401 with HTML", async () => {
+    respond("<html><body>401 Authorization Required</body></html>", {
+      status: 401,
+      headers: { "content-type": "text/html" },
+    });
+    const err = await request({ ...ctx, token: "bak_123" }, "/api/vega-backend/v1/resources").catch(
+      (e) => e,
+    );
+    // Both diagnoses apply: the gateway ate the request AND the key is the thing
+    // to re-issue. Neither may hide the other.
+    expect((err as HttpError).hint).toMatch(/did not reach the service/);
+    expect((err as HttpError).hint).toMatch(/appkey create/);
+  });
+
+  it("carries the routing hint into a 403, which reads as a permissions problem", async () => {
+    respond("<html><body>403 Forbidden</body></html>", {
+      status: 403,
+      headers: { "content-type": "text/html" },
+    });
+    const err = await request(ctx, "/api/automation/v2/dags").catch((e) => e);
+    expect(formatError(err)).toMatch(/did not reach the service/);
+  });
+
+  it("detects a gateway page sent with a 200 and no html content-type", async () => {
+    respond("<!DOCTYPE html><html><body>hello</body></html>", { status: 200 });
+    const err = await request(ctx, "/api/vega-backend/v1/resources").catch((e) => e);
+    expect(err).toBeInstanceOf(NonJsonResponseError);
+    expect(formatError(err)).toMatch(/did not reach the service/);
+  });
+
+  it("reports a non-JSON 200 body instead of throwing a bare SyntaxError", async () => {
+    respond("not json at all", { status: 200, headers: { "content-type": "text/plain" } });
+    const err = await request(ctx, "/api/vega-backend/v1/resources").catch((e) => e);
+    expect(err).toBeInstanceOf(NonJsonResponseError);
+    expect(formatError(err)).toMatch(/non-JSON body \(text\/plain\).*not json at all/);
+  });
+
+  it("still returns undefined for an empty body", async () => {
+    respond("", { status: 200 });
+    await expect(request(ctx, "/api/vega-backend/v1/resources/r-1")).resolves.toBeUndefined();
+  });
+});

--- a/test/unit/resources.test.ts
+++ b/test/unit/resources.test.ts
@@ -8,6 +8,7 @@ import {
   updateResource,
 } from "../../src/api/resources.js";
 import type { RequestContext } from "../../src/types.js";
+import { HttpError } from "../../src/utils/errors.js";
 
 const ctx: RequestContext = {
   baseUrl: "https://demo.example.com",
@@ -141,6 +142,84 @@ describe("updateResource/configureResourceIndex", () => {
       ref_property: "body",
       config: { analyzer: "ik_max_word" },
     });
+  });
+
+  it("resolves a numeric embedding model id to the name the index config takes", async () => {
+    const resource = {
+      entries: [
+        {
+          id: "r-1",
+          catalog_id: "c-1",
+          name: "orders",
+          schema_definition: [{ name: "title", type: "text" }],
+        },
+      ],
+    };
+    const fn = vi.fn(async (input: string) =>
+      new URL(input).pathname.startsWith("/api/mf-model-manager")
+        ? new Response(JSON.stringify({ model_name: "text-embedding-v4" }), { status: 200 })
+        : new Response(JSON.stringify(resource), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fn);
+    await configureResourceIndex(ctx, "r-1", {
+      embeddingFields: ["title"],
+      embeddingModel: "2064382281006583808",
+    });
+    const calls = (fn as unknown as { mock: { calls: CallArgs[] } }).mock.calls;
+    const lookup = calls.find(([u]) => String(u).includes("/mf-model-manager"));
+    expect(new URL(lookup?.[0] ?? "").searchParams.get("model_id")).toBe("2064382281006583808");
+    const body = JSON.parse(calls.at(-1)?.[1].body as string);
+    expect(body.index_config.default_embedding_model).toBe("text-embedding-v4");
+    expect(body.schema_definition[0].features[0].config).toEqual({
+      embedding_model: "text-embedding-v4",
+    });
+  });
+
+  it("rejects an unknown embedding model id before touching the resource", async () => {
+    const fn = vi.fn(async (input: string) =>
+      new URL(input).pathname.startsWith("/api/mf-model-manager")
+        ? new Response("{}", { status: 404 })
+        : new Response(JSON.stringify({ entries: [{ id: "r-1" }] }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fn);
+    await expect(configureResourceIndex(ctx, "r-1", { embeddingModel: "999" })).rejects.toThrow(
+      /No small model found with id 999/,
+    );
+    const methods = (fn as unknown as { mock: { calls: CallArgs[] } }).mock.calls.map(
+      ([, init]) => init.method,
+    );
+    expect(methods).not.toContain("PUT");
+  });
+
+  it("keeps a gateway 404 as a routing failure, not as a bad-id InputError", async () => {
+    const fn = vi.fn(async (input: string) =>
+      new URL(input).pathname.startsWith("/api/mf-model-manager")
+        ? new Response("<html><body>404 Not Found</body></html>", {
+            status: 404,
+            headers: { "content-type": "text/html" },
+          })
+        : new Response(JSON.stringify({ entries: [{ id: "r-1" }] }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fn);
+    // A deploy without model-factory answers 404 too — but nothing behind the
+    // route saw the id, so "you typed a bad id" is the wrong conclusion.
+    const err = await configureResourceIndex(ctx, "r-1", { embeddingModel: "999" }).catch((e) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).gateway).toBe(true);
+    expect((err as HttpError).hint).toMatch(/did not reach the service/);
+  });
+
+  it("keeps a model-factory auth failure as itself, not as a bad-id InputError", async () => {
+    const fn = vi.fn(async (input: string) =>
+      new URL(input).pathname.startsWith("/api/mf-model-manager")
+        ? new Response(JSON.stringify({ error: "token expired" }), { status: 401 })
+        : new Response(JSON.stringify({ entries: [{ id: "r-1" }] }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fn);
+    // Exit code 3 (auth), not 2 (bad input) — "log in again" ≠ "you typed a wrong id".
+    const err = await configureResourceIndex(ctx, "r-1", { embeddingModel: "999" }).catch((e) => e);
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(401);
   });
 });
 


### PR DESCRIPTION
实机跑 `openbkn` 时撞到的三条 CLI 侧问题，都是"错误信息指不到真凶"这一类。

## 1. `create-from-catalog` 把资源详情的信封当成资源本身

`GET /resources/{id}` 和 list 一样返回 `{entries:[…]}`，但 `createFromCatalog` 直接把响应当资源读。结果每张表的 `name` 是 `""`、`columns` 是 `[]`，一路带到很下游才炸：

```
Cannot auto-detect a primary key for table ''.
--pk-map references unknown table 'yanfeng_kb.document'.
```

同文件的 `configureResourceIndex` 走了 `firstResource()` 解包，这条路径漏了。

修法：
- 导出 `firstResource()`，详情响应统一过它
- 空表名在入口就拒，报错带上出问题的 resource id，指向 `vega catalog discover`
- `--tables` / `--pk-map` / `--embedding-fields` 的 key 走同一套匹配：认 catalog 的表名，也认用户从数据库里复制来的 schema 全名（`yanfeng_kb.document` 匹配 `document`）；不匹配时列出 catalog 真实表名，而不是只说 unknown
- viewMap 直接用 list 阶段的 resource id，去掉按表名反查资源那趟 —— 少一个依赖表名的失败点

## 2. 依赖服务缺失时报错无指向

`create-from-csv` 每批数据跑一条 dataflow DAG。该部署没给 dataflow 配路由时，返回的是 nginx 的 HTML 错误页，于是 12 张表刷出 12 行一模一样的：

```
[block] import failed: HTTP 404
```

HTML body 连看都看不到 —— 日志只取了 `e.message`。

修法：
- Phase 1 之前先探 `listDataflows`，404/501/502/503 或非 JSON 就停，报错给替代路径（自行入库 → `catalog discover` → `create-from-catalog`）
- HTTP 层识别网关页：content-type 或 body 头部像 HTML 就提示"请求没到达该路径背后的服务，后端可能未部署或未配路由"
- 200 但非 JSON 抛 `NonJsonResponseError`，不再是裸 `SyntaxError`
- 导入日志改用 `formatError(e)`，body 和 hint 都露出来

## 3. `--embedding-model` 只认 name

flag 说明写 `name/id`，实际透传给后端，传 `model small get-default` 返回的首字段（数字 id）会得到 `embedding model "..." not found`。

修法：仿已有的 `resolveLlmModelName`，加 `resolveSmallModelName` 挂在 `configureResourceIndex` 上 —— 四个 flag 入口一次覆盖。查不到就明确报错且不发 PUT。flag 说明改成 `<name-or-id>`。

## 测试

新增 `test/unit/bkn-create.test.ts`(7)、`test/unit/http.test.ts`(4)，`resources.test.ts` 补 2 条。覆盖信封解包、schema 前缀匹配、未知表名列真实表、无名资源、dataflow 预检不读 CSV、HTML 网关页、模型 id 解析。

`npm run ci`：454 passed。

## 破坏性变更（存量脚本请注意）

1. **`--tables` 未命中不再静默忽略。** 以前传一个 catalog 里不存在的表名只是被跳过，现在报错并列出真实表名。传表名超集当过滤器用的脚本会挂。例外：`create-from-csv` 未手传 `--tables` 时走自己派生的列表，未被 discover 收录的表跳过并 log —— 因为那时行已落库，硬失败会让整批数据没有 KN。
2. **`--embedding-model` 传纯数字会先查一次模型工厂。** 以前原样透传，现在解析成 `model_name`。多一次 HTTP；id 不存在时报 `InputError`（退出码 2），网关 404 / 401 / 5xx 保留各自的错误与退出码。传名字的调用路径不变。
3. **`--pk-map` / `--embedding-fields` 指向未知表一律报错**（含 `create-from-csv`），只有"已导入但 catalog 尚未收录"的表名会被丢弃并 log。拼写错误在任何副作用之前失败。

4. **`create-from-catalog` / `create-from-csv` 的用户输入错误统一退出码 2。** 之前坏表名、坏列名、复合主键抛裸 `Error`（退出码 1），只有坏模型 id 是 `InputError`（2）。按退出码分支的脚本要改。

同样属于对外契约、但向后兼容的：`HttpError` 新增只读字段 `gateway` 与第 5 个可选构造参数；新增导出 `NonJsonResponseError`（以前这条路径抛的是内置 `SyntaxError`）。

## 不在本 PR 内

- **字段特征自引用**（`ensureFeature` 把 `ref_property` 指向字段自身，平台 0.1.4 判为非法）：等平台确认正确形状后单独提，去重逻辑要一起改
- **`openbkn doctor`**：新命令，范围待定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

