### PR TITLE
fix(vega): align build task progress contract

### DIFF
--- a/docs/product-specs/vega.md
+++ b/docs/product-specs/vega.md
@@ -35,8 +35,8 @@ snapshots that configuration.
 
 CLI:
 
-- `openbkn vega dataset build <resource-id> --mode batch [--embedding-fields …] [--build-key-fields …] [--embedding-model …] [--fulltext-fields …] [--execute-type incremental|full] [--wait] [--timeout <s>]` — optional index flags update the Resource, then create a BuildTask.
-- `openbkn vega dataset build-status <task-id>` — progress: `status` + `synced_count` / `vectorized_count`.
+- `openbkn vega dataset build <resource-id> --mode batch [--embedding-fields …] [--build-key-fields …] [--embedding-model <model-id>] [--fulltext-fields …] [--execute-type incremental|full] [--wait] [--timeout <s>]` — optional index flags update the Resource, then create a BuildTask. `--embedding-model` is a small-model ID.
+- `openbkn vega dataset build-status <task-id>` — progress: `status` + `synced_count`; a document is counted only after all required index processing, including vectorization, succeeds.
 - `openbkn vega dataset build-list --status pending,running` — filter by one or
   more statuses; the SDK sends repeated `status` query parameters. Use
   `--sort create_time|start_time|finish_time|last_progress_time` and

--- a/docs/references/bkn-platform-api-llms.txt
+++ b/docs/references/bkn-platform-api-llms.txt
@@ -27,12 +27,14 @@ Index build — BuildTask (current/target model)
 - Create: POST /build-tasks   body = CreateBuildTaskRequest
     resource_id      (required)  which resource
     mode             (required)  "streaming" | "batch"
-    embedding_fields (optional)  fields to vectorize
-    build_key_fields (optional)  batch: time field; streaming: unique row id
-    embedding_model  (optional)  default if omitted
-    model_dimensions (optional)  vector dimensions
-- Status/progress: GET /build-tasks/{id}  → state + SyncedCount / VectorizedCount
-- Config persists on the BuildTask entity (not on catalog/resource).
+    execute_type     (optional)  batch only: "incremental" | "full"; rejected for streaming
+- Index configuration: PUT /resources/{id} updates two Resource fields:
+  index_config (build_key_fields; default_embedding_model;
+  default_fulltext_analyzer) and schema_definition (per-property vector feature
+  config.embedding_model as a small-model ID; fulltext feature config.analyzer).
+  The BuildTask snapshots this Resource configuration when created.
+- Status/progress: GET /build-tasks/{id}  → status + synced_count
+- Config persists on the Resource; BuildTask retains the creation-time snapshot.
 - Resource property.feature_type ∈ {keyword, fulltext, vector} declares searchability (schema layer).
 - Resource.index_name is filled back by the build task after the index is built.
 - REPLACES the removed KN-level build (old: POST /api/ontology-manager/v1/knowledge-networks/{id}/jobs {job_type:"full"}).

--- a/src/api/vega.ts
+++ b/src/api/vega.ts
@@ -167,7 +167,6 @@ export const BuildTask = z
     state: z.string().optional(),
     total_count: z.number().optional(),
     synced_count: z.number().optional(),
-    vectorized_count: z.number().optional(),
     start_time: z.number().optional(),
     finish_time: z.number().optional(),
     last_progress_time: z.number().optional(),
@@ -199,7 +198,6 @@ export const BuildTaskSummary = z
     execute_type: BuildTaskExecuteType.optional(),
     total_count: z.number(),
     synced_count: z.number(),
