### PR TITLE
feat(bkn)!: point `bkn search` at search_instance

### DIFF
--- a/skills/openbkn/references/bkn.md
+++ b/skills/openbkn/references/bkn.md
@@ -2,7 +2,7 @@
 
 | Area | Commands |
 |------|----------|
-| KN | `list`, `get <kn> [--stats] [--export]`, `search <kn> <query> [--max-concepts]`, `stats <kn>`, `export <kn>`, `create`/`update`/`delete`, `subgraph <kn> --body`. |
+| KN | `list`, `get <kn> [--stats] [--export]`, `search <kn> <query> [--object-types ids] [--max-instances n] [--rerank]`（自然语言召回实例，附带命中对象类的定义）, `stats <kn>`, `export <kn>`, `create`/`update`/`delete`, `subgraph <kn> --body`. |
 | Schema | `object-type|relation-type|action-type list/get/create/update/delete` (create/update take `--body`/`--body-file`); `action-type query/execute`. |
 | Metric / concept-group / schedules | `metric …`, `concept-group …`, `action-log …`, `action-schedule …`. (No KN-level build jobs — index builds are Vega build tasks, see [vega.md](vega.md).) |
 | Paths / resources | `relation-type-paths <kn> --body`, `resources`. Both `relation-type-paths` and `subgraph` need `source_object_type_id` + `direction` (`forward` \| `backward` \| `bidirectional`) + `path_length` (1–3) in the body — omit any of them and the backend 400s. |

--- a/src/api/knowledge-networks.ts
+++ b/src/api/knowledge-networks.ts
@@ -401,10 +401,21 @@ export function validateMetric(ctx: RequestContext, knId: string, body: unknown)
   });
 }
 
