### PR TITLE
fix(osdk): stop sending x-business-domain, as the TypeScript SDK stopped

### DIFF
--- a/python/bkn_osdk/__init__.py
+++ b/python/bkn_osdk/__init__.py
@@ -30,7 +30,6 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _version
 
 from .config import (
-    DEFAULT_BUSINESS_DOMAIN,
     DEFAULT_TIMEOUT,
     Context,
     configure,
@@ -72,7 +71,6 @@ except PackageNotFoundError:  # running from a source tree that was never instal
     __version__ = "0.0.0.dev0"
 
 __all__ = [
-    "DEFAULT_BUSINESS_DOMAIN",
     "DEFAULT_TIMEOUT",
     "BknError",
     "Comparison",

--- a/python/bkn_osdk/config.py
+++ b/python/bkn_osdk/config.py
@@ -37,7 +37,6 @@ from typing import Any
 from .errors import InputError
 
 __all__ = [
-    "DEFAULT_BUSINESS_DOMAIN",
     "DEFAULT_CLIENT_ID",
     "DEFAULT_TIMEOUT",
     "Context",
@@ -48,7 +47,6 @@ __all__ = [
     "write_refreshed_token",
 ]
 
-DEFAULT_BUSINESS_DOMAIN = "bd_public"
 DEFAULT_TIMEOUT = 30.0
 #: The public OAuth client the CLI logs in as; the refresh grant needs the same one.
 DEFAULT_CLIENT_ID = "openbkn-sdk"
@@ -77,7 +75,6 @@ class Context:
 
     base_url: str
     token: str
-    business_domain: str = DEFAULT_BUSINESS_DOMAIN
     insecure: bool = False
     timeout: float = DEFAULT_TIMEOUT
     #: Set when the token came from the store and can be refreshed in place.
@@ -98,7 +95,6 @@ class _Overrides:
 
     base_url: str | None = None
     token: str | None = None
-    business_domain: str | None = None
     insecure: bool | None = None
     timeout: float | None = None
     user: str | None = None
@@ -122,7 +118,6 @@ def configure(
     *,
     base_url: str | None = None,
     token: str | None = None,
-    business_domain: str | None = None,
     insecure: bool | None = None,
     timeout: float | None = None,
     user: str | None = None,
@@ -141,7 +136,6 @@ def configure(
     _process_default = _Overrides(
         base_url=base_url,
         token=token,
-        business_domain=business_domain,
         insecure=insecure,
         timeout=timeout,
         user=user,
@@ -157,7 +151,6 @@ def session(
     *,
     base_url: str | None = None,
     token: str | None = None,
-    business_domain: str | None = None,
     insecure: bool | None = None,
     timeout: float | None = None,
     user: str | None = None,
@@ -179,7 +172,6 @@ def session(
         overrides=_Overrides(
             base_url=base_url,
             token=token,
-            business_domain=business_domain,
             insecure=insecure,
             timeout=timeout,
             user=user,
@@ -297,20 +289,12 @@ def resolve_context() -> Context:
         # repeat it. The opt-out is scoped to this platform's own requests.
         insecure = bool(stored.get("tlsInsecure", False))
 
-    # The same user the token came from, not whoever the CLI last logged in as:
-    # `session(user=…)` would otherwise read one user's token and another's
-    # business domain, and send the pair out together.
-    business_domain = pick("business_domain") or _read_platform_config(base_url, user_id).get(
-        "businessDomain"
-    )
-
     timeout = pick("timeout")
 
     return Context(
         base_url=base_url,
         token=token,
         credential=credential,
-        business_domain=business_domain or DEFAULT_BUSINESS_DOMAIN,
         insecure=bool(insecure),
         timeout=float(timeout) if timeout is not None else DEFAULT_TIMEOUT,
         check_schema=bool(pick("check_schema")),

--- a/python/bkn_osdk/http.py
+++ b/python/bkn_osdk/http.py
@@ -124,7 +124,6 @@ def _headers(
     # the redirect target.
     headers = {
         "authorization": f"Bearer {bearer}",
-        "x-business-domain": ctx.business_domain,
         "accept": "application/json",
     }
     if has_body:

--- a/python/examples/credentials.py
+++ b/python/examples/credentials.py
@@ -73,10 +73,7 @@ def main() -> None:
     # environment so code running there joins the caller's turn with no argument
     # passing. See examples/platform/sandbox.py.
     live = bkn_osdk.resolve_context()
-    print(
-        f"\n业务域 {live.business_domain} | "
-        f"环境里的 turn {live.conversation_id or '(无)'} / {live.interaction_id or '(无)'}"
-    )
+    print(f"\n环境里的 turn {live.conversation_id or '(无)'} / {live.interaction_id or '(无)'}")
 
     # The CLI takes the same four fields as flags, and applies them as a
     # `session(...)` scope — so the command line and the library agree on

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -26,7 +26,6 @@ def test_env_alone_resolves(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert ctx.base_url == PLATFORM  # trailing slash stripped
     assert ctx.token == "env-token"
-    assert ctx.business_domain == "bd_public"
     assert ctx.insecure is False
 
 
@@ -35,14 +34,12 @@ def test_store_is_the_last_resort(isolated_config: Path) -> None:
         isolated_config,
         PLATFORM,
         token={"accessToken": "stored-token", "tlsInsecure": True},
-        config={"businessDomain": "bd_ops"},
     )
 
     ctx = resolve_context()
 
     assert (ctx.base_url, ctx.token) == (PLATFORM, "stored-token")
     assert ctx.insecure is True
-    assert ctx.business_domain == "bd_ops"
 
 
 def test_env_token_wins_over_the_store_while_base_url_still_comes_from_it(
@@ -77,11 +74,11 @@ def test_configure_with_no_arguments_clears_the_process_default(
 
 
 def test_session_beats_configure_and_inherits_what_it_omits() -> None:
-    configure(base_url=PLATFORM, token="process-token", business_domain="bd_ops")
+    configure(base_url=PLATFORM, token="process-token", insecure=True)
 
     with session(token="scoped-token") as ctx:
         assert (ctx.base_url, ctx.token) == (PLATFORM, "scoped-token")
-        assert ctx.business_domain == "bd_ops"
+        assert ctx.insecure is True
 
     assert resolve_context().token == "process-token"
 
@@ -158,33 +155,6 @@ def test_user_selects_a_saved_identity_by_username(isolated_config: Path) -> Non
     assert resolve_context().token == "first"
 
 
-def test_the_business_domain_follows_the_user_whose_token_is_used(
-    isolated_config: Path,
-) -> None:
-    """Reading one user's token beside another's config would send the pair out
-    together — the wrong `x-business-domain` on a request the token authorises."""
-    write_store(
-        isolated_config,
-        PLATFORM,
-        user_id="u-1",
-        token={"accessToken": "first"},
-        config={"businessDomain": "active-domain"},
-    )
-    write_store(
-        isolated_config,
-        PLATFORM,
-        user_id="u-2",
-        token={"accessToken": "second", "username": "ops@example.com"},
-        config={"businessDomain": "other-domain"},
-        active=False,
-    )
-
-    with session(user="ops@example.com") as ctx:
-        assert (ctx.token, ctx.business_domain) == ("second", "other-domain")
-
-    assert resolve_context().business_domain == "active-domain"
-
-
 def test_unknown_user_lists_what_is_saved_instead(isolated_config: Path) -> None:
     write_store(isolated_config, PLATFORM, user_id="u-1")
 
@@ -249,17 +219,6 @@ def test_a_stored_tls_opt_out_can_be_overridden_explicitly(isolated_config: Path
         assert ctx.insecure is False
 
     assert resolve_context().insecure is True
-
-
-def test_business_domain_prefers_the_scope_over_the_stored_platform_config(
-    isolated_config: Path,
-) -> None:
-    write_store(isolated_config, PLATFORM, config={"businessDomain": "bd_ops"})
-
-    with session(business_domain="bd_finance") as ctx:
-        assert ctx.business_domain == "bd_finance"
-
-    assert resolve_context().business_domain == "bd_ops"
 
 
 def test_the_timeout_has_a_default_and_a_scope_override(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/python/tests/test_http.py
+++ b/python/tests/test_http.py
@@ -73,11 +73,16 @@ def test_a_body_implies_post_and_sets_content_type(record: list[httpx.Request]) 
     assert json.loads(record[0].read()) == {"a": 1}
 
 
-def test_auth_and_business_domain_headers(record: list[httpx.Request]) -> None:
-    http_module.request(ctx(business_domain="bd_ops"), "/api/thing")
+def test_the_token_rides_in_authorization_and_nothing_else_is_added(
+    record: list[httpx.Request],
+) -> None:
+    """`x-business-domain` was removed platform-side (bkn-sdk#78); sending a
+    stale one is worse than sending none — a wrong domain filters a read to
+    zero rows and reports success."""
+    http_module.request(ctx(), "/api/thing")
 
     assert record[0].headers["authorization"] == "Bearer t-1"
-    assert record[0].headers["x-business-domain"] == "bd_ops"
+    assert "x-business-domain" not in record[0].headers
 
 
 def test_method_override_rides_a_header(record: list[httpx.Request]) -> None:


### PR DESCRIPTION
Follows #78, which removed business domain and tenant support from the TypeScript side. The Python runtime landed in #83 still sent `x-business-domain` on every request, read it from the store's `config.json`, and exposed it on `Context`, `configure(...)` and `session(...)`.

## Why it matters more than a stale header usually does

Measured on `14.103.77.23`:

| header | result |
| --- | --- |
| `x-business-domain: bd_public` | HTTP 200, 1 row |
| `x-business-domain: garbage_domain` | HTTP 200, **0 rows** |
| empty value | HTTP 200, 1 row |
| header omitted | HTTP 200, 1 row |

A wrong domain does not fail — it filters the read to nothing and reports success. So a value left in a store after the platform stopped using it reads as an empty network. Omitting the header was verified on both deploys.

## What goes

`Context.business_domain`, `DEFAULT_BUSINESS_DOMAIN`, the `business_domain=` argument on `configure` and `session`, the `businessDomain` read from the store, and the header itself. Two tests that existed only to pin the field are removed; the header test now asserts the header is **not** sent, with the reason.

Suite: 390 passed. Live suites green on both deploys — `ecommerce_ops_bkn_public` 32/32, `worldcup_vega_catalog_bkn` 29 passed 3 skipped — and the examples run unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)