### PR TITLE
feat(vega): add resource discovery SDK controls

### DIFF
--- a/docs/exec-plans/completed/2026-08-27-vega-resource-discovery-sdk.md
+++ b/docs/exec-plans/completed/2026-08-27-vega-resource-discovery-sdk.md
@@ -1,0 +1,12 @@
+# Vega Resource Discovery SDK Plan
+
+1. Update discovery and resource API schemas plus request mapping for the new
+   endpoints and fields. Completed.
+2. Expose the operations from resource and Vega SDK namespaces without breaking
+   command-to-resource-to-API layering. Completed.
+3. Add CLI commands and filters, keeping queue priority display-only. Completed.
+4. Update Vega product/reference documentation and focused API/CLI regression
+   tests. Completed.
+5. Run lint, unit tests, and a diff check; move this plan to `completed/` after
+   successful verification. Completed: `npm run lint`, `npm test`, and
+   `git diff --check` pass.

--- a/docs/product-specs/vega.md
+++ b/docs/product-specs/vega.md
@@ -14,9 +14,9 @@ Browse the Vega catalog — data sources, views, atomic views, connector types �
 - `openbkn vega catalog delete <id> --dry-run` — preview the resources, pending
   tasks, running blockers, and schedules affected by deletion. Omit `--dry-run`
   to perform the real deletion.
-- `openbkn vega resource list` — resources (limit 30); `openbkn vega resource preview <id>` — sample (limit 50).
+- `openbkn vega resource list` — resources (limit 30); `openbkn vega resource discover <id>` refreshes one resource's metadata, and `enable|disable <id>` changes only its enabled state.
 - `openbkn vega discover-schedule …` — create/list/get/update/delete discovery schedules and enable or disable them explicitly. Full updates require the current `catalog_id`, `enabled`, `strategy`, both time-window bounds, and `--expected-update-time` for optimistic locking.
-- `openbkn vega discover-task list|get|delete` — inspect and clean up discovery-task history.
+- `openbkn vega discover-task list|get|delete` — inspect and clean up discovery-task history; list accepts `--resource-id`. Tasks expose a read-only `queue_priority` and cannot be sorted by it.
 - `openbkn vega semantic-task create|list|get|delete` — manage semantic-understanding task lifecycles for a Catalog or Resource.
 - `openbkn vega resource document-*` — create, read, upsert, and delete dataset documents. Batch create/delete-by-filter use Vega's required method-override header internally.
 - Health / inspection: connector-type listing and health checks across catalog resources.
@@ -61,9 +61,9 @@ determines what is indexed; the BuildTask uses its snapshot.
 - `resource.update` and `resource.configureIndex` read the current Resource before issuing the backend's full PUT and automatically send its `update_time` as `expected_update_time`. An explicit `expectedUpdateTime` on `resource.update` overrides the freshly read value.
 - Catalog and Resource list/get/create responses are typed at the HTTP boundary. List responses use summary types and omit detail-only JSON fields; detail GETs preserve the backend batch envelope (`{ entries }`), and their `update_time` values can be passed directly to optimistic updates.
 - `vega.discoverSchedules`, `get/create/update/deleteDiscoverSchedule`, and the enable/disable actions cover the full DiscoverSchedule contract. Schedule updates require `catalogId`, `enabled`, `startTime`, `endTime`, `strategy`, and `expectedUpdateTime`, mapped to the backend's strict replacement fields.
-- `vega.discoverCatalog`, `discoverTasks`, `getDiscoverTask`, and `deleteDiscoverTasks` cover asynchronous manual triggering plus task history. `discoverCatalog` returns the new task ID and accepts an optional strategy. `vega.create/semanticUnderstandingTasks/get/deleteSemanticUnderstandingTask(s)` cover semantic task lifecycles.
+- `vega.discoverCatalog`, `discoverResource`, `discoverTasks`, `getDiscoverTask`, and `deleteDiscoverTasks` cover asynchronous manual triggering plus task history. Catalog discovery accepts an optional strategy; resource discovery has no request body. Resource-level tasks include `resource_id` and a read-only `queue_priority`; list filtering accepts `resourceId` but priority is not a sort input. `vega.create/semanticUnderstandingTasks/get/deleteSemanticUnderstandingTask(s)` cover semantic task lifecycles.
 - `resource.create` is the typed creation API for user-creatable `dataset` and `logicview` resources. `resource.query`, `createDocuments`, `upsertDocument(s)`, `getDocument`, `deleteDocuments`, and `deleteDocumentsByFilter` cover ResourceData. Dynamic document reads retain unsafe integers as native `bigint`; CLI document JSON and filter input preserve them on the request path too.
