### PR TITLE
feat(vega): align resource index state contract

### DIFF
--- a/docs/product-specs/vega.md
+++ b/docs/product-specs/vega.md
@@ -45,7 +45,7 @@ CLI:
   more statuses; the SDK sends repeated `status` query parameters. Use
   `--sort create_time|start_time|finish_time|last_progress_time` and
   `--direction asc|desc` for ordering.
-- `openbkn vega dataset build-start <task-id> [--reset]` — `--reset` restarts only a full task; it is ignored for incremental tasks.
+- `openbkn vega dataset build-start <task-id> [--reset]` — `--reset` restarts only a full task; incremental tasks reject it.
 
 **Field searchability is separate** — declared on the resource property schema via
 `feature_type` (`keyword` | `fulltext` | `vector`). The Resource configuration

--- a/src/api/resources.ts
+++ b/src/api/resources.ts
@@ -60,6 +60,9 @@ export type ResourceCategory = z.infer<typeof ResourceCategory>;
 export const ResourceStatus = z.enum(["active", "disabled", "deprecated", "stale"]);
 export type ResourceStatus = z.infer<typeof ResourceStatus>;
 
+export const ResourceLocalStatus = z.enum(["unavailable", "available", "stale"]);
+export type ResourceLocalStatus = z.infer<typeof ResourceLocalStatus>;
+
 export interface ResourceLike {
   id?: string;
   catalog_id?: string;
@@ -138,6 +141,7 @@ export const Resource = z
       })
       .passthrough()
       .optional(),
+    local_status: ResourceLocalStatus,
     index_name: z.string().optional(),
     column_count: z.number().optional(),
     row_count: z.number().optional(),

--- a/src/api/vega.ts
+++ b/src/api/vega.ts
@@ -355,7 +355,6 @@ export async function getBuildTask(ctx: RequestContext, taskId: string): Promise
 
 export interface DeleteBuildTasksOptions {
   ignoreMissing?: boolean;
-  deleteActiveIndex?: boolean;
 }
 
 export function deleteBuildTasks(
@@ -367,8 +366,6 @@ export function deleteBuildTasks(
     method: "DELETE",
     query: {
       ignore_missing: opts.ignoreMissing === undefined ? undefined : String(opts.ignoreMissing),
-      delete_active_index:
-        opts.deleteActiveIndex === undefined ? undefined : String(opts.deleteActiveIndex),
     },
   });
 }