-export interface SemanticSearchOptions {
-  mode?: string;
-  maxConcepts?: number;
-  returnQueryUnderstanding?: boolean;
+export interface SearchInstanceOptions {
+  /** Restrict recall to these concept groups. */
+  conceptGroups?: string[];
+  /** Pin recall to these object-type ids (ids, not names). */
+  objectTypes?: string[];
+  /** Drop these object-type ids from recall; wins over `objectTypes` on overlap. */
+  excludeObjectTypes?: string[];
+  /** How many object types may take part. Each one costs a downstream query. */
+  maxObjectTypes?: number;
+  /** How many instances to return per object type. */
+  maxInstancesPerType?: number;
+  /** Re-rank hits with a cross-encoder; silently skipped if no rerank model is deployed. */
+  rerank?: boolean;
+  /** Ship the trimmed definitions of the object types that produced hits (default true). */
+  includeObjectTypes?: boolean;
   /**
    * A `bkn_context` the caller built itself, sent as-is.
    *
@@ -416,39 +427,52 @@ export interface SemanticSearchOptions {
   bknContext?: BknContext;
 }
 
-function searchBody(knId: string, query: string, opts: SemanticSearchOptions) {
+function searchBody(knId: string, query: string, opts: SearchInstanceOptions) {
   return {
     kn_id: knId,
     query,
-    mode: opts.mode ?? "keyword_vector_retrieval",
-    max_concepts: opts.maxConcepts ?? 10,
-    return_query_understanding: opts.returnQueryUnderstanding ?? false,
+    ...(opts.conceptGroups?.length ? { concept_groups: opts.conceptGroups } : {}),
+    ...(opts.objectTypes?.length ? { object_types: opts.objectTypes } : {}),
+    ...(opts.excludeObjectTypes?.length ? { exclude_object_types: opts.excludeObjectTypes } : {}),
+    ...(opts.maxObjectTypes === undefined ? {} : { max_object_types: opts.maxObjectTypes }),
+    ...(opts.maxInstancesPerType === undefined
+      ? {}
+      : { max_instances_per_type: opts.maxInstancesPerType }),
+    ...(opts.rerank === undefined ? {} : { rerank: opts.rerank }),
+    ...(opts.includeObjectTypes === undefined
+      ? {}
+      : { include_object_types: opts.includeObjectTypes }),
   };
 }
 
 /**
- * Semantic search over a KN.
+ * Recall instances from one natural-language sentence: concept recall picks the
+ * object types, then each one is searched semantically (vector + full text,
+ * fused by rank). Hits carry the trimmed object-type definitions needed to read
+ * them, so a caller does not have to fetch schema separately.
  *
- * This is the one `/kn/*` tool with no MCP equivalent, so it cannot fall back
- * to the transport that merges a conversation per connection — deploys that
- * enforce the lifecycle contract need a `bkn_context` in the body, and
- * {@link withManagedLifecycle} opens the session that supplies one. Deploys
+ * Only properties whose `condition_operations` include `match` or `knn` take
+ * part, so an object type with no index produces no instances. No hits is not
+ * an error: `nodes` comes back empty with a `message`.
+ *
+ * Deploys that enforce the lifecycle contract need a `bkn_context` in the body;
+ * {@link withManagedLifecycle} opens the session that supplies one, and deploys
  * without the contract get the request unchanged.
  */
-export function semanticSearch(
+export function searchInstance(
   ctx: RequestContext,
   knId: string,
   query: string,
-  opts: SemanticSearchOptions = {},
+  opts: SearchInstanceOptions = {},
 ): Promise<unknown> {
   if (opts.bknContext) {
-    return request(ctx, `${RETRIEVAL_BASE}/semantic-search`, {
+    return request(ctx, `${RETRIEVAL_BASE}/search_instance`, {
       method: "POST",
       body: { ...searchBody(knId, query, opts), bkn_context: opts.bknContext },
     });
   }
   return withManagedLifecycle(ctx, knId, query, (bknContext) =>
-    request(ctx, `${RETRIEVAL_BASE}/semantic-search`, {
+    request(ctx, `${RETRIEVAL_BASE}/search_instance`, {
       method: "POST",
       body: {
         ...searchBody(knId, query, opts),

--- a/src/commands/bkn.ts
+++ b/src/commands/bkn.ts
@@ -54,13 +54,25 @@ export function bknCommand(): Command {
 
   bkn
     .command("search <kn-id> <query>")
-    .description("Semantic search within a knowledge network → {concepts} (schema, not instances)")
-    .option("--max-concepts <n>", "max concepts to return", int, 10)
-    .option("--mode <mode>", "retrieval mode", "keyword_vector_retrieval")
+    .description(
+      "Recall instances from a plain sentence — no object type or field names needed → {nodes, object_types}",
+    )
+    .option("--object-types <ids>", "pin recall to these object-type ids (comma-separated)")
+    .option("--exclude-object-types <ids>", "drop these object-type ids (comma-separated)")
+    .option("--concept-groups <names>", "limit recall to these concept groups (comma-separated)")
+    .option("--max-object-types <n>", "how many object types may take part", int)
+    .option("--max-instances <n>", "instances per object type", int)
+    .option("--rerank", "re-rank hits with a cross-encoder (needs a rerank model deployed)")
+    .option("--no-object-types-detail", "omit the object-type definitions that come with hits")
     .action(async (knId: string, query: string, opts, cmd: Command) => {
       const data = await clientFrom(cmd).kn.search(knId, query, {
-        maxConcepts: opts.maxConcepts,
-        mode: opts.mode,
+        objectTypes: csv(opts.objectTypes),
+        excludeObjectTypes: csv(opts.excludeObjectTypes),
+        conceptGroups: csv(opts.conceptGroups),
+        maxObjectTypes: opts.maxObjectTypes,
+        maxInstancesPerType: opts.maxInstances,
+        rerank: opts.rerank,
+        includeObjectTypes: opts.objectTypesDetail === false ? false : undefined,
       });
       printJson(data, outputOptions(cmd));
     });
@@ -615,6 +627,13 @@ export function bknCommand(): Command {
     bkn,
     `WHERE IDS COME FROM
   \`list\` gives kn ids; \`object-type list <kn-id>\` and \`search <kn-id> "<q>"\` give the rest.
+
+SEARCH VS THE MCP SIDE
+  \`search\` recalls instance rows from one sentence and ships the object-type definitions
+  needed to read them — start here when you do not know the schema yet. It only reaches
+  properties indexed for match/knn, so an unindexed object type yields nothing, and no hits
+  comes back as empty nodes with a message rather than an error. For schema alone use
+  \`openbkn context search-schema\`; for a structured filter use \`object-type query\`.
 
 EDITING SCHEMA AS FILES
   pull <kn-id> ./dir  ->  edit  ->  validate ./dir  ->  push ./dir

--- a/src/resources/knowledge-networks.ts
+++ b/src/resources/knowledge-networks.ts
@@ -29,7 +29,7 @@ import {
   type GetKnOptions,
   type ListKnOptions,
   type ListSchemaOptions,
-  type SemanticSearchOptions,
+  type SearchInstanceOptions,
   cancelActionLog,
   createKnowledgeNetwork,
   createMetric,
@@ -54,7 +54,7 @@ import {
   queryMetricData,
   queryObjectTypeInstances,
   querySubgraph,
-  semanticSearch,
+  searchInstance,
   updateKnowledgeNetwork,
   updateMetric,
   updateSchemaItem,
@@ -71,8 +71,8 @@ export function kn(ctx: RequestContext) {
   return {
     list: (opts?: ListKnOptions) => listKnowledgeNetworks(ctx, opts),
     get: (knId: string, opts?: GetKnOptions) => getKnowledgeNetwork(ctx, knId, opts),
-    search: (knId: string, query: string, opts?: SemanticSearchOptions) =>
-      semanticSearch(ctx, knId, query, opts),
+    search: (knId: string, query: string, opts?: SearchInstanceOptions) =>
+      searchInstance(ctx, knId, query, opts),
     create: (opts: CreateKnOptions) => createKnowledgeNetwork(ctx, opts),
     update: (knId: string, body: unknown) => updateKnowledgeNetwork(ctx, knId, body),
     delete: (knId: string) => deleteKnowledgeNetwork(ctx, knId),

--- a/test/unit/knowledge-networks.test.ts
+++ b/test/unit/knowledge-networks.test.ts
@@ -14,7 +14,7 @@ import {
   queryMetricData,
   queryObjectTypeInstances,
   querySubgraph,
-  semanticSearch,
+  searchInstance,
 } from "../../src/api/knowledge-networks.js";
 import { resetLifecycleCaches } from "../../src/api/lifecycle.js";
 import { readBody } from "../../src/commands/_shared.js";
@@ -225,28 +225,52 @@ describe("reads tunnelled over POST", () => {
   });
 });
 
-describe("semanticSearch", () => {
+describe("searchInstance", () => {
   // Search probes the MCP tool catalog first to decide whether this deploy
   // needs a `bkn_context`, so the retrieval POST is no longer the first call.
   beforeEach(() => resetLifecycleCaches());
 
-  it("POSTs the retrieval body with defaults", async () => {
+  it("POSTs only the sentence when nothing is narrowed", async () => {
     const fetchMock = mockFetch();
-    await semanticSearch(ctx, "kn-1", "churn");
-    const call = callTo(fetchMock, "/api/agent-retrieval/v1/kn/semantic-search");
+    await searchInstance(ctx, "kn-1", "churn");
+    const call = callTo(fetchMock, "/api/agent-retrieval/v1/kn/search_instance");
     expect(call[1].method).toBe("POST");
+    const body = JSON.parse(call[1].body as string);
+    expect(body).toMatchObject({ kn_id: "kn-1", query: "churn" });
+    // The server owns the defaults for everything else, so an untouched flag
+    // must not travel as an explicit value.
+    expect(body).not.toHaveProperty("max_object_types");
+    expect(body).not.toHaveProperty("rerank");
+    expect(body).not.toHaveProperty("include_object_types");
+  });
+
+  it("passes the narrowing options through under their wire names", async () => {
+    const fetchMock = mockFetch();
+    await searchInstance(ctx, "kn-1", "churn", {
+      objectTypes: ["customer"],
+      excludeObjectTypes: ["log"],
+      conceptGroups: ["sales"],
+      maxObjectTypes: 3,
+      maxInstancesPerType: 2,
+      rerank: true,
+      includeObjectTypes: false,
+    });
+    const call = callTo(fetchMock, "/api/agent-retrieval/v1/kn/search_instance");
     expect(JSON.parse(call[1].body as string)).toMatchObject({
-      kn_id: "kn-1",
-      query: "churn",
-      mode: "keyword_vector_retrieval",
-      max_concepts: 10,
+      object_types: ["customer"],
+      exclude_object_types: ["log"],
+      concept_groups: ["sales"],
+      max_object_types: 3,
+      max_instances_per_type: 2,
+      rerank: true,
+      include_object_types: false,
     });
   });
 
   it("leaves the body untouched when the deploy has no lifecycle tools", async () => {
     const fetchMock = mockFetch();
-    await semanticSearch(ctx, "kn-1", "churn");
-    const call = callTo(fetchMock, "/api/agent-retrieval/v1/kn/semantic-search");
+    await searchInstance(ctx, "kn-1", "churn");
+    const call = callTo(fetchMock, "/api/agent-retrieval/v1/kn/search_instance");
     expect(JSON.parse(call[1].body as string)).not.toHaveProperty("bkn_context");
   });
 });

--- a/test/unit/lifecycle.test.ts
+++ b/test/unit/lifecycle.test.ts
@@ -3,7 +3,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { callTool, searchSchema } from "../../src/api/context-loader.js";
-import { semanticSearch } from "../../src/api/knowledge-networks.js";
+import { searchInstance } from "../../src/api/knowledge-networks.js";
 import { releaseLifecycleSessions, resetLifecycleCaches } from "../../src/api/lifecycle.js";
 import type { RequestContext } from "../../src/types.js";
 import { HttpError, ToolError } from "../../src/utils/errors.js";
@@ -156,7 +156,7 @@ function mockDeploy(opts: MockOptions = {}): Recorded {
         );
       }
 
-      if (url.includes("/kn/semantic-search")) {
+      if (url.includes("/kn/search_instance")) {
         recorded.retrievalBodies.push(JSON.parse(init?.body as string));
         const reply = retrieval[Math.min(retrievalIndex, retrieval.length - 1)] ?? {
           status: 200,
@@ -172,10 +172,10 @@ function mockDeploy(opts: MockOptions = {}): Recorded {
   return recorded;
 }
 
-/** The body of the most recent `/kn/semantic-search` POST. */
+/** The body of the most recent `/kn/search_instance` POST. */
 function lastRetrievalBody(f: typeof fetch): Record<string, unknown> {
   const calls = (f as unknown as { mock: { calls: [string | URL, RequestInit][] } }).mock.calls;
-  const hit = calls.filter(([url]) => String(url).includes("/kn/semantic-search")).pop();
+  const hit = calls.filter(([url]) => String(url).includes("/kn/search_instance")).pop();
   if (!hit) throw new Error("no retrieval POST captured");
   return JSON.parse(hit[1].body as string) as Record<string, unknown>;
 }
@@ -192,7 +192,7 @@ afterEach(() => {
 describe("managed lifecycle on semantic search", () => {
   it("omits bkn_context on a deploy without the lifecycle tools", async () => {
     const recorded = mockDeploy({ catalog: LEGACY_CATALOG });
-    await semanticSearch(freshCtx(), "kn-legacy", "物料");
+    await searchInstance(freshCtx(), "kn-legacy", "物料");
 
     expect(recorded.toolCalls).toHaveLength(0);
     expect(recorded.retrievalBodies[0]).not.toHaveProperty("bkn_context");
@@ -201,14 +201,14 @@ describe("managed lifecycle on semantic search", () => {
 
   it("omits bkn_context when the catalog probe fails", async () => {
     const recorded = mockDeploy({ catalog: { unexpected: "shape" } });
-    await semanticSearch(freshCtx(), "kn-odd", "物料");
+    await searchInstance(freshCtx(), "kn-odd", "物料");
 
     expect(recorded.retrievalBodies[0]).not.toHaveProperty("bkn_context");
   });
 
   it("v1: creates a conversation, starts an interaction, and sends an operation_key", async () => {
     const recorded = mockDeploy({ catalog: V1_CATALOG });
-    await semanticSearch(freshCtx(), "kn-managed", "物料");
+    await searchInstance(freshCtx(), "kn-managed", "物料");
 
     expect(recorded.toolCalls.map((c) => c.name)).toEqual([
       "bkn_create_conversation",
@@ -228,7 +228,7 @@ describe("managed lifecycle on semantic search", () => {
   it("reports a conversation it minted, and one it did not", async () => {
     const minted: string[] = [];
     mockDeploy({ catalog: V2_CATALOG });
-    await semanticSearch(
+    await searchInstance(
       freshCtx({ onConversationOpened: (id) => minted.push(id) }),
       "kn-managed",
       "物料",
@@ -239,7 +239,7 @@ describe("managed lifecycle on semantic search", () => {
     // let a `--conversation-id` meant for one command become the stored default.
     const borrowed: string[] = [];
     mockDeploy({ catalog: V2_CATALOG });
-    await semanticSearch(
+    await searchInstance(
       freshCtx({
         onConversationOpened: (id) => borrowed.push(id),
         trace: { requestId: "req_x", traceparent: "00-x-y-01", conversationId: "conv_theirs" },
@@ -253,7 +253,7 @@ describe("managed lifecycle on semantic search", () => {
   it("stays silent on v1, where a later command could not use the conversation", async () => {
     const seen: string[] = [];
     mockDeploy({ catalog: V1_CATALOG });
-    await semanticSearch(
+    await searchInstance(
       freshCtx({ onConversationOpened: (id) => seen.push(id) }),
       "kn-v1",
       "物料",
@@ -270,7 +270,7 @@ describe("managed lifecycle on semantic search", () => {
       // The stored conversation was swept, or still holds an interaction.
       toolErrorsOnce: { bkn_start_interaction: "conversation_required" },
     });
-    await semanticSearch(
+    await searchInstance(
       freshCtx({
         rememberedConversationId: "conv_stale",
         onConversationOpened: (id) => seen.push(id),
@@ -293,7 +293,7 @@ describe("managed lifecycle on semantic search", () => {
       catalog: V2_CATALOG,
       toolErrorsOnce: { bkn_start_interaction: "conversation_required" },
     });
-    await semanticSearch(
+    await searchInstance(
       freshCtx({
         trace: { requestId: "req_x", traceparent: "00-x-y-01", conversationId: "conv_same" },
         rememberedConversationId: "conv_same",
@@ -326,7 +326,7 @@ describe("managed lifecycle on semantic search", () => {
         catalog: V2_CATALOG,
         toolHttpOnce: { bkn_start_interaction: status },
       });
-      await semanticSearch(
+      await searchInstance(
         freshCtx({ rememberedConversationId: "conv_stale" }),
         "kn-managed",
         "物料",
@@ -342,19 +342,19 @@ describe("managed lifecycle on semantic search", () => {
     // the refusal surfaces as the server's `conversation_required` on the
     // business call — naming neither the field nor the handshake.
     const withMode = mockDeploy({ catalog: V2_CATALOG_WITH_MODE });
-    await semanticSearch(freshCtx(), "kn-managed", "物料");
+    await searchInstance(freshCtx(), "kn-managed", "物料");
     expect(withMode.toolCalls[0]?.arguments.conversation_mode).toBe("new");
 
     // And not where it is absent: v2 validates strictly, and a deploy may
     // reject an argument it never published.
     const without = mockDeploy({ catalog: V2_CATALOG });
-    await semanticSearch(freshCtx(), "kn-managed", "物料");
+    await searchInstance(freshCtx(), "kn-managed", "物料");
     expect(without.toolCalls[0]?.arguments).not.toHaveProperty("conversation_mode");
   });
 
   it("joins with continue, not new", async () => {
     const recorded = mockDeploy({ catalog: V2_CATALOG_WITH_MODE });
-    await semanticSearch(
+    await searchInstance(
       freshCtx({
         trace: { requestId: "req_x", traceparent: "00-x-y-01", conversationId: "conv_theirs" },
       }),
@@ -371,7 +371,7 @@ describe("managed lifecycle on semantic search", () => {
   it("does not report a conversation it only joined", async () => {
     const seen: string[] = [];
     mockDeploy({ catalog: V2_CATALOG });
-    await semanticSearch(
+    await searchInstance(
       freshCtx({
         rememberedConversationId: "conv_kept",
         onConversationOpened: (id) => seen.push(id),
@@ -386,7 +386,7 @@ describe("managed lifecycle on semantic search", () => {
 
   it("ignores a remembered conversation on v1, where joining one traps the next call", async () => {
     const recorded = mockDeploy({ catalog: V1_CATALOG });
-    await semanticSearch(freshCtx({ rememberedConversationId: "conv_v1" }), "kn-v1", "物料");
+    await searchInstance(freshCtx({ rememberedConversationId: "conv_v1" }), "kn-v1", "物料");
     // v1 opens its own conversation; the field is public, so an SDK caller must
     // not be able to reach the hole the CLI's write side already avoids.
     const start = recorded.toolCalls.find((c) => c.name === "bkn_start_interaction");
@@ -397,8 +397,8 @@ describe("managed lifecycle on semantic search", () => {
     const recorded = mockDeploy({ catalog: V2_CATALOG });
     // Same deploy, same identity, same KN — only the wanted conversation differs.
     const base = freshCtx();
-    await semanticSearch({ ...base, rememberedConversationId: "conv_a" }, "kn-managed", "物料");
-    await semanticSearch({ ...base, rememberedConversationId: "conv_b" }, "kn-managed", "物料");
+    await searchInstance({ ...base, rememberedConversationId: "conv_a" }, "kn-managed", "物料");
+    await searchInstance({ ...base, rememberedConversationId: "conv_b" }, "kn-managed", "物料");
 
     // A caller that asked for B must not be handed the session opened on A —
     // the guarantee `sessionKey` already documents for a named conversation.
@@ -413,7 +413,7 @@ describe("managed lifecycle on semantic search", () => {
 
   it("v2: mints both ids in one call and omits operation_key", async () => {
     const recorded = mockDeploy({ catalog: V2_CATALOG });
-    await semanticSearch(freshCtx(), "kn-managed", "物料");
+    await searchInstance(freshCtx(), "kn-managed", "物料");
 
     expect(recorded.toolCalls.map((c) => c.name)).toEqual(["bkn_start_interaction"]);
     expect(recorded.toolCalls[0]?.arguments).toEqual({
@@ -435,7 +435,7 @@ describe("managed lifecycle on semantic search", () => {
       toolErrorsOnce: { bkn_start_interaction: "invalid_params" },
     });
 
-    await expect(semanticSearch(freshCtx(), "kn-managed", "物料")).rejects.toThrow(
+    await expect(searchInstance(freshCtx(), "kn-managed", "物料")).rejects.toThrow(
       /Context-loader error:.*invalid_params/,
     );
     expect(recorded.retrievalBodies).toHaveLength(0);
@@ -444,8 +444,8 @@ describe("managed lifecycle on semantic search", () => {
   it("v1: reuses one session across calls but never reuses an operation_key", async () => {
     const recorded = mockDeploy({ catalog: V1_CATALOG });
     const ctx = freshCtx();
-    await semanticSearch(ctx, "kn-managed", "物料");
-    await semanticSearch(ctx, "kn-managed", "供应商");
+    await searchInstance(ctx, "kn-managed", "物料");
+    await searchInstance(ctx, "kn-managed", "供应商");
 
     // A replayed operation_key returns the receipt instead of the payload, so
     // the second search would come back empty.
@@ -460,8 +460,8 @@ describe("managed lifecycle on semantic search", () => {
   it("v2: reuses one session and probes the catalog once", async () => {
     const recorded = mockDeploy({ catalog: V2_CATALOG });
     const ctx = freshCtx();
-    await semanticSearch(ctx, "kn-managed", "物料");
-    await semanticSearch(ctx, "kn-managed", "供应商");
+    await searchInstance(ctx, "kn-managed", "物料");
+    await searchInstance(ctx, "kn-managed", "供应商");
 
     expect(recorded.toolCalls).toHaveLength(1);
     expect(recorded.infoCount).toBe(1);
@@ -477,7 +477,7 @@ describe("managed lifecycle on semantic search", () => {
         interactionId: "int_caller_owned",
       },
     });
-    await semanticSearch(ctx, "kn-managed", "物料");
+    await searchInstance(ctx, "kn-managed", "物料");
 
     expect(recorded.toolCalls).toHaveLength(0);
     const context = recorded.retrievalBodies[0]?.bkn_context as Record<string, string>;
@@ -495,7 +495,7 @@ describe("managed lifecycle on semantic search", () => {
         conversationId: "conv_caller_named",
       },
     });
-    await semanticSearch(ctx, "kn-managed", "物料");
+    await searchInstance(ctx, "kn-managed", "物料");
 
     // Opening a fresh conversation would file the evidence somewhere the caller
     // never asked for, silently.
@@ -515,8 +515,8 @@ describe("managed lifecycle on semantic search", () => {
   it("keeps one session per KN rather than reusing another KN's conversation", async () => {
     const recorded = mockDeploy();
     const ctx = freshCtx();
-    await semanticSearch(ctx, "kn-alpha", "物料");
-    await semanticSearch(ctx, "kn-beta", "物料");
+    await searchInstance(ctx, "kn-alpha", "物料");
+    await searchInstance(ctx, "kn-beta", "物料");
 
     // The conversation is opened over an MCP session bound to `x-kn-id`.
     const alpha = recorded.retrievalBodies[0]?.bkn_context as Record<string, string>;
@@ -542,8 +542,8 @@ describe("managed lifecycle on semantic search", () => {
       baseUrl: host,
       trace: { ...trace, conversationId: "conv_B" },
     };
-    await semanticSearch(a, "kn-1", "物料");
-    await semanticSearch(b, "kn-1", "供应商");
+    await searchInstance(a, "kn-1", "物料");
+    await searchInstance(b, "kn-1", "供应商");
 
     // A caller who named conv_B must not silently get an interaction on conv_A,
     // nor have it released on their behalf at exit.
@@ -595,14 +595,14 @@ describe("managed lifecycle on semantic search", () => {
     vi.setSystemTime(new Date("2026-08-05T00:00:00.000Z"));
     const ctx = freshCtx();
 
-    await semanticSearch(ctx, "kn-1", "物料");
+    await searchInstance(ctx, "kn-1", "物料");
     // Inside the failure window the probe is not repeated: a durably missing
     // catalog would otherwise cost a doomed round trip on every business call.
-    await semanticSearch(ctx, "kn-1", "供应商");
+    await searchInstance(ctx, "kn-1", "供应商");
     expect(probes).toBe(1);
 
     vi.setSystemTime(new Date("2026-08-05T00:01:00.000Z"));
-    await semanticSearch(ctx, "kn-1", "订单");
+    await searchInstance(ctx, "kn-1", "订单");
     // And past it, the deploy gets another chance — caching the failure for
     // good would leave a long-lived process sending no bkn_context for the
     // rest of its life, with no path back.
@@ -614,8 +614,8 @@ describe("managed lifecycle on semantic search", () => {
     const host = `https://shared-${Date.now()}.example.com`;
     const alice: RequestContext = { ...freshCtx(), baseUrl: host, token: "alice" };
     const bob: RequestContext = { ...freshCtx(), baseUrl: host, token: "bob" };
-    await semanticSearch(alice, "kn-managed", "物料");
-    await semanticSearch(bob, "kn-managed", "物料");
+    await searchInstance(alice, "kn-managed", "物料");
+    await searchInstance(bob, "kn-managed", "物料");
 
     // Sharing would file Bob's evidence under Alice's turn, and release it with
     // her credential.
@@ -666,8 +666,8 @@ describe("managed lifecycle on semantic search", () => {
     const host = `https://tenants-${hostSeq}.example.com`;
     const alice: RequestContext = { ...freshCtx(), baseUrl: host, token: "stale" };
     const bob: RequestContext = { ...freshCtx(), baseUrl: host, token: "good" };
-    await semanticSearch(alice, "kn-1", "物料");
-    const bobBody = await semanticSearch(bob, "kn-1", "物料").then(() =>
+    await searchInstance(alice, "kn-1", "物料");
+    const bobBody = await searchInstance(bob, "kn-1", "物料").then(() =>
       lastRetrievalBody(fetch as unknown as typeof fetch),
     );
 
@@ -684,7 +684,7 @@ describe("managed lifecycle on semantic search", () => {
       interaction_id: "int_owned",
       operation_key: "op:pre-registered",
     };
-    await semanticSearch(freshCtx(), "kn-managed", "物料", { bknContext: owned });
+    await searchInstance(freshCtx(), "kn-managed", "物料", { bknContext: owned });
 
     // The same escape hatch context.toolCall has: a pre-registered
     // operation_key must reach the server unchanged.
@@ -702,7 +702,7 @@ describe("managed lifecycle on semantic search", () => {
         { status: 200, body: { concepts: [{ id: "material" }] } },
       ],
     });
-    const result = (await semanticSearch(freshCtx(), "kn-managed", "物料")) as {
+    const result = (await searchInstance(freshCtx(), "kn-managed", "物料")) as {
       concepts: unknown[];
     };
 
@@ -723,7 +723,7 @@ describe("managed lifecycle on semantic search", () => {
   it("releases a v2 interaction so the conversation does not linger", async () => {
     const recorded = mockDeploy({ catalog: V2_CATALOG });
     const ctx = freshCtx();
-    await semanticSearch(ctx, "kn-managed", "物料");
+    await searchInstance(ctx, "kn-managed", "物料");
     await releaseLifecycleSessions();
 
     const finish = recorded.toolCalls.at(-1);
@@ -736,7 +736,7 @@ describe("managed lifecycle on semantic search", () => {
   it("leaves a v1 interaction to the idle sweeper rather than mis-closing it", async () => {
     const recorded = mockDeploy({ catalog: V1_CATALOG });
     const ctx = freshCtx();
-    await semanticSearch(ctx, "kn-managed", "物料");
+    await searchInstance(ctx, "kn-managed", "物料");
     await releaseLifecycleSessions();
 
     expect(recorded.toolCalls.map((c) => c.name)).not.toContain("bkn_finish_interaction");
@@ -767,7 +767,7 @@ describe("managed lifecycle on semantic search", () => {
       },
     });
 
-    await expect(semanticSearch(ctx, "kn-managed", "物料")).rejects.toBeInstanceOf(HttpError);
+    await expect(searchInstance(ctx, "kn-managed", "物料")).rejects.toBeInstanceOf(HttpError);
     expect(recorded.retrievalBodies).toHaveLength(1);
     expect(recorded.toolCalls).toHaveLength(0);
   });
@@ -777,7 +777,7 @@ describe("managed lifecycle on semantic search", () => {
       retrieval: [{ status: 400, body: { error: { code: "kn_not_found" } } }],
     });
 
-    await expect(semanticSearch(freshCtx(), "kn-missing", "物料")).rejects.toBeInstanceOf(
+    await expect(searchInstance(freshCtx(), "kn-missing", "物料")).rejects.toBeInstanceOf(
       HttpError,
     );
     expect(recorded.retrievalBodies).toHaveLength(1);


### PR DESCRIPTION
`bkn search` called `/kn/semantic-search`. Foundry's API docs list that as the early retrieval entry — 「早期语义检索，带查询理解与实例样本」 — and name `search_schema` the contract new callers should adopt.

Two of its three modes are now worse than they read. `agent_intent_retrieval` and `agent_intent_planning` relied on the Conceptual Intention Analysis and Recall Strategy agents; with agent-factory retired, `agent_intent_retrieval.go` says the path "is downgraded to Query-based keyword recall (longtail)". The CLI accepted `--mode` as a free string with no validation, so a caller asking for intent analysis silently got keyword recall.

## What it calls now

`POST /kn/search_instance` — the endpoint that matches what the command claims to do:

```
{ "kn_id": "...", "query": "customer churn" }
```

One sentence in, instance rows out, ranked globally across object types, each carrying the trimmed object-type definition needed to read it. Concept recall picks the object types, then vector (`knn`) and full text (`match`) run concurrently and fuse by rank.

Two behaviours worth knowing, both from the contract: only properties whose `condition_operations` include `match` or `knn` take part, so an unindexed object type yields nothing; and no hits is not an error — empty `nodes` plus a `message`.

## Flags

| flag | wire field |
|---|---|
| `--object-types` / `--exclude-object-types` | `object_types` / `exclude_object_types` (ids, not names) |
| `--concept-groups` | `concept_groups` |
| `--max-object-types` / `--max-instances` | `max_object_types` / `max_instances_per_type` |
| `--rerank` | `rerank` — cross-encoder, silently skipped where no rerank model is deployed |
| `--no-object-types-detail` | `include_object_types: false` |

An untouched flag is absent from the body rather than sent as a client-side default, so the server keeps owning what the defaults are — a unit test pins that.

## Breaking

`--max-concepts` and `--mode` are gone. The response changes from concepts + query understanding to ranked instance nodes. Callers who specifically want `query_understanding` should call `/kn/semantic-search` through `openbkn call`; it remains registered.

`bkn --help` gains a SEARCH VS THE MCP SIDE block: `search` for instances when the schema is unknown, `context search-schema` for schema alone, `object-type query` for a structured filter.

Stacked on #80 (which is stacked on #79); base flips as those merge.

## Testing

`npm run lint`, `npm test` — 556 passed, 1 skipped. Not exercised against a live deploy: the tests mock `fetch` and assert the request, so the response-shape change rests on the published contract rather than a real call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)