-- Resource list filtering uses the protocol field `schema` and `catalogId`, mapped to `catalog_id` on the wire. Resource updates expose only user-owned fields; catalog/category are read from the current Resource for the strict PUT precondition, while discovery-owned metadata is not sent as mutable input.
+- Resource list filtering uses the protocol field `schema` and `catalogId`, mapped to `catalog_id` on the wire. A Resource's `enabled` state is independent of its `active`, `deprecated`, or `stale` discovery status; use `resource.enable` or `resource.disable` to change it. Resource updates preserve the current `enabled` value while catalog/category are read for the strict PUT precondition, and discovery-owned metadata is not sent as mutable input.
 - `vega.deleteCatalog(id, { dryRun: true })` returns a typed
   `CatalogDeletionImpact`; `vega.deleteCatalog(id)` performs the real deletion
   and returns `undefined`.

--- a/docs/superpowers/specs/2026-08-27-vega-resource-discovery-design.md
+++ b/docs/superpowers/specs/2026-08-27-vega-resource-discovery-design.md
@@ -1,0 +1,47 @@
+# Vega Resource Discovery SDK Design
+
+## Scope
+
+Adapt the SDK and CLI to Foundry's resource-level discovery contract:
+
+1. Trigger discovery with `POST /resources/{id}/discover`.
+2. Surface `resource_id` and read-only `queue_priority` on discovery tasks and
+   filter task history by resource.
+3. Represent Resource enablement independently from its discovery status and
+   expose the enable/disable actions.
+
+The scheduler's internal priority ordering is not configurable and is not a
+public sort field.
+
+## Design
+
+- Keep discovery transport in `api/vega-discovery.ts`, alongside catalog
+  discovery and task history. `discoverResource` takes only the resource id
+  because the endpoint does not accept a strategy.
+- Keep resource enablement in `api/resources.ts` and expose it from the
+  programmatic `resource` namespace. Resource PUT helpers carry the current
+  `enabled` value so a user-owned update cannot accidentally change it.
+- Parse `enabled` as a required Resource response field. Resource status
+  remains forward-compatible and no longer models `disabled` as a status.
+- Expose the resource discovery trigger through `client.vega`, matching the
+  existing catalog discovery operation. Add matching `vega resource discover`,
+  `enable`, and `disable` commands. The top-level `resource` alias also exposes
+  enable/disable for parity with the Vega resource commands.
+- Add `--resource-id` to discovery-task list. Keep `queue_priority` output-only:
+  it is returned in task objects but cannot be supplied as a list sort or a
+  command option.
+
+## Compatibility
+
+This is part of the unreleased 0.1.5 surface. Existing callers that inspect
+`ResourceStatus` must stop treating `disabled` as a discovery status and use
+`enabled` instead. Full resource updates preserve the server's current enabled
+state automatically.
+
+## Verification
+
+- Unit-test request paths, task query mapping, and response parsing.
+- Unit-test that full Resource PUT preserves `enabled`.
+- CLI-test the resource discovery trigger, enable/disable actions, and task
+  resource filter.
+- Run `npm run lint`, `npm test`, and `git diff --check`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openbkn/bkn-sdk",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openbkn/bkn-sdk",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openbkn/bkn-sdk",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Unified TypeScript SDK + CLI for the BKN (Business Knowledge Network) platform.",
   "type": "module",
   "license": "Apache-2.0",

--- a/skills/openbkn/references/resource.md
+++ b/skills/openbkn/references/resource.md
@@ -4,6 +4,6 @@
 |---------|-------|
 | `list [--catalog-id <c>] [--category table] [--limit]` | Browse. `--type` is an alias of `--category`. |
 | `find --name <name> [--catalog-id <c>] [--exact] [--limit]` | Search by name. `--limit` is the rows scanned before filtering — raise it when an expected match doesn't show up. |