--- a/src/commands/vega.ts
+++ b/src/commands/vega.ts
@@ -1038,7 +1038,7 @@ export function vegaCommand(): Command {
   dataset
     .command("build-start <task-id>")
     .description("Start a BuildTask")
-    .option("--reset", "restart a full task from the beginning (ignored for incremental tasks)")
+    .option("--reset", "restart a full task from the beginning (rejected for incremental tasks)")
     .action(async (taskId: string, opts, cmd: Command) => {
       printJson(
         await clientFrom(cmd).vega.startBuildTask(taskId, { reset: opts.reset }),
@@ -1057,12 +1057,10 @@ export function vegaCommand(): Command {
     .command("build-delete <ids...>")
     .description("Delete one or more BuildTasks")
     .option("--ignore-missing", "ignore missing task ids")
-    .option("--delete-active-index", "delete active indexes too")
     .action(async (ids: string[], opts, cmd: Command) => {
       printJson(
         await clientFrom(cmd).vega.deleteBuildTasks(ids, {
           ignoreMissing: opts.ignoreMissing,
-          deleteActiveIndex: opts.deleteActiveIndex,
         }),
         outputOptions(cmd),
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,6 +191,7 @@ export type {
   ResourceCategory,
   ResourceDataPaging,
   ResourceDocument,
+  ResourceLocalStatus,
   ResourceStatus,
   UpdateResourceOptions,
 } from "./api/resources.js";

--- a/test/unit/bkn-create.test.ts
+++ b/test/unit/bkn-create.test.ts
@@ -71,6 +71,7 @@ function normalizeVegaResponse(url: URL, body: unknown): unknown {
     catalog_id: "c-1",
     category: "table",
     status: "active",
+    local_status: "unavailable",
     source_identifier: "table",
     creator: { id: "u-1", type: "user" },
     create_time: 1,

--- a/test/unit/resources.test.ts
+++ b/test/unit/resources.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import {
   configureResourceIndex,
   createResource,
@@ -15,6 +15,7 @@ import {
   upsertResourceDocument,
   upsertResourceDocuments,
 } from "../../src/api/resources.js";
+import type { ResourceLocalStatus } from "../../src/index.js";
 import type { RequestContext } from "../../src/types.js";
 import { HttpError, InputError } from "../../src/utils/errors.js";
 
@@ -55,6 +56,12 @@ function firstCall(fetchMock: typeof fetch): CallArgs {
 }
 
 afterEach(() => vi.unstubAllGlobals());
+
+describe("ResourceLocalStatus", () => {
+  it("is exported from the SDK entry point", () => {
+    expectTypeOf<ResourceLocalStatus>().toEqualTypeOf<"unavailable" | "available" | "stale">();
+  });
+});
 
 describe("listResources", () => {
   it("maps list filters to vega-backend query params", async () => {

--- a/test/unit/resources.test.ts
+++ b/test/unit/resources.test.ts
@@ -39,6 +39,7 @@ function resourceFixture(overrides: Record<string, unknown> = {}) {
     name: "orders",
     category: "table",
     status: "active",
+    local_status: "unavailable",
     source_identifier: "orders",
     creator: { id: "u-1", type: "user" },
     create_time: 1,
@@ -116,6 +117,9 @@ describe("listResources", () => {
     await expect(listResources(ctx)).resolves.toMatchObject({
       entries: [{ category: "warehouse", status: "archived", logic_type: "materialized" }],
     });
+
+    mockFetch({ entries: [resourceFixture({ local_status: "unknown" })], total_count: 1 });
+    await expect(listResources(ctx)).rejects.toThrow();
   });
 
   it("rejects an empty resource detail envelope", () => {

--- a/test/unit/vega.test.ts
+++ b/test/unit/vega.test.ts
@@ -381,7 +381,6 @@ describe("createBuildTask", () => {
     await stopBuildTask(ctx, "t-1");
     await deleteBuildTasks(ctx, ["t-1", "t-2"], {
       ignoreMissing: true,
-      deleteActiveIndex: true,
     });
     const calls = (f as unknown as { mock: { calls: CallArgs[] } }).mock.calls;
     expect(new URL(calls[0]?.[0] ?? "").pathname).toBe(
@@ -392,7 +391,7 @@ describe("createBuildTask", () => {
     const deleteUrl = new URL(calls[2]?.[0] ?? "");
     expect(deleteUrl.pathname).toBe("/api/vega-backend/v1/build-tasks/t-1,t-2");
     expect(deleteUrl.searchParams.get("ignore_missing")).toBe("true");
-    expect(deleteUrl.searchParams.get("delete_active_index")).toBe("true");
+    expect(deleteUrl.searchParams.has("delete_active_index")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What Changed

- [x] Add the typed Resource `local_status` contract (`unavailable`, `available`, `stale`).
- [x] Remove the obsolete BuildTask `delete_active_index` API option and CLI flag.
- [x] Update the incremental-reset CLI/product wording and regression coverage.

---

## Why

- Related Issue: Closes #774
- Background: Resource-owned local-index state and committed batch checkpoints replace Task-owned state for the current index lifecycle.

---

## How

- Validate `local_status` at the SDK HTTP boundary and export `ResourceLocalStatus` from the package entry point.
- Stop serializing `delete_active_index`; task deletion no longer controls the Resource current index.
- Breaking changes (API, config, database, etc.): removes `DeleteBuildTasksOptions.deleteActiveIndex` and `openbkn vega dataset build-delete --delete-active-index`; Resource responses now require `local_status`.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not run; no backend integration environment)
- [ ] Verified in test environment (not run)

Test notes:

- `npm run lint`
- `npm test` — 560 passed, 1 skipped
- `npm run build`

---

## Risk & Rollback

- Potential risks: callers using the removed delete option need to remove it; callers must consume the new Resource response field.
- Rollback plan: revert this SDK PR together with the corresponding backend contract rollout.

---

## Additional Notes

- No generated API artifacts changed.