### PR TITLE
refactor(vega): remove extensions contract

### DIFF
--- a/src/api/resources.ts
+++ b/src/api/resources.ts
@@ -35,7 +35,6 @@ export interface ResourceProperty {
   original_description?: string;
   features?: PropertyFeature[];
   attributes?: Record<string, unknown>;
-  extensions?: Record<string, string>;
 }
 
 export interface ResourceIndexConfig {
@@ -77,7 +76,6 @@ export interface ResourceLike {
   schema_definition?: ResourceProperty[];
   index_config?: ResourceIndexConfig;
   logic_definition?: unknown;
-  extensions?: Record<string, string>;
   update_time?: number;
 }
 
@@ -111,7 +109,6 @@ const ResourcePropertySchema: z.ZodType<ResourceProperty> = z
       )
       .optional(),
     attributes: z.record(z.unknown()).optional(),
-    extensions: z.record(z.string()).optional(),
   })
   .passthrough();
 
@@ -131,7 +128,6 @@ export const Resource = z
     schema: z.string().optional(),
     source_identifier: z.string(),
     source_metadata: z.record(z.unknown()).optional(),
-    extensions: z.record(z.string()).optional(),
     schema_definition: z.array(ResourcePropertySchema).optional(),
     index_config: z
       .object({
@@ -175,9 +171,6 @@ export interface ListResourcesOptions {
   offset?: number;
   sort?: "name" | "create_time" | "update_time";
   direction?: "asc" | "desc";
-  includeExtensions?: boolean;
-  includeExtensionKeys?: string;
-  extensionPairs?: Array<{ key: string; value: string }>;
 }
 
 export async function listResources(
@@ -203,11 +196,6 @@ export async function listResources(
       offset: opts.offset,
       sort: opts.sort,
       direction: opts.direction,
-      include_extensions:
-        opts.includeExtensions === undefined ? undefined : String(opts.includeExtensions),
-      include_extension_keys: opts.includeExtensionKeys || undefined,
-      extension_key: opts.extensionPairs?.map((p) => p.key),
-      extension_value: opts.extensionPairs?.map((p) => p.value),
     },
   });
   return ListResourcesResponse.parse(result);
@@ -243,7 +231,6 @@ export interface CreateResourceRequest {
   schema?: string;
   sourceIdentifier?: string;
   sourceMetadata?: Record<string, unknown>;
-  extensions?: Record<string, string>;
   schemaDefinition?: ResourceProperty[];
   indexConfig?: ResourceIndexConfig;
   logicDefinition?: unknown;
@@ -264,7 +251,6 @@ export async function createResource(
     ...(req.schema !== undefined ? { schema: req.schema } : {}),
     ...(req.sourceIdentifier !== undefined ? { source_identifier: req.sourceIdentifier } : {}),
     ...(req.sourceMetadata !== undefined ? { source_metadata: req.sourceMetadata } : {}),
-    ...(req.extensions !== undefined ? { extensions: req.extensions } : {}),
     ...(req.schemaDefinition !== undefined ? { schema_definition: req.schemaDefinition } : {}),
     ...(req.indexConfig !== undefined ? { index_config: req.indexConfig } : {}),
     ...(req.logicDefinition !== undefined ? { logic_definition: req.logicDefinition } : {}),
@@ -279,7 +265,6 @@ export interface UpdateResourceOptions {
   schemaDefinition?: ResourceProperty[];
   indexConfig?: ResourceIndexConfig;
   logicDefinition?: unknown;
-  extensions?: Record<string, string>;
   /** Optimistic-lock version from an earlier Resource `update_time`. */
   expectedUpdateTime?: number;
 }
@@ -378,9 +363,6 @@ function resourceUpdateBody(
     index_config: patch.indexConfig === undefined ? current.index_config : patch.indexConfig,
     logic_definition: patch.logicDefinition ?? current.logic_definition,
   };
-  if (patch.extensions !== undefined || current.extensions !== undefined) {
-    body.extensions = patch.extensions ?? current.extensions;
-  }
   const expectedUpdateTime = patch.expectedUpdateTime ?? current.update_time;
   if (expectedUpdateTime !== undefined) {
     body.expected_update_time = expectedUpdateTime;

--- a/src/api/vega.ts
+++ b/src/api/vega.ts
@@ -71,7 +71,6 @@ export const Catalog = z
     connector_type: z.string(),
     connector_config: z.record(z.unknown()).optional(),
     metadata: z.record(z.unknown()).optional(),
-    extensions: z.record(z.string()).optional(),
     health_check_status: z.string().optional(),
     last_check_time: z.number().optional(),
     health_check_result: z.string().optional(),
@@ -106,9 +105,7 @@ export type ListCatalogsResponse = z.infer<typeof ListCatalogsResponse>;
 export const BatchCatalogsResponse = z.object({ entries: z.array(Catalog) }).passthrough();
 export type BatchCatalogsResponse = z.infer<typeof BatchCatalogsResponse>;
 
-export const CatalogRef = z
-  .object({ id: z.string(), extensions: z.record(z.string()).optional() })
-  .passthrough();
+export const CatalogRef = z.object({ id: z.string() }).passthrough();
 export type CatalogRef = z.infer<typeof CatalogRef>;
 
 export const CatalogHealthStatus = z
@@ -453,9 +450,6 @@ export interface ListCatalogsOptions {
   connectorType?: string;
   enabled?: boolean;
   healthCheckStatus?: CatalogHealthCheckStatus;
-  includeExtensions?: boolean;
-  includeExtensionKeys?: string;
-  extensionPairs?: Array<{ key: string; value: string }>;
   sort?: "name" | "create_time" | "update_time";
   direction?: "asc" | "desc";
 }
@@ -474,11 +468,6 @@ export async function listCatalogs(
       connector_type: opts.connectorType || undefined,
       enabled: opts.enabled === undefined ? undefined : String(opts.enabled),
       health_check_status: opts.healthCheckStatus || undefined,
-      include_extensions:
-        opts.includeExtensions === undefined ? undefined : String(opts.includeExtensions),
-      include_extension_keys: opts.includeExtensionKeys || undefined,
-      extension_key: opts.extensionPairs?.map((p) => p.key),
-      extension_value: opts.extensionPairs?.map((p) => p.value),
       sort: opts.sort,
       direction: opts.direction,
     },
@@ -515,7 +504,6 @@ export interface CreateCatalogRequest {
   enabled?: boolean;
   id?: string;
   internal?: boolean;
-  extensions?: Record<string, string>;
   healthCheckSchedule?: CatalogHealthCheckScheduleConfig | null;
 }
 
@@ -527,7 +515,6 @@ export interface UpdateCatalogRequest {
   connectorConfig?: Record<string, unknown>;
   tags?: string[];
   description?: string;
-  extensions?: Record<string, string>;
   /** Required optimistic-lock version from the latest Catalog `update_time`. */
   expectedUpdateTime: number;
 }
@@ -552,7 +539,6 @@ export function createCatalog(
       ...(req.description !== undefined ? { description: req.description } : {}),
       ...(req.enabled !== undefined ? { enabled: req.enabled } : {}),
       ...(req.internal !== undefined ? { internal: req.internal } : {}),
-      ...(req.extensions !== undefined ? { extensions: req.extensions } : {}),
       ...(req.healthCheckSchedule !== undefined
         ? {
             health_check_schedule:
@@ -585,7 +571,6 @@ export function updateCatalog(
       ...(req.connectorConfig !== undefined ? { connector_config: req.connectorConfig } : {}),
       ...(req.tags !== undefined ? { tags: req.tags } : {}),
       ...(req.description !== undefined ? { description: req.description } : {}),
-      ...(req.extensions !== undefined ? { extensions: req.extensions } : {}),
       expected_update_time: req.expectedUpdateTime,
     },
     timeoutMs: 60_000,

--- a/src/commands/resource.ts
+++ b/src/commands/resource.ts
@@ -9,17 +9,6 @@ import { printJson } from "../utils/output.js";
 import { clientFrom, outputOptions } from "./_shared.js";
 
 const int = (v: string) => Number.parseInt(v, 10);
-const parsePairs = (raw?: string): Array<{ key: string; value: string }> | undefined => {
-  if (!raw) return undefined;
-  return raw
-    .split(",")
-    .map((part) => {
-      const idx = part.indexOf("=");
-      if (idx < 1) throw new Error("--extension must be key=value[,key=value]");
-      return { key: part.slice(0, idx).trim(), value: part.slice(idx + 1).trim() };
-    })
-    .filter((p) => p.key.length > 0);
-};
 
 export function resourceCommand(): Command {
   const cmd = new Command("resource")
@@ -36,9 +25,6 @@ export function resourceCommand(): Command {
     .option("--schema <name>", "filter by source schema")
     .option("--limit <n>", "page size", int, DEFAULT_LIST_LIMIT)
     .option("--offset <n>", "page offset", int, 0)
-    .option("--include-extensions", "include all extension key/value pairs")
-    .option("--include-extension-keys <keys>", "include selected extension keys")
-    .option("--extension <k=v,...>", "filter by extension key/value pairs")
     .option("--sort <field>", "sort field: name | create_time | update_time")
     .option("--direction <dir>", "sort direction: asc | desc")
     .action(async (opts, cmd: Command) => {
@@ -49,9 +35,6 @@ export function resourceCommand(): Command {
         schema: opts.schema,
         limit: opts.limit,
         offset: opts.offset,
-        includeExtensions: opts.includeExtensions,
-        includeExtensionKeys: opts.includeExtensionKeys,
-        extensionPairs: parsePairs(opts.extension),
         sort: opts.sort,
         direction: opts.direction,
       });

--- a/src/commands/vega.ts
+++ b/src/commands/vega.ts
@@ -69,14 +69,6 @@ const parseJsonObject = (value: string, flag: string): Record<string, unknown> =
   return parsed as Record<string, unknown>;
 };
 
-const parseStringRecord = (value: string, flag: string): Record<string, string> => {
-  const parsed = parseJsonObject(value, flag);
-  if (Object.values(parsed).some((item) => typeof item !== "string")) {
-    throw new InputError(`${flag} values must be strings`);
-  }
-  return parsed as Record<string, string>;
-};
-
 const parseJsonArray = (value: string, flag: string): Record<string, unknown>[] => {
   let parsed: unknown;
   try {
@@ -114,18 +106,6 @@ const healthCheckSchedule = (
     return { mode };
   }
   throw new InputError("health-check mode must be inherit, enabled, or disabled");
-};
-
-const parsePairs = (raw?: string): Array<{ key: string; value: string }> | undefined => {
-  if (!raw) return undefined;
-  return raw
-    .split(",")
-    .map((part) => {
-      const idx = part.indexOf("=");
-      if (idx < 1) throw new InputError("--extension must be key=value[,key=value]");
-      return { key: part.slice(0, idx).trim(), value: part.slice(idx + 1).trim() };
-    })
-    .filter((p) => p.key.length > 0);
 };
 
 const buildTaskStatuses = (raw?: string): BuildTaskStatus[] | undefined => {
@@ -279,9 +259,6 @@ export function vegaCommand(): Command {
     .option("--connector-type <type>", "filter by connector type")
     .option("--enabled <bool>", "filter by enabled state")
     .option("--health-check-status <s>", "filter by health status")
-    .option("--include-extensions", "include all extension key/value pairs")
-    .option("--include-extension-keys <keys>", "include selected extension keys")
-    .option("--extension <k=v,...>", "filter by extension key/value pairs")
     .option("--sort <field>", "sort field: name | create_time | update_time")
     .option("--direction <dir>", "sort direction: asc | desc")
     .action(async (_opts, cmd: Command) => {
@@ -295,9 +272,6 @@ export function vegaCommand(): Command {
         connectorType: o.connectorType,
         enabled: o.enabled === undefined ? undefined : o.enabled === "true",
         healthCheckStatus: o.healthCheckStatus,
-        includeExtensions: o.includeExtensions,
-        includeExtensionKeys: o.includeExtensionKeys,
-        extensionPairs: parsePairs(o.extension),
         sort: o.sort,
         direction: o.direction,
       });
@@ -338,15 +312,11 @@ export function vegaCommand(): Command {
     .option("--description <s>", "description")
     .option("--enabled", "create enabled (default: disabled)")
     .option("--internal", "create an internal catalog")
-    .option("--extensions <json>", "extension key/value JSON object")
     .option("--allow-unhealthy", "save the catalog when its connection test fails")
     .option("--health-check-mode <mode>", "health schedule: inherit | enabled | disabled")
     .option("--health-check-cron <expr>", "cron expression for enabled health checks")
     .action(async (opts, cmd: Command) => {
       const connectorConfig = parseJsonObject(opts.connectorConfig, "--connector-config");
-      const extensions = opts.extensions
-        ? parseStringRecord(opts.extensions, "--extensions")
-        : undefined;
       printJson(
         await clientFrom(cmd).vega.createCatalog(
           {
@@ -363,7 +333,6 @@ export function vegaCommand(): Command {
             description: opts.description,
             enabled: opts.enabled ? true : undefined,
             internal: opts.internal ? true : undefined,
-            extensions,
             healthCheckSchedule: healthCheckSchedule(opts.healthCheckMode, opts.healthCheckCron),
           },
           { allowUnhealthy: opts.allowUnhealthy ? true : undefined },
@@ -380,7 +349,6 @@ export function vegaCommand(): Command {
     .option("--connector-config <json>", "connector config JSON")
     .option("--tags <t1,t2>", "comma-separated tags")
     .option("--description <s>", "description")
-    .option("--extensions <json>", "extension key/value JSON object")
     .requiredOption(
       "--expected-update-time <ms>",
       "optimistic-lock update time",
@@ -390,9 +358,6 @@ export function vegaCommand(): Command {
     .action(async (id: string, opts, cmd: Command) => {
       const connectorConfig = opts.connectorConfig
         ? parseJsonObject(opts.connectorConfig, "--connector-config")
-        : undefined;
-      const extensions = opts.extensions
-        ? parseStringRecord(opts.extensions, "--extensions")
         : undefined;
       printJson(
         await clientFrom(cmd).vega.updateCatalog(
@@ -409,7 +374,6 @@ export function vegaCommand(): Command {
               : undefined,
             description: opts.description,
             enabled: opts.enabled,
-            extensions,
             expectedUpdateTime: opts.expectedUpdateTime,
           },
           { allowUnhealthy: opts.allowUnhealthy ? true : undefined },
@@ -852,9 +816,6 @@ export function vegaCommand(): Command {
     .option("--schema <name>", "filter by source schema")
     .option("--limit <n>", "page size", int, DEFAULT_LIST_LIMIT)
     .option("--offset <n>", "page offset", int, 0)
-    .option("--include-extensions", "include all extension key/value pairs")
-    .option("--include-extension-keys <keys>", "include selected extension keys")
-    .option("--extension <k=v,...>", "filter by extension key/value pairs")
     .option("--sort <field>", "sort field: name | create_time | update_time")
     .option("--direction <dir>", "sort direction: asc | desc")
     .action(async (opts, cmd: Command) => {
@@ -866,9 +827,6 @@ export function vegaCommand(): Command {
           schema: opts.schema,
           limit: opts.limit,
           offset: opts.offset,
-          includeExtensions: opts.includeExtensions,
-          includeExtensionKeys: opts.includeExtensionKeys,
-          extensionPairs: parsePairs(opts.extension),
           sort: opts.sort,
           direction: opts.direction,
         }),

--- a/test/unit/resources.test.ts
+++ b/test/unit/resources.test.ts
@@ -73,9 +73,6 @@ describe("listResources", () => {
       schema: "app",
       limit: 10,
       offset: 20,
-      includeExtensions: true,
-      includeExtensionKeys: "owner",
-      extensionPairs: [{ key: "owner", value: "data" }],
       sort: "name",
       direction: "asc",
     });
@@ -88,10 +85,6 @@ describe("listResources", () => {
     expect(url.searchParams.has("database")).toBe(false);
     expect(url.searchParams.get("limit")).toBe("10");
     expect(url.searchParams.get("offset")).toBe("20");
-    expect(url.searchParams.get("include_extensions")).toBe("true");
-    expect(url.searchParams.get("include_extension_keys")).toBe("owner");
-    expect(url.searchParams.getAll("extension_key")).toEqual(["owner"]);
-    expect(url.searchParams.getAll("extension_value")).toEqual(["data"]);
     expect(url.searchParams.get("sort")).toBe("name");
     expect(url.searchParams.get("direction")).toBe("asc");
   });

--- a/test/unit/vega.test.ts
+++ b/test/unit/vega.test.ts
@@ -103,7 +103,7 @@ describe("vega uses the vega-backend base path", () => {
     expect(u.searchParams.has("order")).toBe(false);
   });
 
-  it("listCatalogs sends new filters and repeated extension params", async () => {
+  it("listCatalogs sends filters and sort params", async () => {
     const f = mockFetch();
     await listCatalogs(ctx, {
       name: "prod",
@@ -112,12 +112,6 @@ describe("vega uses the vega-backend base path", () => {
       connectorType: "mysql",
       enabled: true,
       healthCheckStatus: "healthy",
-      includeExtensions: true,
-      includeExtensionKeys: "owner,env",
-      extensionPairs: [
-        { key: "owner", value: "data" },
-        { key: "env", value: "prod" },
-      ],
       sort: "name",
       direction: "asc",
     });
@@ -128,10 +122,6 @@ describe("vega uses the vega-backend base path", () => {
     expect(u.searchParams.get("connector_type")).toBe("mysql");
     expect(u.searchParams.get("enabled")).toBe("true");
     expect(u.searchParams.get("health_check_status")).toBe("healthy");
-    expect(u.searchParams.get("include_extensions")).toBe("true");
-    expect(u.searchParams.get("include_extension_keys")).toBe("owner,env");
-    expect(u.searchParams.getAll("extension_key")).toEqual(["owner", "env"]);
-    expect(u.searchParams.getAll("extension_value")).toEqual(["data", "prod"]);
     expect(u.searchParams.get("sort")).toBe("name");
     expect(u.searchParams.get("direction")).toBe("asc");
   });
@@ -588,7 +578,6 @@ describe("updateCatalog", () => {
         enabled: false,
         tags: [],
         description: "",
-        extensions: {},
         expectedUpdateTime: 1720000000123,
       },
       { allowUnhealthy: true },
@@ -606,7 +595,6 @@ describe("updateCatalog", () => {
       enabled: false,
       tags: [],
       description: "",
-      extensions: {},
       expected_update_time: 1720000000123,
     });
   });


### PR DESCRIPTION
## What Changed

- [x] Remove Catalog, CatalogRef, Resource, and Property extensions from SDK response types
- [x] Remove extensions from Catalog and Resource create and update request types
- [x] Remove extension list filters and projections from SDK APIs and CLI commands
- [x] Update Catalog and Resource unit tests

---

## Why

- Related Issue: https://github.com/openbkn-ai/bkn-foundry/issues/266
- Related Feature: https://github.com/openbkn-ai/bkn-foundry/pull/1160
- Background: the Vega backend removes the unused extensions contract without compatibility handling.

---

## How

- Key implementation points:
  - Delete stale Zod fields and TypeScript request options
  - Stop sending removed query parameters and request body fields
  - Remove the associated openbkn CLI flags and parsers
  - Preserve the supported name, create_time, and update_time sort contract
- Breaking changes:
  - SDK callers can no longer access or submit extensions through typed APIs
  - Removed CLI extension options are no longer accepted

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- npm run ci passed: 560 tests passed and 1 live test skipped
- npm run build passed
- Repository CI still needs to run remotely

---

## Risk & Rollback

- Potential risks:
  - This PR requires the Vega backend contract in bkn-foundry PR 1160
- Rollback plan:
  - Revert this PR and keep the previous SDK version paired with the previous backend contract

---

## Additional Notes

- Merge after https://github.com/openbkn-ai/bkn-foundry/pull/1160.