### PR TITLE
fix(model): take a small-model id where the help says an id

### DIFF
--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -165,8 +165,15 @@ export async function chatCompletionsStream(
   return out;
 }
 
-export function embeddings(ctx: RequestContext, model: string, input: string[]): Promise<unknown> {
-  return request(ctx, `${API}/small-model/embeddings`, { method: "POST", body: { model, input } });
+export async function embeddings(
+  ctx: RequestContext,
+  model: string,
+  input: string[],
+): Promise<unknown> {
+  return request(ctx, `${API}/small-model/embeddings`, {
+    method: "POST",
+    body: { model: await resolveSmallModelName(ctx, model), input },
+  });
 }
 
 // ---- management writes (mf-model-manager) ---------------------------------
@@ -231,7 +238,7 @@ export function getDefaultSmallModel(
   });
 }
 
-export function rerank(
+export async function rerank(
   ctx: RequestContext,
   model: string,
   query: string,
@@ -239,6 +246,6 @@ export function rerank(
 ): Promise<unknown> {
   return request(ctx, `${API}/small-model/reranker`, {
     method: "POST",
-    body: { model, query, documents },
+    body: { model: await resolveSmallModelName(ctx, model), query, documents },
   });
 }

--- a/src/commands/model.ts
+++ b/src/commands/model.ts
@@ -144,8 +144,8 @@ export function modelCommand(): Command {
       printJson(await clientFrom(cmd).models.small.get(id), outputOptions(cmd));
     });
   small
-    .command("embeddings <modelId>")
-    .description("Compute embeddings")
+    .command("embeddings <model>")
+    .description("Compute embeddings (<model> = model name or numeric id)")
     .requiredOption("-i, --input <text>", "comma-separated input texts")
     .action(async (id: string, opts, cmd: Command) => {
       printJson(
@@ -154,8 +154,8 @@ export function modelCommand(): Command {
       );
     });
   small
-    .command("rerank <modelId>")
-    .description("Rerank documents against a query")
+    .command("rerank <model>")
+    .description("Rerank documents against a query (<model> = model name or numeric id)")
     .requiredOption("-q, --query <text>", "query")
     .requiredOption("-d, --documents <list>", "comma-separated documents")
     .action(async (id: string, opts, cmd: Command) => {

--- a/test/unit/models.test.ts
+++ b/test/unit/models.test.ts
@@ -2,10 +2,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   chatCompletions,
   chatCompletionsStream,
+  embeddings,
   getDefaultSmallModel,
   getLlmModel,
   listLlmModels,
   listSmallModels,
+  rerank,
   setDefaultLlm,
   setDefaultSmallModel,
 } from "../../src/api/models.js";
@@ -128,5 +130,44 @@ describe("model invocation (mf-model-api)", () => {
     if (!init) throw new Error("fetch not called");
     const body = JSON.parse(init.body as string);
     expect(body.stream).toBe(true);
+  });
+});
+
+describe("small-model calls take a name or an id", () => {
+  // `small list` and `small get-default` lead with the numeric `model_id`, so
+  // the first value a user copies is the one the backend rejects — with
+  // `ModelFactory.ExternalSmallModel.*` and an HTTP 400, which names neither
+  // the field nor the fact that a name was wanted. `llm chat` has resolved ids
+  // client-side since cffe7e3; these two never did.
+  function mockLookup(body: unknown = { model_name: "text-embedding-v4" }) {
+    const fn = vi.fn(async (input: string) =>
+      new URL(input).pathname.startsWith("/api/mf-model-manager")
+        ? new Response(JSON.stringify(body), { status: 200 })
+        : new Response("{}", { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fn);
+    return fn as unknown as typeof fetch;
+  }
+  const calls = (f: typeof fetch) => (f as unknown as { mock: { calls: CallArgs[] } }).mock.calls;
+
+  it("resolves a numeric id to the name embeddings must send", async () => {
+    const f = mockLookup();
+    await embeddings(ctx, "2064382281006583808", ["apple"]);
+    const lookup = calls(f).find(([u]) => String(u).includes("/mf-model-manager"));
+    expect(new URL(lookup?.[0] ?? "").searchParams.get("model_id")).toBe("2064382281006583808");
+    expect(JSON.parse(calls(f).at(-1)?.[1].body as string).model).toBe("text-embedding-v4");
+  });
+
+  it("resolves a numeric id to the name rerank must send", async () => {
+    const f = mockLookup({ model_name: "reranker" });
+    await rerank(ctx, "2071900034219999001", "apple", ["banana"]);
+    expect(JSON.parse(calls(f).at(-1)?.[1].body as string).model).toBe("reranker");
+  });
+
+  it("sends a name through untouched, without a lookup", async () => {
+    const f = mockLookup();
+    await embeddings(ctx, "text-embedding-v4", ["apple"]);
+    expect(calls(f).some(([u]) => String(u).includes("/mf-model-manager"))).toBe(false);
+    expect(JSON.parse(calls(f).at(-1)?.[1].body as string).model).toBe("text-embedding-v4");
   });
 });


### PR DESCRIPTION
`model small embeddings` / `rerank` 的 help 写着 `<modelId>`，然后拒绝一个 id。

```
$ openbkn model small list --compact
# embedding: model_id=2064382281006583808  model_name=text-embedding-v4

$ openbkn model small embeddings 2064382281006583808 -i apple
Request failed (HTTP 404): {"code":"ModelFactory.ExternalSmallModel.Used.NameNotExist", ...
```

后端认的是 name。而 `model small list` / `get-default` 输出里 `model_id` 在前 —— **用户第一个复制到的值，正是会失败的那个**，而且失败时既没提字段、也没提要的是 name。

## 改法

`resolveSmallModelName` 早就存在，注释里点名的就是这几个调用方：

> Every consumer of a small model (`--embedding-model`, `small embeddings`)

但只有建索引那条路接上了。

这次接在**两个调用本身**而不是两个命令上，SDK 调用方拿到同样的行为，也跟这个 resolver 现有的用法一致。

- name 原样直穿，不查询 —— 不为不需要的往返付钱
- 只有纯数字串才当 id —— 跟 `resolveLlmModelName` 从 cffe7e3 起用的是同一条规则

参数名改成 `<model>`，两条描述都写清它收什么。叫 `<modelId>` 正是这个 issue 的原文：help 不是在描述命令，是在跟命令唱反调。

## 验证

真机 `10.211.55.4`，两个命令 × 两种形式：

| | 修复前 | 修复后 |
| --- | --- | --- |
| `embeddings 2064382281006583808` | 404 | 应答 |
| `embeddings text-embedding-v4` | 应答 | 不变 |
| `rerank 2071900034219999001` | 404 | 应答 |
| `rerank reranker` | 应答 | 不变 |

两处解析逐个删，各有测试变红。`npm run ci`：566 passed。

Closes #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)