### PR TITLE
fix(bkn): a 504 on the probe means nothing answered

### DIFF
--- a/src/api/dataflow.ts
+++ b/src/api/dataflow.ts
@@ -16,6 +16,22 @@ export function listDataflows(ctx: RequestContext): Promise<unknown> {
   return request(ctx, `${BASE}/dags`, { query: { type: "data-flow", page: 0, limit: -1 } });
 }
 
+/**
+ * Reach the dataflow service without asking it for anything, for callers that
+ * only need to know whether it answers.
+ *
+ * `listDataflows` fetches every DAG (`limit=-1`); on a deploy with many of them
+ * that read is heavy enough that a gateway timeout says "this query was slow",
+ * not "nothing is there". A probe that draws that conclusion has to ask for one
+ * row and give up early, so a 504 has only one explanation left.
+ */
+export function pingDataflows(ctx: RequestContext): Promise<unknown> {
+  return request(ctx, `${BASE}/dags`, {
+    query: { type: "data-flow", page: 0, limit: 1 },
+    timeoutMs: 10_000,
+  });
+}
+
 /** Create a dataflow (DAG) from a full document body. Returns the new DAG id. */
 export function createDataflow(ctx: RequestContext, body: unknown): Promise<unknown> {
   return request(ctx, `${BASE_V1}/data-flow/flow`, { method: "POST", body });

--- a/src/api/dataflow.ts
+++ b/src/api/dataflow.ts
@@ -26,8 +26,12 @@ export function listDataflows(ctx: RequestContext): Promise<unknown> {
  *
  * The request keeps the default deadline on purpose. A shorter one would cut
  * off the very answer a caller wants: a hung upstream produces 504 only once
- * the gateway's own read timeout elapses (nginx defaults to 60s, Envoy to 15s),
- * so giving up first turns a diagnosis into an abort with nothing to say.
+ * the gateway's own read timeout elapses, and giving up first turns a diagnosis
+ * into an abort with nothing to say. Envoy's 15s default fits inside the 30s
+ * deadline; nginx's 60s does not, so on such a deploy a hung upstream still
+ * aborts client-side and the caller falls back to whatever it does when the
+ * probe says nothing. That is the safe direction — a probe that cannot tell
+ * lets the real call speak — but it is a boundary, not full coverage.
  */
 export function pingDataflows(ctx: RequestContext): Promise<unknown> {
   return request(ctx, `${BASE}/dags`, { query: { type: "data-flow", page: 0, limit: 1 } });

--- a/src/api/dataflow.ts
+++ b/src/api/dataflow.ts
@@ -22,14 +22,15 @@ export function listDataflows(ctx: RequestContext): Promise<unknown> {
  *
  * `listDataflows` fetches every DAG (`limit=-1`); on a deploy with many of them
  * that read is heavy enough that a gateway timeout says "this query was slow",
- * not "nothing is there". A probe that draws that conclusion has to ask for one
- * row and give up early, so a 504 has only one explanation left.
+ * not "nothing is there". Asking for one row removes that reading.
+ *
+ * The request keeps the default deadline on purpose. A shorter one would cut
+ * off the very answer a caller wants: a hung upstream produces 504 only once
+ * the gateway's own read timeout elapses (nginx defaults to 60s, Envoy to 15s),
+ * so giving up first turns a diagnosis into an abort with nothing to say.
  */
 export function pingDataflows(ctx: RequestContext): Promise<unknown> {
-  return request(ctx, `${BASE}/dags`, {
-    query: { type: "data-flow", page: 0, limit: 1 },
-    timeoutMs: 10_000,
-  });
+  return request(ctx, `${BASE}/dags`, { query: { type: "data-flow", page: 0, limit: 1 } });
 }
 
 /** Create a dataflow (DAG) from a full document body. Returns the new DAG id. */

--- a/src/resources/bkn-create.ts
+++ b/src/resources/bkn-create.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 OpenBKN. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See the LICENSE file in the project root.
 
-import { executeDataflow, listDataflows } from "../api/dataflow.js";
+import { executeDataflow, pingDataflows } from "../api/dataflow.js";
 /**
  * `bkn create-from-catalog` orchestration. Build a knowledge network from a
  * Vega catalog's tables:
@@ -642,13 +642,18 @@ export interface ImportCsvResult {
  * fine, so the probe steps aside and lets the real call speak (the same rule as
  * in `models.ts`). A 500 also steps aside: the service handled the request
  * badly, which is not the same as not being there.
+ *
+ * Reading 504 that way only holds because the probe asks for one row and gives
+ * up early (`pingDataflows`). Against the full listing a gateway timeout would
+ * as easily mean "that query was slow", and the costs are not symmetric: this
+ * branch aborts the command, while stepping aside costs one wasted attempt.
  */
 async function ensureDataflowAvailable(
   ctx: RequestContext,
   log: (m: string) => void,
 ): Promise<void> {
   try {
-    await listDataflows(ctx);
+    await pingDataflows(ctx);
   } catch (e) {
     // Both halves ask the same question — was it the service that answered?
     // `request()` raises `NonJsonResponseError` only for a 2xx, so here it

--- a/src/resources/bkn-create.ts
+++ b/src/resources/bkn-create.ts
@@ -634,11 +634,14 @@ export interface ImportCsvResult {
  * one identical 404 per table, hundreds of rows in — long past the point where
  * the user can tell "this deploy can't do that" from "my data is wrong".
  *
- * Only a gateway page or a 5xx counts as "no service": the probe reads
- * `automation/v2`, while the import runs on `v1`, so a plain JSON 404 means the
- * service answered — it just does not serve this listing. Blocking on that
- * would ground an import whose own endpoints are fine, so the probe steps
- * aside and lets the real call speak (see the same rule in `models.ts`).
+ * What counts as "no service" is narrow: a gateway page, or a status the
+ * gateway itself produces when nothing answers behind the route — 501, 502,
+ * 503, 504. The probe reads `automation/v2` while the import runs on `v1`, so a
+ * plain JSON 404 means the service answered and simply does not serve this
+ * listing; blocking on that would ground an import whose own endpoints are
+ * fine, so the probe steps aside and lets the real call speak (the same rule as
+ * in `models.ts`). A 500 also steps aside: the service handled the request
+ * badly, which is not the same as not being there.
  */
 async function ensureDataflowAvailable(
   ctx: RequestContext,
@@ -653,9 +656,14 @@ async function ensureDataflowAvailable(
     // something other than JSON (it is there; this listing just is not JSON).
     // Treating the second as an absent service is the JSON-404 false positive
     // again, wearing a different body.
+    // 504 belongs with 502/503, not with 500: the gateway routed the request
+    // and nothing answered. Every import batch would then wait out the full
+    // client timeout before failing, so twelve tables cost minutes of silence
+    // and twelve identical errors — the exact shape the preflight exists to
+    // prevent, one status code over.
     const missing =
       (e instanceof NonJsonResponseError && e.gateway) ||
-      (e instanceof HttpError && (e.gateway || [501, 502, 503].includes(e.status)));
+      (e instanceof HttpError && (e.gateway || [501, 502, 503, 504].includes(e.status)));
     if (!missing) {
       // An auth refusal is as conclusive as an absent service and just as
       // wasteful to discover per batch — surface it now, with its own cause and

--- a/src/resources/bkn-create.ts
+++ b/src/resources/bkn-create.ts
@@ -643,10 +643,10 @@ export interface ImportCsvResult {
  * in `models.ts`). A 500 also steps aside: the service handled the request
  * badly, which is not the same as not being there.
  *
- * Reading 504 that way only holds because the probe asks for one row and gives
- * up early (`pingDataflows`). Against the full listing a gateway timeout would
- * as easily mean "that query was slow", and the costs are not symmetric: this
- * branch aborts the command, while stepping aside costs one wasted attempt.
+ * Reading 504 that way only holds because the probe asks for one row
+ * (`pingDataflows`). Against the full listing a gateway timeout would as easily
+ * mean "that query was slow", and the costs are not symmetric: this branch
+ * aborts the command, while stepping aside costs one wasted attempt.
  */
 async function ensureDataflowAvailable(
   ctx: RequestContext,

--- a/test/unit/bkn-create.test.ts
+++ b/test/unit/bkn-create.test.ts
@@ -894,6 +894,40 @@ describe("createFromCsv dependency preflight", () => {
     expect(logs.join("\n")).toMatch(/preflight inconclusive/);
   });
 
+  it("stops on a 504, but not on a 500", async () => {
+    // 504: the gateway routed the request and nothing answered. Left to the
+    // import, every batch waits out the full client timeout before failing.
+    const gone = mockFetch([
+      [
+        /^\/api\/automation\/v2\/dags$/,
+        () => new Response(JSON.stringify({ error: "upstream timeout" }), { status: 504 }),
+      ],
+    ]);
+    await expect(
+      createFromCsv(ctx, { catalogId: "c-1", name: "kn", files: "/tmp/none.csv" }),
+    ).rejects.toThrow(/dataflow service is not available.*create-from-catalog/s);
+    expect(paths(gone)).toEqual(["/api/automation/v2/dags"]);
+
+    // 500: the service handled the request badly, which is not the same as not
+    // being there — the probe must step aside and let the real call speak.
+    const logs: string[] = [];
+    mockFetch([
+      [
+        /^\/api\/automation\/v2\/dags$/,
+        () => new Response(JSON.stringify({ error: "boom" }), { status: 500 }),
+      ],
+    ]);
+    await expect(
+      createFromCsv(ctx, {
+        catalogId: "c-1",
+        name: "kn",
+        files: "/tmp/none.csv",
+        onProgress: (m) => logs.push(m),
+      }),
+    ).rejects.not.toThrow(/dataflow service is not available/);
+    expect(logs.join("\n")).toMatch(/preflight inconclusive/);
+  });
+
   it("stops when a proxy answers the probe with a 200 login page", async () => {
     const f = mockFetch([
       // Session expired: an SSO proxy replies 200 with a sign-in page. The

--- a/test/unit/dataflow.test.ts
+++ b/test/unit/dataflow.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getDataflowLogs, listDataflowRuns, listDataflows } from "../../src/api/dataflow.js";
+import {
+  getDataflowLogs,
+  listDataflowRuns,
+  listDataflows,
+  pingDataflows,
+} from "../../src/api/dataflow.js";
 import type { RequestContext } from "../../src/types.js";
 
 const ctx: RequestContext = {
@@ -30,6 +35,16 @@ describe("dataflow read endpoints (automation v2)", () => {
     expect(u.pathname).toBe("/api/automation/v2/dags");
     expect(u.searchParams.get("type")).toBe("data-flow");
     expect(u.searchParams.get("limit")).toBe("-1");
+  });
+
+  it("ping asks for one row, not the whole listing", async () => {
+    const f = mockFetch();
+    await pingDataflows(ctx);
+    const u = url(f);
+    expect(u.pathname).toBe("/api/automation/v2/dags");
+    // A gateway timeout on the full listing would as easily mean "slow query"
+    // as "nobody answered"; callers reading 504 as absence need the bounded ask.
+    expect(u.searchParams.get("limit")).toBe("1");
   });
 
   it("runs hits /dag/{id}/results", async () => {

--- a/test/unit/dataflow.test.ts
+++ b/test/unit/dataflow.test.ts
@@ -37,6 +37,32 @@ describe("dataflow read endpoints (automation v2)", () => {
     expect(u.searchParams.get("limit")).toBe("-1");
   });
 
+  it("ping keeps the default deadline, so a gateway can still answer 504", async () => {
+    vi.useFakeTimers();
+    try {
+      let signal: AbortSignal | undefined;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_i: string, init: RequestInit = {}) => {
+          signal = init.signal ?? undefined;
+          // Never settles: the point is what happens while the request is open.
+          return new Promise<Response>(() => {});
+        }),
+      );
+      void pingDataflows(ctx);
+      await Promise.resolve();
+      // A hung upstream yields 504 only once the gateway's own read timeout
+      // elapses. Giving up before then would abort with nothing to report, and
+      // the preflight reading 504 as absence would never see one.
+      vi.advanceTimersByTime(20_000);
+      expect(signal?.aborted).toBe(false);
+      vi.advanceTimersByTime(11_000);
+      expect(signal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("ping asks for one row, not the whole listing", async () => {
     const f = mockFetch();
     await pingDataflows(ctx);


### PR DESCRIPTION
#49 评审最后留下的一条，不阻塞，单独提。

`create-from-csv` 的 dataflow 预检把 501 / 502 / 503 判成「这个部署没有 dataflow 服务」，唯独漏了 **504**。而 504 是网关给出的同一类结论：**路由通了，上游没回话**（没起来 / 崩着 / 挂死）。

漏掉的代价正是这个预检存在的理由。导入链路是 create → run → 轮询，上游没起来时 `createDataflow` 那一次要等满 30s 客户端超时才失败，下一张表重来 —— 12 张表就是几分钟空等外加 12 行一模一样的 `[table] import failed`。#49 描述里第 2 条要消灭的就是这一幕，它换了个状态码又进来了。

**500 仍然不算**：服务把请求处理砸了，说明它在那儿，和「不存在」不是一回事 —— 预检该让开，由真实调用说话。这条和 `models.ts` 里「裸 404 是真的没这条记录」是同一条判据。

## 测试

`stops on a 504, but not on a 500` 一条覆盖两侧：

- 504 → 抛「服务不可用」并指向 `create-from-catalog`，且只发了探针那一个请求（一个 CSV 都没读）
- 500 → 不抛那句，日志出 `preflight inconclusive`，放行

改回 `[501, 502, 503]` 后第一半必红 —— 验过。

`npm run ci`：488 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)