-| `get <id>` / `query <id> [--limit] [--offset] [--paging-mode single\|cursor] [--cursor]` / `delete <id>` | Detail / data rows / delete. Resource queries use Vega's `paging` contract and send the required GET method-override header; `--cursor` continues from `paging.next_cursor`. |
+| `get <id>` / `enable\|disable <id>` / `query <id> [--limit] [--offset] [--paging-mode single\|cursor] [--cursor]` / `delete <id>` | Detail / change enabled state / data rows / delete. Resource queries use Vega's `paging` contract and send the required GET method-override header; `--cursor` continues from `paging.next_cursor`. |
 
 For BKN object-type binding use `data_source: { type: "resource", id }`.

--- a/skills/openbkn/references/vega.md
+++ b/skills/openbkn/references/vega.md
@@ -7,8 +7,9 @@
 | `catalog delete <id> [--dry-run]` | Preview deletion impact with `--dry-run`; omit it to delete. Running tasks and protected resources block deletion. |
 | `catalog health <ids...>` | Health-status for one or more catalogs. |
 | `catalog discover <id> [--strategy full_sync\|create_only\|cleanup_only]` | Start asynchronous resource discovery; returns a discovery-task id. |
+| `resource discover <id>` / `resource enable\|disable <id>` | Refresh one Resource's metadata, or change its enabled state without changing discovery status. |
 | `discover-schedule create\|list\|get\|update\|delete\|enable\|disable` | Manage catalog discovery schedules. Update is a full replacement and requires the current state plus `--expected-update-time`. |
