### PR TITLE
fix(sdk): send conversation_mode where the deploy requires it

### DIFF
--- a/src/api/lifecycle.ts
+++ b/src/api/lifecycle.ts
@@ -47,6 +47,26 @@ export interface BknContext {
 /** Which lifecycle contract a deploy speaks, decided from its tool catalog. */
 type Contract = "none" | "managed-v1" | "managed-v2";
 
+/**
+ * What the catalog says about opening an interaction, beyond which tools exist.
+ *
+ * `bkn_start_interaction` gained a required `conversation_mode` in a later
+ * platform build. A deploy that wants it refuses every handshake without it,
+ * and the refusal surfaces as the server's own `conversation_required` on the
+ * *business* call — so the whole `context` surface stops working with an error
+ * that names neither the field nor the handshake.
+ *
+ * Read from the tool's own `input_schema` rather than assumed from the contract
+ * name: both shapes advertise `managed-v2`, and only the schema separates them.
+ * Sending the field where it is not declared is not the safe default either —
+ * v2 validates `bkn_context` strictly, and a deploy is entitled to reject an
+ * argument it never published.
+ */
+interface Lifecycle {
+  contract: Contract;
+  startWantsConversationMode: boolean;
+}
+
 interface Session {
   contract: Exclude<Contract, "none">;
   conversationId: string;
@@ -93,7 +113,7 @@ const AGENT_NAME = "openbkn-sdk";
  */
 const RELEASE_TIMEOUT_MS = 3_000;
 
-const contracts = new Map<string, Promise<Contract>>();
+const contracts = new Map<string, Promise<Lifecycle>>();
 
 /**
  * How long a failed probe stays failed.
@@ -126,19 +146,26 @@ export function resetLifecycleCaches(): void {
  * that fails answers "none": an unreachable catalog must not turn into a hard
  * error on a request that might have succeeded without any context.
  */
-export function lifecycleContract(ctx: RequestContext): Promise<Contract> {
+const NO_LIFECYCLE: Lifecycle = { contract: "none", startWantsConversationMode: false };
+
+export function lifecycleFor(ctx: RequestContext): Promise<Lifecycle> {
   const failureKey = `${ctx.baseUrl}\0${identityOf(ctx)}`;
   const failedAt = probeFailures.get(failureKey);
   if (failedAt !== undefined) {
-    if (Date.now() - failedAt < PROBE_FAILURE_TTL_MS) return Promise.resolve("none");
+    if (Date.now() - failedAt < PROBE_FAILURE_TTL_MS) return Promise.resolve(NO_LIFECYCLE);
     probeFailures.delete(failureKey);
   }
   let pending = contracts.get(ctx.baseUrl);
   if (!pending) {
-    pending = mcpInfo(ctx).then((info): Contract => {
+    pending = mcpInfo(ctx).then((info): Lifecycle => {
       const names = toolNames(info);
-      if (names.includes(V1_MARKER)) return "managed-v1";
-      return names.includes(V2_MARKER) ? "managed-v2" : "none";
+      const startWantsConversationMode = requiresArgument(info, V2_MARKER, "conversation_mode");
+      if (names.includes(V1_MARKER)) {
+        return { contract: "managed-v1", startWantsConversationMode };
+      }
+      return names.includes(V2_MARKER)
+        ? { contract: "managed-v2", startWantsConversationMode }
+        : NO_LIFECYCLE;
     });
     contracts.set(ctx.baseUrl, pending);
     // Same rule the session cache follows: a probe that failed is not a lasting
@@ -156,7 +183,28 @@ export function lifecycleContract(ctx: RequestContext): Promise<Contract> {
   }
   // Degrade for this call regardless: an unreachable catalog must not turn into
   // a hard error on a request that might have succeeded without any context.
-  return pending.catch((): Contract => "none");
+  return pending.catch((): Lifecycle => NO_LIFECYCLE);
+}
+
+/** Kept for callers that only care which contract a deploy speaks. */
+export function lifecycleContract(ctx: RequestContext): Promise<Contract> {
+  return lifecycleFor(ctx).then((l) => l.contract);
+}
+
+/**
+ * Does a tool declare this argument as required?
+ *
+ * `false` when the catalog cannot be read that far — an unknown schema means
+ * "send what has always worked", not "guess a new field in".
+ */
+function requiresArgument(info: unknown, tool: string, argument: string): boolean {
+  const tools = (info as { tools?: Array<Record<string, unknown>> } | undefined)?.tools;
+  if (!Array.isArray(tools)) return false;
+  const found = tools.find((t) => t?.name === tool);
+  // The catalog spells it `input_schema`; MCP's own wire format uses
+  // `inputSchema`. Accept both rather than depend on which one answers.
+  const schema = (found?.input_schema ?? found?.inputSchema) as { required?: unknown } | undefined;
+  return Array.isArray(schema?.required) && schema.required.includes(argument);
 }
 
 function isAuthFailure(err: unknown): boolean {
@@ -252,10 +300,16 @@ function joinTarget(ctx: RequestContext, contract: Exclude<Contract, "none">): s
 async function openSession(
   ctx: RequestContext,
   knId: string,
-  contract: Exclude<Contract, "none">,
+  lifecycle: Lifecycle & { contract: Exclude<Contract, "none"> },
   question: string,
 ): Promise<Session> {
+  const { contract } = lifecycle;
   generation += 1;
+  // Declared required by later builds, absent from the schema of earlier ones.
+  // `continue` whenever a conversation is named — that is exactly what the
+  // enum means — and `new` when one is being minted.
+  const mode = (joining: boolean) =>
+    lifecycle.startWantsConversationMode ? { conversation_mode: joining ? "continue" : "new" } : {};
   const named = joinTarget(ctx, contract);
   if (contract === "managed-v2") {
     // Without a conversation_id the server mints a fresh conversation. Reusing
@@ -264,6 +318,7 @@ async function openSession(
     // a caller-named conversation is passed back in.
     const started = await callToolRaw(ctx, knId, V2_MARKER, {
       question,
+      ...mode(Boolean(named)),
       // The name is fixed when the conversation is created, so it belongs only
       // on the call that creates one. Joining a conversation the caller named
       // and relabelling it `openbkn-sdk` would rewrite their attribution — the
@@ -297,6 +352,7 @@ async function openSession(
       conversation_id: named,
       idempotency_key: `start:${PROCESS_ID}:${generation}`,
       question,
+      ...mode(true),
     });
     return {
       contract,
@@ -319,6 +375,7 @@ async function openSession(
     conversation_id: conversationId,
     idempotency_key: `start:${PROCESS_ID}:${generation}`,
     question,
+    ...mode(true),
   });
   return {
     contract,
@@ -372,9 +429,10 @@ function sessionKey(ctx: RequestContext, knId: string): string {
 function ensureSession(
   ctx: RequestContext,
   knId: string,
-  contract: Exclude<Contract, "none">,
+  lifecycle: Lifecycle & { contract: Exclude<Contract, "none"> },
   question: string,
 ): Promise<Session> {
+  const { contract } = lifecycle;
   const key = sessionKey(ctx, knId);
   const cached = sessions.get(key);
   if (cached) return cached;
@@ -391,12 +449,12 @@ function ensureSession(
   // under them.
   const remembered = callerNamedConversation(ctx) ? undefined : joinTarget(ctx, contract);
   const opening = remembered
-    ? openSession(ctx, knId, contract, question).catch((err: unknown) => {
+    ? openSession(ctx, knId, lifecycle, question).catch((err: unknown) => {
         if (!refusesThisConversation(err)) throw err;
         const { rememberedConversationId: _dropped, ...fresh } = ctx;
-        return openSession(fresh, knId, contract, question);
+        return openSession(fresh, knId, lifecycle, question);
       })
-    : openSession(ctx, knId, contract, question);
+    : openSession(ctx, knId, lifecycle, question);
   // Report only a conversation this call minted. One the caller named is
   // already theirs to keep, and echoing it back would let a `--conversation-id`
   // meant for a single command quietly become the stored default.
@@ -456,14 +514,16 @@ export async function bknContextFor(
   knId: string,
   question: string,
 ): Promise<BknContext | undefined> {
-  const contract = await lifecycleContract(ctx);
+  const lifecycle = await lifecycleFor(ctx);
+  const { contract } = lifecycle;
   if (contract === "none") return undefined;
 
   const owned = callerOwnedSession(ctx);
   if (owned) return contextFor(owned, contract);
 
   try {
-    return contextFor(await ensureSession(ctx, knId, contract, question), contract);
+    const session = await ensureSession(ctx, knId, { ...lifecycle, contract }, question);
+    return contextFor(session, contract);
   } catch {
     // Fall through with no context: the server's own error names the missing
     // piece far better than a handshake failure would.

--- a/test/unit/lifecycle.test.ts
+++ b/test/unit/lifecycle.test.ts
@@ -15,6 +15,22 @@ const V2_CATALOG = {
   tools: [{ name: "bkn_start_interaction" }, { name: "bkn_finish_interaction" }],
 };
 const LEGACY_CATALOG = { tools: [{ name: "search_schema" }] };
+// A later platform build declares `conversation_mode` required on the start
+// tool. Both shapes advertise the same tool names, so only the schema tells
+// them apart — which is why the probe reads it.
+const V2_CATALOG_WITH_MODE = {
+  tools: [
+    {
+      name: "bkn_start_interaction",
+      input_schema: {
+        type: "object",
+        required: ["conversation_mode", "question", "agent_name"],
+        properties: { conversation_mode: { enum: ["continue", "new"] } },
+      },
+    },
+    { name: "bkn_finish_interaction" },
+  ],
+};
 
 /** A fresh host per test: both the lifecycle and MCP session caches key on it. */
 let hostSeq = 0;
@@ -320,6 +336,37 @@ describe("managed lifecycle on semantic search", () => {
       );
     },
   );
+
+  it("sends conversation_mode only where the catalog declares it required", async () => {
+    // Without it, a deploy that requires the field refuses every handshake, and
+    // the refusal surfaces as the server's `conversation_required` on the
+    // business call — naming neither the field nor the handshake.
+    const withMode = mockDeploy({ catalog: V2_CATALOG_WITH_MODE });
+    await semanticSearch(freshCtx(), "kn-managed", "物料");
+    expect(withMode.toolCalls[0]?.arguments.conversation_mode).toBe("new");
+
+    // And not where it is absent: v2 validates strictly, and a deploy may
+    // reject an argument it never published.
+    const without = mockDeploy({ catalog: V2_CATALOG });
+    await semanticSearch(freshCtx(), "kn-managed", "物料");
+    expect(without.toolCalls[0]?.arguments).not.toHaveProperty("conversation_mode");
+  });
+
+  it("joins with continue, not new", async () => {
+    const recorded = mockDeploy({ catalog: V2_CATALOG_WITH_MODE });
+    await semanticSearch(
+      freshCtx({
+        trace: { requestId: "req_x", traceparent: "00-x-y-01", conversationId: "conv_theirs" },
+      }),
+      "kn-managed",
+      "物料",
+    );
+    // The enum's own wording: `continue` with an id, `new` without one.
+    expect(recorded.toolCalls[0]?.arguments).toMatchObject({
+      conversation_id: "conv_theirs",
+      conversation_mode: "continue",
+    });
+  });
 
   it("does not report a conversation it only joined", async () => {
     const seen: string[] = [];


### PR DESCRIPTION
跑 e2e 时对着第二台部署（`14.103.77.23`）发现的 —— **那台上 `context` 的全部业务调用不可用**。

## 症状

```
$ openbkn context tool-call <kn> search_schema --arg query=test
Context-loader error: {"code":"conversation_required","message":"conversation_id is required",
                       "required_action":"bkn_start_interaction"}
```

`tool-call` / `search-schema` / `kn-detail` / `object-types` / `query-object-instance` 全挂，`bkn search` 也挂。e2e 在那台上 **42 passed / 14 failed**，14 条全是这一个根因；同一份代码在 `10.211.55.4` 上是 47/0。

## 原因

新版平台给 `bkn_start_interaction` 加了必填的 `conversation_mode`，SDK 从不发。手工补上立刻成功：

```
--args '{"question":"probe","agent_name":"openbkn-sdk","conversation_mode":"new"}'
→ {"interaction_id":"int_757e...","conversation_id":"conv_bc6c...","execution_status":"active"}
```

握手失败之后 `bknContextFor` 会吞掉错误返回 `undefined`（这是有意的降级），于是服务端接着以「缺 `bkn_context`」拒绝业务调用 —— 报错**既没提这个字段，也没提握手**。

## 为什么不能无条件加

两台部署**工具名完全一样**，只有 schema 不同：

```
.23           required: ["conversation_mode", "question", "agent_name"]
10.211.55.4   required: ["question", "agent_name"]
```

v2 对参数校验严格，给一个它没公布过的字段是有权拒绝的。所以判据只能是目录里的 `input_schema.required`。

## 改法

契约探测本来就在拉这份目录，只是取完工具名就把 schema 扔了。现在同一次探测里一并记下「start 工具要不要 `conversation_mode`」：

- 加入已有 conversation → `continue`
- 新建 → `new`

（enum 自己的描述就是这么写的：*Use new without conversation_id ... otherwise continue with the ID returned by start*）

目录读不到那一层时答 `false` —— **schema 未知意味着「发一直以来能用的那份」，不是「猜一个新字段进去」**。

## 验证

真机两侧：

| | 修复前 | 修复后 |
| --- | --- | --- |
| `14.103.77.23` | `conversation_required`，全挂 | 返回 conversation + interaction ✅ |
| `10.211.55.4` | 正常 | 正常，无回归 ✅ |

e2e 套件：`.23` 42/14 → **45/2**（剩 2 条是那台 KN 的模型差异，归 #61）；`10.211.55.4` 仍 47/0。

单测两个方向都钉住：改成「从不发」→ 2 条红；改成「总是发」→ 4 条红。

`npm run ci`：558 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)