-    vectorized_count: z.number(),
     synced_mark: z.string(),
     error_msg: z.string().optional(),
     creator: z.object({

--- a/src/commands/bkn.ts
+++ b/src/commands/bkn.ts
@@ -446,10 +446,7 @@ export function bknCommand(): Command {
     .description("Pack a BKN directory into a tar and import it as a knowledge network")
     .option("--branch <name>", "target branch", "main")
     .option("--build", "submit a Vega build task for each object type declaring a vector index")
-    .option(
-      "--embedding-model <id>",
-      "embedding model id for declared vector indexes (with --build)",
-    )
+    .option("--embedding-model <id>", "small-model ID for declared vector indexes (with --build)")
     .action(async (dir: string, opts, cmd: Command) => {
       printJson(
         await clientFrom(cmd).kn.push(dir, {
@@ -501,7 +498,7 @@ export function bknCommand(): Command {
       "--embedding-fields <map>",
       "columns to vectorize per table (with --build): '<table>:<col>[+<col>...][,...]'",
     )
-    .option("--embedding-model <id>", "embedding model id for the vector index (with --build)")
+    .option("--embedding-model <id>", "small-model ID for the vector index (with --build)")
     .option("--no-rollback", "keep a partially-created KN on failure")
     .action(async (catalogId: string, opts, cmd: Command) => {
       printJson(
@@ -545,7 +542,7 @@ export function bknCommand(): Command {
       "--embedding-fields <map>",
       "columns to vectorize per table (with --build): '<table>:<col>[+<col>...][,...]'",
     )
-    .option("--embedding-model <id>", "embedding model id for the vector index (with --build)")
+    .option("--embedding-model <id>", "small-model ID for the vector index (with --build)")
     .option("--no-rollback", "keep a partially-created KN on failure")
     .action(async (catalogId: string, opts, cmd: Command) => {
       printJson(

--- a/src/commands/vega.ts
+++ b/src/commands/vega.ts
@@ -485,7 +485,7 @@ export function vegaCommand(): Command {
       "--build-key-fields <list>",
       "comma-separated key fields (batch: time; streaming: row id)",
     )
-    .option("--embedding-model <id>", "default embedding model name/id")
+    .option("--embedding-model <id>", "small-model ID for the vector index")
     .option("--fulltext-fields <list>", "comma-separated fields for fulltext index")
     .option("--fulltext-analyzer <name>", "fulltext analyzer")
     .option("--execute-type <type>", "batch execution type: incremental | full")

--- a/test/unit/resources.test.ts
+++ b/test/unit/resources.test.ts
@@ -120,7 +120,7 @@ describe("updateResource/configureResourceIndex", () => {
     await configureResourceIndex(ctx, "r-1", {
       buildKeyFields: ["id"],
       embeddingFields: ["title"],
-      embeddingModel: "text-embedding-v4",
+      embeddingModel: "small-model-1",
       fulltextFields: ["body"],
       fulltextAnalyzer: "ik_max_word",
     });
@@ -128,13 +128,13 @@ describe("updateResource/configureResourceIndex", () => {
     const body = JSON.parse(calls[1]?.[1].body as string);
     expect(body.index_config).toEqual({
       build_key_fields: ["id"],
-      default_embedding_model: "text-embedding-v4",
+      default_embedding_model: "small-model-1",
       default_fulltext_analyzer: "ik_max_word",
     });
     expect(body.schema_definition[0].features[0]).toMatchObject({
       feature_type: "vector",
       ref_property: "title",
-      config: { embedding_model: "text-embedding-v4" },
+      config: { embedding_model: "small-model-1" },
     });
     expect(body.schema_definition[1].features[0]).toMatchObject({
       feature_type: "fulltext",

--- a/test/unit/vega.test.ts
+++ b/test/unit/vega.test.ts
@@ -218,7 +218,6 @@ describe("createBuildTask", () => {
           mode: "batch",
           total_count: 10,
           synced_count: 10,
-          vectorized_count: 8,
           synced_mark: "mark-1",
           creator: { id: "u-1", type: "user" },
           create_time: 100,
@@ -242,7 +241,6 @@ describe("createBuildTask", () => {
           mode: "batch",
           total_count: 10,
           synced_count: 10,
-          vectorized_count: 8,
           synced_mark: "mark-1",
           creator: { id: "u-1", type: "user" },
           create_time: 100,
@@ -257,6 +255,29 @@ describe("createBuildTask", () => {
     });
   });
 
+  it("parses summaries without vectorized_count and preserves it from legacy responses", async () => {
+    const summary = {
+      id: "t-1",
+      resource_id: "r-1",
+      catalog_id: "c-1",
+      status: "completed",
+      mode: "batch",
+      total_count: 10,
+      synced_count: 10,
+      synced_mark: "mark-1",
+      creator: { id: "u-1", type: "user" },
+      create_time: 100,
+    };
+
+    mockFetch({ entries: [summary], total_count: 1 });
+    await expect(listBuildTasks(ctx)).resolves.toMatchObject({ entries: [summary] });
+
+    mockFetch({ entries: [{ ...summary, vectorized_count: 8 }], total_count: 1 });
+    await expect(listBuildTasks(ctx)).resolves.toMatchObject({
+      entries: [{ ...summary, vectorized_count: 8 }],
+    });
+  });
+
   it("parses pending summaries without lifecycle timestamps", async () => {
     mockFetch({
       entries: [
@@ -268,7 +289,6 @@ describe("createBuildTask", () => {
           mode: "batch",
           total_count: 0,
           synced_count: 0,
-          vectorized_count: 0,
           synced_mark: "",
           creator: { id: "u-1", type: "user" },
           create_time: 100,


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Remove the obsolete vectorized_count field from BuildTask response schemas.
- [x] Add a focused regression test for responses with and without the retired field.
- [x] Correct the Vega API reference and update resource-index configuration tests.

---

## Why

- Related Issue: Closes openbkn-ai/bkn-foundry#834
- Related Feature: Converge Build Task vectorization
- Background: Vectorization is now part of a document's synchronous BuildTask processing. synced_count is the only progress counter, and embedding model configuration stores a small-model ID.

---

## How

- Key implementation points: Remove vectorized_count from Zod schemas and fixtures; preserve it at runtime only when an older backend still sends it through Zod passthrough; document synced_count, Resource-held index configuration, and small-model ID semantics.
- Breaking changes (API, config, database, etc.): After openbkn-ai/bkn-foundry#834 is deployed, BuildTask API responses and CLI --json no longer contain vectorized_count. SDK consumers must use synced_count; this PR aligns the typed SDK before that backend change.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable: unit tests mock HTTP)
- [ ] Verified in test environment (not run)

Test notes:

- npm run lint
- npm test -- --run test/unit/vega.test.ts test/unit/resources.test.ts

---

## Risk & Rollback

- Potential risks: Consumers that still access vectorized_count must migrate to synced_count when the backend deployment removes the field.
- Rollback plan: Revert this commit together with the backend contract change if the API rollback is required.

---

## Additional Notes

- The resource configuration fields default_embedding_model and embedding_model remain strings in the SDK; their documented and tested values are now small-model IDs.

/review