### PR TITLE
feat(vega): track build task lifecycle times

### DIFF
--- a/docs/product-specs/vega.md
+++ b/docs/product-specs/vega.md
@@ -39,7 +39,8 @@ CLI:
 - `openbkn vega dataset build-status <task-id>` — progress: `status` + `synced_count` / `vectorized_count`.
 - `openbkn vega dataset build-list --status pending,running` — filter by one or
   more statuses; the SDK sends repeated `status` query parameters. Use
-  `--sort create_time|update_time` and `--direction asc|desc` for ordering.
+  `--sort create_time|start_time|finish_time|last_progress_time` and
+  `--direction asc|desc` for ordering.
 - `openbkn vega dataset build-start <task-id> [--reset]` — `--reset` restarts only a full task; it is ignored for incremental tasks.
 
 **Field searchability is separate** — declared on the resource property schema via

--- a/docs/superpowers/plans/2026-08-14-vega-build-task-lifecycle-times.md
+++ b/docs/superpowers/plans/2026-08-14-vega-build-task-lifecycle-times.md
@@ -1,0 +1,8 @@
+# Vega BuildTask lifecycle times plan
+
+1. Replace BuildTask timestamp schemas and list sort validation with the
+   lifecycle timestamp contract.
+2. Update the dataset build-list CLI help and the Vega product specification.
+3. Update API and CLI regression tests for response parsing and sort query
+   serialization.
+4. Run formatting, lint, unit tests, and the production build.

--- a/docs/superpowers/specs/2026-08-14-vega-build-task-lifecycle-times-design.md
+++ b/docs/superpowers/specs/2026-08-14-vega-build-task-lifecycle-times-design.md
@@ -1,0 +1,35 @@
+# Vega BuildTask lifecycle times
+
+## Intent
+
+Align the SDK's BuildTask contract with the Vega lifecycle timestamp model in
+openbkn-ai/bkn-foundry#806.
+
+## Scope
+
+- Replace the BuildTask `update_time` response field with `start_time`,
+  `finish_time`, and `last_progress_time`.
+- Replace the BuildTask list sort values with `create_time`, `start_time`,
+  `finish_time`, and `last_progress_time`.
+- Update the Vega dataset build-list CLI help and SDK product specification.
+- Keep Discover and Semantic Understanding tasks out of scope: the SDK does
+  not currently expose clients for those endpoints.
+
+## Design
+
+The API-layer Zod schemas remain the SDK contract source of truth. Both the
+single-task and list-summary schemas expose optional lifecycle timestamps,
+because create, list, and status endpoints can return different response
+subsets and the backend omits unset timestamps.
+
+`BuildTaskSort` is the shared validator used by the API options and CLI. Its
+enum replaces `update_time` directly; there is no compatibility alias because
+the backend contract is intentionally breaking. Tests cover response parsing,
+query serialization, and CLI validation.
+
+## Rejected alternatives
+
+- Retain `update_time` as a deprecated SDK alias: it would advertise a query
+  value rejected by the backend and obscure the distinct lifecycle semantics.
+- Add Discover or Semantic Understanding clients in this change: that expands
+  the SDK surface beyond adapting the already exposed BuildTask contract.

--- a/src/api/vega.ts
+++ b/src/api/vega.ts
@@ -32,7 +32,12 @@ export const BuildTaskStatus = z.enum([
 ]);
 export type BuildTaskStatus = z.infer<typeof BuildTaskStatus>;
 
-export const BuildTaskSort = z.enum(["create_time", "update_time"]);
+export const BuildTaskSort = z.enum([
+  "create_time",
+  "start_time",
+  "finish_time",
+  "last_progress_time",
+]);
 export type BuildTaskSort = z.infer<typeof BuildTaskSort>;
 
 export const SortDirection = z.enum(["asc", "desc"]);
@@ -163,6 +168,9 @@ export const BuildTask = z
     total_count: z.number().optional(),
     synced_count: z.number().optional(),
     vectorized_count: z.number().optional(),
+    start_time: z.number().optional(),
+    finish_time: z.number().optional(),
+    last_progress_time: z.number().optional(),
     index_config: z.unknown().optional(),
     catalog_id: z.string().optional(),
     execute_type: BuildTaskExecuteType.optional(),