-| `discover-task list\|get\|delete` | Inspect or clean up discovery-task history. |
+| `discover-task list [--resource-id <id>]\|get\|delete` | Inspect or clean up discovery-task history. Task `queue_priority` is output-only; it cannot be used to sort or reprioritize tasks. |
 | `semantic-task create\|list\|get\|delete` | Manage semantic-understanding tasks. |
 | `connector-type list` / `connector-type get <type>` | Available connector types. |
 | `sql --query "<sql>"` / `sql -d <json>` | Run SQL or OpenSearch DSL directly against a data source. SQL uses a `{{<resource-id>}}` table placeholder; DSL identifies its resource with top-level `resource_id`. See [§ vega sql](#vega-sql--run-sql--dsl-against-a-data-source). |

--- a/src/api/resources.ts
+++ b/src/api/resources.ts
@@ -56,7 +56,7 @@ export const ResourceCategory = z.enum([
 ]);
 export type ResourceCategory = z.infer<typeof ResourceCategory>;
 
-export const ResourceStatus = z.enum(["active", "disabled", "deprecated", "stale"]);
+export const ResourceStatus = z.enum(["active", "deprecated", "stale"]);
 export type ResourceStatus = z.infer<typeof ResourceStatus>;
 
 export const ResourceLocalStatus = z.enum(["unavailable", "available", "stale"]);
@@ -70,6 +70,7 @@ export interface ResourceLike {
   description?: string;
   category?: string;
   status?: string;
+  enabled?: boolean;
   schema?: string;
   source_identifier?: string;
   source_metadata?: Record<string, unknown>;
@@ -149,6 +150,8 @@ export const Resource = z
     // status; request options below remain constrained to known values.
     category: z.string(),
     status: z.string(),
+    // Older deployments omit this newly split field; the migration default is enabled.
+    enabled: z.boolean().default(true),
     status_message: z.string().optional(),
     last_discover_status: z.string().optional(),
     schema: z.string().optional(),
@@ -315,6 +318,16 @@ export function updateResourceRaw(
   return request(ctx, `${BASE}/${encodeURIComponent(id)}`, { method: "PUT", body });
 }
 
+/** Enable a Resource without changing its discovery status or metadata. */
+export function enableResource(ctx: RequestContext, id: string): Promise<unknown> {
+  return request(ctx, `${BASE}/${encodeURIComponent(id)}/enable`, { method: "POST" });
+}
+
+/** Disable a Resource without changing its discovery status or metadata. */
+export function disableResource(ctx: RequestContext, id: string): Promise<unknown> {
+  return request(ctx, `${BASE}/${encodeURIComponent(id)}/disable`, { method: "POST" });
+}
+
 export async function updateResource(
   ctx: RequestContext,
   id: string,
@@ -394,6 +407,7 @@ function resourceUpdateBody(
     tags: patch.tags ?? current.tags ?? [],
     description: patch.description ?? current.description ?? "",
     category: current.category,
+    enabled: current.enabled,
     schema_definition: patch.schemaDefinition ?? current.schema_definition,
     index_config: patch.indexConfig === undefined ? current.index_config : patch.indexConfig,
     logic_definition: patch.logicDefinition ?? current.logic_definition,

--- a/src/api/vega-discovery.ts
+++ b/src/api/vega-discovery.ts
@@ -204,10 +204,13 @@ export const DiscoverTask = z
   .object({
     id: z.string(),
     catalog_id: z.string(),
+    resource_id: z.string().optional(),
     catalog_name: z.string().optional(),
     schedule_id: z.string(),
     strategy: z.string(),
     trigger_type: z.string(),
+    // Catalog tasks created before priority support have the manual default.
+    queue_priority: z.number().default(20),
     status: z.string(),
     progress: z.number(),
     message: z.string(),
@@ -239,6 +242,7 @@ export type ListDiscoverTasksResponse = z.infer<typeof ListDiscoverTasksResponse
 
 export interface ListDiscoverTasksOptions {
   catalogId?: string;
+  resourceId?: string;
   scheduleId?: string;
   status?: VegaTaskStatus | VegaTaskStatus[];
   strategy?: DiscoverStrategy;
@@ -256,6 +260,7 @@ export async function listDiscoverTasks(
   const result = await request<unknown>(ctx, `${VEGA_BASE}/discover-tasks`, {
     query: {
       catalog_id: opts.catalogId || undefined,
+      resource_id: opts.resourceId || undefined,
       schedule_id: opts.scheduleId || undefined,
       status: opts.status,
       strategy: opts.strategy,
@@ -304,6 +309,19 @@ export async function discoverCatalog(
     ctx,
     `${VEGA_BASE}/catalogs/${encodeURIComponent(catalogId)}/discover`,
     { method: "POST", body: req.strategy ? { strategy: req.strategy } : {} },
+  );
+  return IdResponse.parse(result);
+}
+
+/** Trigger metadata discovery for one Resource. */
+export async function discoverResource(
+  ctx: RequestContext,
+  resourceId: string,
+): Promise<{ id: string }> {
+  const result = await request<unknown>(
+    ctx,
+    `${VEGA_BASE}/resources/${encodeURIComponent(resourceId)}/discover`,
+    { method: "POST" },
   );
   return IdResponse.parse(result);
 }

--- a/src/api/vega-discovery.ts
+++ b/src/api/vega-discovery.ts
@@ -205,6 +205,7 @@ export const DiscoverTask = z
     id: z.string(),
     catalog_id: z.string(),
     resource_id: z.string().optional(),
+    resource_name: z.string().optional(),
     catalog_name: z.string().optional(),
     schedule_id: z.string(),
     strategy: z.string(),

--- a/src/api/vega.ts
+++ b/src/api/vega.ts
@@ -314,6 +314,7 @@ export interface ListBuildTasksOptions {
   catalogId?: string;
   status?: BuildTaskStatus | BuildTaskStatus[];
   mode?: BuildMode;
+  executeType?: BuildTaskExecuteType;
   sort?: BuildTaskSort;
   direction?: SortDirection;
 }
@@ -341,6 +342,7 @@ export async function listBuildTasks(
       catalog_id: opts.catalogId || undefined,
       status: opts.status || undefined,
       mode: opts.mode,
+      execute_type: opts.executeType,
       sort: opts.sort,
       direction: opts.direction,
     },

--- a/src/commands/resource.ts
+++ b/src/commands/resource.ts
@@ -13,7 +13,7 @@ const int = (v: string) => Number.parseInt(v, 10);
 export function resourceCommand(): Command {
   const cmd = new Command("resource")
     .alias("res")
-    .description("Resources — list, find, get, query, delete");
+    .description("Resources — list, find, get, enable, disable, query, delete");
 
   cmd
     .command("list")

--- a/src/commands/resource.ts
+++ b/src/commands/resource.ts
@@ -64,6 +64,17 @@ export function resourceCommand(): Command {
       printJson(await clientFrom(cmd).resource.get(id), outputOptions(cmd));
     });
 
+  for (const action of ["enable", "disable"] as const) {
+    cmd
+      .command(`${action} <id>`)
+      .description(`${action[0]?.toUpperCase()}${action.slice(1)} a resource`)
+      .action(async (id: string, _opts, cmd: Command) => {
+        const api = clientFrom(cmd).resource;
+        const result = action === "enable" ? await api.enable(id) : await api.disable(id);
+        printJson(result, outputOptions(cmd));
+      });
+  }
+
   cmd
     .command("query <id>")
     .description("Fetch data rows from a resource")

--- a/src/commands/vega.ts
+++ b/src/commands/vega.ts
@@ -16,6 +16,7 @@ import {
   SemanticUnderstandingTaskSort,
 } from "../api/vega-semantic.js";
 import {
+  BuildTaskExecuteType,
   BuildTaskSort,
   BuildTaskStatus,
   type CatalogHealthCheckScheduleConfig,
@@ -131,6 +132,17 @@ const buildTaskSort = (raw?: string): BuildTaskSort | undefined => {
   if (!parsed.success) {
     throw new InputError(
       `invalid build task sort "${raw}"; expected one of ${BuildTaskSort.options.join(", ")}`,
+    );
+  }
+  return parsed.data;
+};
+
+const buildTaskExecuteType = (raw?: string): BuildTaskExecuteType | undefined => {
+  if (raw === undefined) return undefined;
+  const parsed = BuildTaskExecuteType.safeParse(raw);
+  if (!parsed.success) {
+    throw new InputError(
+      `invalid build task execute type "${raw}"; expected one of ${BuildTaskExecuteType.options.join(", ")}`,
     );
   }
   return parsed.data;
@@ -993,6 +1005,10 @@ export function vegaCommand(): Command {
     .option("--catalog-id <id>", "filter by catalog id")
     .option("--status <status>", `comma-separated statuses: ${BuildTaskStatus.options.join(" | ")}`)
     .option("--mode <mode>", "filter by mode: batch | streaming")
+    .option(
+      "--execute-type <type>",
+      `filter by execution type: ${BuildTaskExecuteType.options.join(" | ")}`,
+    )
     .option("--sort <field>", `sort field: ${BuildTaskSort.options.join(" | ")}`)
     .option("--direction <dir>", `sort direction: ${SortDirection.options.join(" | ")}`)
     .action(async (opts, cmd: Command) => {
@@ -1004,6 +1020,7 @@ export function vegaCommand(): Command {
           catalogId: opts.catalogId,
           status: buildTaskStatuses(opts.status),
           mode: opts.mode,
+          executeType: buildTaskExecuteType(opts.executeType),
           sort: buildTaskSort(opts.sort),
           direction: sortDirection(opts.direction),
         }),

--- a/src/commands/vega.ts
+++ b/src/commands/vega.ts
@@ -571,6 +571,7 @@ export function vegaCommand(): Command {
     .command("list")
     .description("List discovery tasks")
     .option("--catalog-id <id>", "filter by catalog id")
+    .option("--resource-id <id>", "filter by resource id")
     .option("--schedule-id <id>", "filter by schedule id")
     .option("--status <status>", `comma-separated: ${VegaTaskStatus.options.join(" | ")}`)
     .option("--strategy <strategy>", `strategy: ${DiscoverStrategy.options.join(" | ")}`)
@@ -583,6 +584,7 @@ export function vegaCommand(): Command {
       printJson(
         await clientFrom(cmd).vega.discoverTasks({
           catalogId: opts.catalogId,
+          resourceId: opts.resourceId,
           scheduleId: opts.scheduleId,
           status: taskStatuses(opts.status),
           strategy: discoverStrategy(opts.strategy),
@@ -839,6 +841,22 @@ export function vegaCommand(): Command {
     .action(async (id: string, _opts, cmd: Command) => {
       printJson(await clientFrom(cmd).resource.get(id), outputOptions(cmd));
     });
+  resource
+    .command("discover <id>")
+    .description("Trigger metadata discovery for a resource")
+    .action(async (id: string, _opts, cmd: Command) => {
+      printJson(await clientFrom(cmd).vega.discoverResource(id), outputOptions(cmd));
+    });
+  for (const action of ["enable", "disable"] as const) {
+    resource
+      .command(`${action} <id>`)
+      .description(`${action[0]?.toUpperCase()}${action.slice(1)} a resource`)
+      .action(async (id: string, _opts, cmd: Command) => {
+        const api = clientFrom(cmd).resource;
+        const result = action === "enable" ? await api.enable(id) : await api.disable(id);
+        printJson(result, outputOptions(cmd));
+      });
+  }
   resource
     .command("query <id>")
     .description("Fetch data rows from a resource")

--- a/src/resources/resources.ts
+++ b/src/resources/resources.ts
@@ -15,6 +15,8 @@ import {
   deleteResource,
   deleteResourceDocuments,
   deleteResourceDocumentsByFilter,
+  disableResource,
+  enableResource,
   findResource,
   getResource,
   getResourceDocument,
@@ -34,6 +36,8 @@ export function resources(ctx: RequestContext) {
     delete: (id: string | string[], opts?: Parameters<typeof deleteResource>[2]) =>
       deleteResource(ctx, id, opts),
     update: (id: string, patch: UpdateResourceOptions) => updateResource(ctx, id, patch),
+    enable: (id: string) => enableResource(ctx, id),
+    disable: (id: string) => disableResource(ctx, id),
     configureIndex: (id: string, opts: Parameters<typeof configureResourceIndex>[2]) =>
       configureResourceIndex(ctx, id, opts),
     find: (name: string, opts?: FindResourceOptions) => findResource(ctx, name, opts),

--- a/src/resources/vega.ts
+++ b/src/resources/vega.ts
@@ -12,6 +12,7 @@ import {
   deleteDiscoverTasks,
   disableDiscoverSchedule,
   discoverCatalog,
+  discoverResource,
   enableDiscoverSchedule,
   getDiscoverSchedule,
   getDiscoverTask,
@@ -99,6 +100,7 @@ export function vega(ctx: RequestContext) {
       updateCatalogHealthCheckSchedule(ctx, id, req),
     discoverCatalog: (catalogId: string, req?: Parameters<typeof discoverCatalog>[2]) =>
       discoverCatalog(ctx, catalogId, req),
+    discoverResource: (resourceId: string) => discoverResource(ctx, resourceId),
     catalogResources: (id: string, category?: string, limit?: number, offset?: number) =>
       listCatalogResources(ctx, id, category, limit, offset),
     catalogHealth: (id: string) => catalogHealthStatus(ctx, id),

--- a/test/unit/resource-command.test.ts
+++ b/test/unit/resource-command.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { resourceCommand } from "../../src/commands/resource.js";
+
+describe("resourceCommand", () => {
+  it("documents enabled-state commands in the command summary", () => {
+    const command = resourceCommand();
+
+    expect(command.description()).toContain("enable, disable");
+    expect(command.commands.map((child) => child.name())).toEqual(
+      expect.arrayContaining(["enable", "disable"]),
+    );
+  });
+});

--- a/test/unit/resources.test.ts
+++ b/test/unit/resources.test.ts
@@ -7,6 +7,8 @@ import {
   deleteResource,
   deleteResourceDocuments,
   deleteResourceDocumentsByFilter,
+  disableResource,
+  enableResource,
   findResource,
   firstResource,
   getResource,
@@ -42,6 +44,7 @@ function resourceFixture(overrides: Record<string, unknown> = {}) {
     name: "orders",
     category: "table",
     status: "active",
+    enabled: true,
     local_status: "unavailable",
     source_identifier: "orders",
     creator: { id: "u-1", type: "user" },
@@ -204,11 +207,25 @@ describe("updateResource/configureResourceIndex", () => {
     const body = JSON.parse(calls[1]?.[1].body as string);
     expect(body.name).toBe("orders");
     expect(body.catalog_id).toBe("c-1");
+    expect(body.enabled).toBe(true);
     expect(body).not.toHaveProperty("schema");
     expect(body).not.toHaveProperty("source_identifier");
     expect(body).not.toHaveProperty("source_metadata");
     expect(body.index_config).toEqual({ build_key_fields: ["id"] });
     expect(body.expected_update_time).toBe(1720000000123);
+  });
+
+  it("uses action endpoints for independent enabled state", async () => {
+    const f = mockFetch();
+    await enableResource(ctx, "r/1");
+    await disableResource(ctx, "r 2");
+    const requestCalls = (f as unknown as { mock: { calls: CallArgs[] } }).mock.calls;
+    expect(new URL(requestCalls[0]?.[0] ?? "").pathname).toBe(
+      "/api/vega-backend/v1/resources/r%2F1/enable",
+    );
+    expect(new URL(requestCalls[1]?.[0] ?? "").pathname).toBe(
+      "/api/vega-backend/v1/resources/r%202/disable",
+    );
   });
 
   it("writes resource index_config and schema features for build intent", async () => {

--- a/test/unit/vega-command.test.ts
+++ b/test/unit/vega-command.test.ts
@@ -579,6 +579,52 @@ describe("vega dataset build-list", () => {
     expect(url.searchParams.getAll("status")).toEqual(["pending", "running"]);
   });
 
+  it("forwards a validated execute type", async () => {
+    const fetchMock = mockFetch({ entries: [], total_count: 0 });
+    suppressOutput();
+
+    await cli().parseAsync(
+      [
+        "--base-url",
+        "https://demo.example.com",
+        "--token",
+        "t",
+        "vega",
+        "dataset",
+        "build-list",
+        "--execute-type",
+        "incremental",
+      ],
+      { from: "user" },
+    );
+
+    const url = new URL(fetchMock.mock.calls[0]?.[0] as string);
+    expect(url.searchParams.get("execute_type")).toBe("incremental");
+  });
+
+  it("rejects an invalid execute type before issuing a request", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      cli().parseAsync(
+        [
+          "--base-url",
+          "https://demo.example.com",
+          "--token",
+          "t",
+          "vega",
+          "dataset",
+          "build-list",
+          "--execute-type",
+          "unknown",
+        ],
+        { from: "user" },
+      ),
+    ).rejects.toThrow(/invalid build task execute type/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("rejects an empty status list before issuing a request", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);

--- a/test/unit/vega-command.test.ts
+++ b/test/unit/vega-command.test.ts
@@ -89,6 +89,54 @@ describe("vega resource document input", () => {
   });
 });
 
+describe("vega resource discovery commands", () => {
+  it("triggers a resource discovery task without a strategy body", async () => {
+    const fetchMock = mockFetch({ id: "t-1" });
+    suppressOutput();
+
+    await cli().parseAsync(
+      [
+        "--base-url",
+        "https://demo.example.com",
+        "--token",
+        "t",
+        "vega",
+        "resource",
+        "discover",
+        "r/1",
+      ],
+      { from: "user" },
+    );
+
+    expect(new URL(fetchMock.mock.calls[0]?.[0] as string).pathname).toBe(
+      "/api/vega-backend/v1/resources/r%2F1/discover",
+    );
+    expect(fetchMock.mock.calls[0]?.[1]?.body).toBeUndefined();
+  });
+
+  it("forwards resource enabled-state actions and task resource filters", async () => {
+    const fetchMock = mockFetch({ entries: [], total_count: 0 });
+    suppressOutput();
+    const base = ["--base-url", "https://demo.example.com", "--token", "t", "vega"];
+
+    await cli().parseAsync([...base, "resource", "enable", "r-1"], { from: "user" });
+    await cli().parseAsync([...base, "resource", "disable", "r-1"], { from: "user" });
+    await cli().parseAsync([...base, "discover-task", "list", "--resource-id", "r-1"], {
+      from: "user",
+    });
+
+    expect(new URL(fetchMock.mock.calls[0]?.[0] as string).pathname).toBe(
+      "/api/vega-backend/v1/resources/r-1/enable",
+    );
+    expect(new URL(fetchMock.mock.calls[1]?.[0] as string).pathname).toBe(
+      "/api/vega-backend/v1/resources/r-1/disable",
+    );
+    expect(new URL(fetchMock.mock.calls[2]?.[0] as string).searchParams.get("resource_id")).toBe(
+      "r-1",
+    );
+  });
+});
+
 describe("vega optimistic updates", () => {
   it("requires an optimistic-lock version for every Vega PUT command", async () => {
     suppressOutput();

--- a/test/unit/vega-discovery.test.ts
+++ b/test/unit/vega-discovery.test.ts
@@ -3,6 +3,7 @@ import {
   createDiscoverSchedule,
   deleteDiscoverTasks,
   discoverCatalog,
+  discoverResource,
   getDiscoverSchedule,
   listDiscoverSchedules,
   listDiscoverTasks,
@@ -104,12 +105,36 @@ describe("DiscoverSchedule APIs", () => {
 });
 
 describe("DiscoverTask APIs", () => {
-  it("lists tasks with repeated statuses", async () => {
-    const f = mockFetch({ entries: [], total_count: 0 });
-    await listDiscoverTasks(ctx, { status: ["pending", "running"], scheduleId: "s-1" });
+  it("lists tasks with repeated statuses and a resource filter", async () => {
+    const f = mockFetch({
+      entries: [
+        {
+          id: "t-1",
+          catalog_id: "c-1",
+          resource_id: "r-1",
+          schedule_id: "",
+          strategy: "full_sync",
+          trigger_type: "manual",
+          queue_priority: 30,
+          status: "pending",
+          progress: 0,
+          creator: account,
+          create_time: 10,
+        },
+      ],
+      total_count: 1,
+    });
+    await expect(
+      listDiscoverTasks(ctx, {
+        status: ["pending", "running"],
+        scheduleId: "s-1",
+        resourceId: "r-1",
+      }),
+    ).resolves.toMatchObject({ entries: [{ resource_id: "r-1", queue_priority: 30 }] });
     const url = new URL(calls(f)[0]?.[0] ?? "");
     expect(url.searchParams.getAll("status")).toEqual(["pending", "running"]);
     expect(url.searchParams.get("schedule_id")).toBe("s-1");
+    expect(url.searchParams.get("resource_id")).toBe("r-1");
   });
 
   it("triggers a task and encodes batch deletion ids separately", async () => {
@@ -123,6 +148,13 @@ describe("DiscoverTask APIs", () => {
     expect(JSON.parse(calls(triggerFetch)[0]?.[1].body as string)).toEqual({
       strategy: "cleanup_only",
     });
+
+    const resourceTriggerFetch = mockFetch({ id: "t-2" });
+    await expect(discoverResource(ctx, "r/1")).resolves.toEqual({ id: "t-2" });
+    expect(new URL(calls(resourceTriggerFetch)[0]?.[0] ?? "").pathname).toContain(
+      "/resources/r%2F1/discover",
+    );
+    expect(calls(resourceTriggerFetch)[0]?.[1].body).toBeUndefined();
 
     const deleteFetch = mockFetch();
     await deleteDiscoverTasks(ctx, ["t/1", "t 2"], { ignoreMissing: true });

--- a/test/unit/vega.test.ts
+++ b/test/unit/vega.test.ts
@@ -250,6 +250,7 @@ describe("createBuildTask", () => {
       catalogId: "c-1",
       status: ["pending", "running"],
       mode: "batch",
+      executeType: "incremental",
       sort: "last_progress_time",
       direction: "asc",
       limit: 5,
@@ -262,6 +263,7 @@ describe("createBuildTask", () => {
     expect(u.searchParams.getAll("status")).toEqual(["pending", "running"]);
     expect(u.searchParams.has("active")).toBe(false);
     expect(u.searchParams.get("mode")).toBe("batch");
+    expect(u.searchParams.get("execute_type")).toBe("incremental");
     expect(u.searchParams.get("sort")).toBe("last_progress_time");
     expect(u.searchParams.get("direction")).toBe("asc");
     expect(u.searchParams.get("limit")).toBe("5");


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Add resource discovery, enable/disable SDK operations, and task resource filtering.
- [x] Add matching CLI commands and keep `queue_priority` output-only.
- [x] Bump the SDK package version to 0.1.5 and update Vega references, design, and execution records.

---

## Why

- Related Issue: openbkn-ai/bkn-foundry#260
- Related Feature: Resource metadata refresh and discovery-task prioritization
- Background: Expose the Foundry resource-discovery contract consistently to TypeScript SDK and CLI consumers.

---

## How

- Key implementation points: `vega.discoverResource`, `resource.enable`, and `resource.disable` map to the resource action endpoints; DiscoverTask exposes optional `resource_id`, numeric `queue_priority`, and `resourceId` filtering. Resource PUT preserves the current `enabled` state.
- Breaking changes (API, config, database, etc.): `ResourceStatus` no longer includes `disabled`; callers use the independent `enabled` field instead. Missing legacy response fields normalize to `enabled=true` and `queue_priority=20`.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not run; no integration environment was used)
- [ ] Verified in test environment (not run)

Test notes:

- `npm run lint` passed.
- `npm test` passed: 552 tests passed, 1 live test skipped.
- `git diff --check` passed before commit.

---

## Risk & Rollback

- Potential risks: Consumers relying on the former `disabled` Resource status must migrate to `enabled`.
- Rollback plan: Revert this SDK commit and publish the prior 0.1.4 package version if the 0.1.5 contract cannot be deployed.

---

## Additional Notes

- Backend dependency: openbkn-ai/bkn-foundry#1169. That PR contains `Closes #260`; this SDK PR intentionally does not close the Foundry issue.
- `queue_priority` remains a read-only number: 10/20/30 are current server defaults, not a fixed SDK enum.