@@ -200,7 +208,9 @@ export const BuildTaskSummary = z
       type: z.string(),
     }),
     create_time: z.number(),
-    update_time: z.number(),
+    start_time: z.number().optional(),
+    finish_time: z.number().optional(),
+    last_progress_time: z.number().optional(),
     index_health: z
       .object({
         embedding: z.string(),
@@ -254,7 +264,7 @@ export async function listBuildTasks(
   const legacy = opts as ListBuildTasksOptions & { orderBy?: unknown; order?: unknown };
   if (legacy.orderBy !== undefined || legacy.order !== undefined) {
     throw new InputError(
-      'orderBy/order were replaced by sort ("create_time" | "update_time") and direction ("asc" | "desc")',
+      'orderBy/order were replaced by sort ("create_time" | "start_time" | "finish_time" | "last_progress_time") and direction ("asc" | "desc")',
     );
   }
   const res = await request<unknown>(ctx, `${VEGA_BASE}/build-tasks`, {

--- a/src/api/vega.ts
+++ b/src/api/vega.ts
@@ -267,6 +267,11 @@ export async function listBuildTasks(
       'orderBy/order were replaced by sort ("create_time" | "start_time" | "finish_time" | "last_progress_time") and direction ("asc" | "desc")',
     );
   }
+  if (opts.sort !== undefined && !BuildTaskSort.safeParse(opts.sort).success) {
+    throw new InputError(
+      `invalid build task sort "${opts.sort}"; expected one of ${BuildTaskSort.options.join(", ")}`,
+    );
+  }
   const res = await request<unknown>(ctx, `${VEGA_BASE}/build-tasks`, {
     query: {
       limit: opts.limit,

--- a/test/unit/vega-command.test.ts
+++ b/test/unit/vega-command.test.ts
@@ -215,7 +215,7 @@ describe("vega dataset build-list", () => {
         "dataset",
         "build-list",
         "--sort",
-        "update_time",
+        "finish_time",
         "--direction",
         "asc",
       ],
@@ -223,7 +223,7 @@ describe("vega dataset build-list", () => {
     );
 
     const url = new URL(fetchMock.mock.calls[0]?.[0] as string);
-    expect(url.searchParams.get("sort")).toBe("update_time");
+    expect(url.searchParams.get("sort")).toBe("finish_time");
     expect(url.searchParams.get("direction")).toBe("asc");
     expect(url.searchParams.has("order_by")).toBe(false);
     expect(url.searchParams.has("order")).toBe(false);
@@ -236,6 +236,7 @@ describe("vega dataset build-list", () => {
 
     const invalidOptions = [
       ["--sort", "created_at", /invalid build task sort/],
+      ["--sort", "update_time", /invalid build task sort/],
       ["--direction", "up", /invalid sort direction/],
     ] as const;
     for (const [flag, value, message] of invalidOptions) {

--- a/test/unit/vega.test.ts
+++ b/test/unit/vega.test.ts
@@ -201,6 +201,9 @@ describe("createBuildTask", () => {
         order: "asc",
       } as never),
     ).rejects.toThrow(/orderBy\/order were replaced by sort/);
+    await expect(listBuildTasks(ctx, { sort: "update_time" } as never)).rejects.toThrow(
+      /invalid build task sort/,
+    );
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -252,6 +255,32 @@ describe("createBuildTask", () => {
       ],
       total_count: 1,
     });
+  });
+
+  it("parses pending summaries without lifecycle timestamps", async () => {
+    mockFetch({
+      entries: [
+        {
+          id: "t-1",
+          resource_id: "r-1",
+          catalog_id: "c-1",
+          status: "pending",
+          mode: "batch",
+          total_count: 0,
+          synced_count: 0,
+          vectorized_count: 0,
+          synced_mark: "",
+          creator: { id: "u-1", type: "user" },
+          create_time: 100,
+        },
+      ],
+      total_count: 1,
+    });
+
+    const result = await listBuildTasks(ctx);
+    expect(result.entries[0]?.start_time).toBeUndefined();
+    expect(result.entries[0]?.finish_time).toBeUndefined();
+    expect(result.entries[0]?.last_progress_time).toBeUndefined();
   });
 
   it("exposes the persisted batch execute type and lifecycle timestamps", async () => {

--- a/test/unit/vega.test.ts
+++ b/test/unit/vega.test.ts
@@ -173,7 +173,7 @@ describe("createBuildTask", () => {
       catalogId: "c-1",
       status: ["pending", "running"],
       mode: "batch",
-      sort: "update_time",
+      sort: "last_progress_time",
       direction: "asc",
       limit: 5,
       offset: 10,
@@ -185,7 +185,7 @@ describe("createBuildTask", () => {
     expect(u.searchParams.getAll("status")).toEqual(["pending", "running"]);
     expect(u.searchParams.has("active")).toBe(false);
     expect(u.searchParams.get("mode")).toBe("batch");
-    expect(u.searchParams.get("sort")).toBe("update_time");
+    expect(u.searchParams.get("sort")).toBe("last_progress_time");
     expect(u.searchParams.get("direction")).toBe("asc");
     expect(u.searchParams.get("limit")).toBe("5");
     expect(u.searchParams.get("offset")).toBe("10");
@@ -219,7 +219,9 @@ describe("createBuildTask", () => {
           synced_mark: "mark-1",
           creator: { id: "u-1", type: "user" },
           create_time: 100,
-          update_time: 200,
+          start_time: 120,
+          finish_time: 200,
+          last_progress_time: 180,
           failure_detail: "detail-only",
           index_config: { features: [{ vector: {} }] },
         },
@@ -241,7 +243,9 @@ describe("createBuildTask", () => {
           synced_mark: "mark-1",
           creator: { id: "u-1", type: "user" },
           create_time: 100,
-          update_time: 200,
+          start_time: 120,
+          finish_time: 200,
+          last_progress_time: 180,
           failure_detail: "detail-only",
           index_config: { features: [{ vector: {} }] },
         },
@@ -250,11 +254,21 @@ describe("createBuildTask", () => {
     });
   });
 
-  it("exposes the persisted batch execute_type on task responses", async () => {
-    mockFetch({ id: "t-1", mode: "batch", execute_type: "incremental" });
+  it("exposes the persisted batch execute type and lifecycle timestamps", async () => {
+    mockFetch({
+      id: "t-1",
+      mode: "batch",
+      execute_type: "incremental",
+      start_time: 120,
+      finish_time: 200,
+      last_progress_time: 180,
+    });
     await expect(getBuildTask(ctx, "t-1")).resolves.toMatchObject({
       id: "t-1",
       execute_type: "incremental",
+      start_time: 120,
+      finish_time: 200,
+      last_progress_time: 180,
     });
   });
 


### PR DESCRIPTION
## What Changed

- [x] Replace BuildTask `update_time` with `start_time`, `finish_time`, and `last_progress_time`.
- [x] Replace BuildTask list sort values and CLI validation.
- [x] Add Vega lifecycle-time design, plan, product-spec, and regression coverage.

---

## Why

- Related Issue: [openbkn-ai/bkn-foundry#806](https://github.com/openbkn-ai/bkn-foundry/issues/806)
- Related Backend PR: [openbkn-ai/bkn-foundry#878](https://github.com/openbkn-ai/bkn-foundry/pull/878)
- Background: align the exposed SDK BuildTask contract with Vega lifecycle timestamps.

---

## How

- Key implementation points: update the API-layer Zod schemas and shared `BuildTaskSort` enum, which powers both SDK options and the dataset build-list CLI.
- Breaking changes (API, config, database, etc.): removes `update_time` from BuildTask responses and valid list sort values. No compatibility alias is retained.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable; this SDK change has no external-dependency test suite)
- [ ] Verified in test environment (not run)

Test notes:

- `npm run format`
- `npm run lint`
- `npm test` — 441 passed; 1 existing live test skipped
- `npm run build`

---

## Risk & Rollback

- Potential risks: callers still sending or reading `update_time` must migrate with the backend contract.
- Rollback plan: revert commit `c15859e` and deploy a compatible SDK version.

---

## Additional Notes

- Discover and Semantic Understanding clients are not currently exposed by this SDK, so they are outside this PR scope.
- /review