### PR TITLE
fix(context): align receipt lifecycle compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,20 @@ opened, so work spanning several commands lands in one thread. `openbkn context 
 is in force and where it came from; `--forget` drops it. An explicit `--token` /
 `BKN_TOKEN` opts out (identity there is the token, not the stored user) — use
 `BKN_CONVERSATION_ID` to thread such a script's commands together.
-`--interaction-id` / `BKN_INTERACTION_ID` must always be paired with its owning
-Conversation ID; the CLI rejects an interaction-only business call before sending MCP traffic.
+`--interaction-id` / `BKN_INTERACTION_ID` can be supplied on its own for
+existing scripts. The SDK follows the automatic lifecycle handshake, but does
+not forward that orphan ID as a business header once it has opened an
+authoritative context; it never invents a matching Conversation ID locally. Use
+the returned receipt to establish the authoritative business context.
 
-`context tool-call --receipt` requires `--json` and emits `{ value, bkn_receipt }`
-(use `--compact` for one line). It is opt-in; the default command output and SDK
+`context tool-call --receipt` requires `--json` or `--compact` and emits
+`{ value, bkn_receipt }` (`--compact` is the one-line form). It is opt-in; the default command output and SDK
 `context.toolCall()` remain business-value-only. The receipt is validated for this
 call, not a bearer credential; confirm access under the current identity with
 `openbkn trace receipts get <receipt-id>` when authorization evidence is required.
+Check `bkn_receipt.receipt_status`, not whether `value` is `null`: a `pending`
+receipt has no consumable value and must be read back by `receipt_id` rather
+than retried.
 
 Tokens are stored per platform/user under `~/.bkn/` (override: `BKN_CONFIG_DIR`).
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -54,13 +54,16 @@ openbkn --help        # 分组命令树
 `openbkn context conversation` 显示当前生效的是哪个、来自哪一层；`--forget` 丢掉它。
 显式 `--token` / `BKN_TOKEN` 不参与（那里的身份是 token 本身，不是存下来的用户）——
 这类脚本用 `BKN_CONVERSATION_ID` 把多条命令串起来。
-`--interaction-id` / `BKN_INTERACTION_ID` 必须始终与所属 Conversation ID 一起提供；CLI 会在
-发送 MCP 请求前拒绝只有 interaction 的业务调用。
+既有脚本可以单独提供 `--interaction-id` / `BKN_INTERACTION_ID`。SDK 会走自动 lifecycle handshake；
+一旦建立权威上下文，孤立 ID 不会再作为业务 header 透传，也不会在本地伪造对应的 Conversation ID；以返回的
+Receipt 确认权威业务上下文。
 
-`context tool-call --receipt` 必须带 `--json`，输出 `{ value, bkn_receipt }`（带
-`--compact` 时为单行）。这是显式选择；默认命令输出和 SDK 的 `context.toolCall()` 仍只返回
+`context tool-call --receipt` 必须带 `--json` 或 `--compact`，输出 `{ value, bkn_receipt }`（
+`--compact` 即单行形式）。这是显式选择；默认命令输出和 SDK 的 `context.toolCall()` 仍只返回
 业务值。Receipt 仅证明其已通过本次调用的字段校验，不是 bearer credential；需要授权证据时，
 应在当前身份下运行 `openbkn trace receipts get <receipt-id>` 回读确认。
+不要用 `value` 是否为 `null` 判断结果是否可用；应检查 `bkn_receipt.receipt_status`。`pending` 表示
+业务值不可消费，应使用 `receipt_id` 回读，而不是重试业务工具。
 
 Token 按平台/用户存于 `~/.bkn/`（可用 `BKN_CONFIG_DIR` 覆盖）。
 

--- a/docs/product-specs/bkn-trace.md
+++ b/docs/product-specs/bkn-trace.md
@@ -62,11 +62,16 @@ Community 制品不分发 2.x Evidence 写入 Session、Artifact 正文读写、
 
 `trace get <conversation-id>` 与 `trace spans <conversation-id>` 均读取会话 Span；`trace detail <trace-id>` 读取单条类型化技术 Trace，避免改变既有 `trace get` 的参数语义。
 
-Context Loader 的通用调用可通过 `openbkn --json context tool-call <kn> <tool> --receipt`
+Context Loader 的通用调用可在 JSON 输出模式下通过
+`openbkn --json context tool-call <kn> <tool> --receipt`（或将 `--json` 换为 `--compact`）
 返回 `{ value, bkn_receipt }`。这里的 receipt 是 SDK 已校验字段形状且与本次受管调用
 一致的 **validated** 证据，不等同于当前身份已获授权的 **authorized** 证据；后者必须经
 `openbkn trace receipts get <receipt-id>`（或等价 API）在当前身份下回读确认。Receipt JSON
 不是 bearer credential，不应作为认证材料、日志标签或指标维度传播。
+
+Receipt 的消费以 `receipt_status` 为准，而不是 `value === null`：`pending` 只能通过 `receipt_id`
+回读，不能重试业务工具。若 catalog 明确不支持 lifecycle，Receipt 请求仍可执行一次业务调用；没有
+Receipt 时返回稳定的 `receipt_missing` 错误，不能据此假定业务操作未发生。
 
 Interaction 终止 manifest 和 Operation retry fencing 字段通过受保护的 `--body-file` 提交。lease token 不进入命令行参数，避免出现在 shell history 或进程列表。
 

--- a/skills/openbkn/references/context.md
+++ b/skills/openbkn/references/context.md
@@ -28,7 +28,16 @@ HTTP retrieval path, where `client.kn.search(kn, q, { bknContext })` takes the
 same object. The same holds for
 `--conversation-id` / `--interaction-id` (and `BKN_CONVERSATION_ID` /
 `BKN_INTERACTION_ID`) on the CLI. Given only a conversation, the SDK opens its
-interaction inside that conversation rather than starting a new one.
+interaction inside that conversation rather than starting a new one. Given only
+an interaction, it uses the automatic lifecycle handshake; after a context is
+opened it does not forward the orphan interaction
+as a business header, and it never guesses a Conversation ID locally. Treat the returned
+Receipt, not the supplied interaction alone, as the authoritative context.
+
+A complete caller-owned `bkn_context` does not require a lifecycle catalog
+probe: the caller has already asserted the business pair. A receipt-requested
+call still requires the server to return and validate its Receipt; catalog
+unavailability is not an authorization bypass.
 
 The CLI remembers a conversation it opened **on a `managed-v2` deploy**, per
 platform and active identity, so
@@ -167,11 +176,16 @@ openbkn --json context tool-call <kn> <tool-name> --args '{"k":"v"}' --receipt
 # → { "value": ..., "bkn_receipt": { "receipt_id": ..., "receipt_status": ... } }
 ```
 
-`--receipt` 必须配合 `--json`（可再配合 `--compact`），不能与 `--schema` 一起使用。
+`--receipt` 必须配合 `--json` 或 `--compact`，不能与 `--schema` 一起使用。
 默认 `tool-call` 输出不变，只返回业务值。SDK 对 Receipt 的必要字段和状态作本地校验，
 但这只说明它与当前调用匹配（validated）；若需确认当前身份仍有权限读取该证据，应使用
 `openbkn trace receipts get <receipt-id>` 回读（authorized）。Receipt 不是凭据，勿写入日志、
 指标标签或后续工具参数。
+
+`value: null` 本身不是状态：`pending` Receipt 的 value 不可消费，必须依据
+`bkn_receipt.receipt_status` 判断，并使用 `receipt_id` 回读；不得通过重试业务工具取得结果。
+在 catalog 明确不支持 lifecycle 的部署上，`--receipt` 仍会执行一次业务调用，但若服务端不返回
+Receipt，命令以 `receipt_missing` 失败，业务副作用不会被回滚。
 
 `call-method <kn> <method>` does the same for raw MCP protocol methods
 (`tools/list`, `resources/read`, `prompts/get`, …) that have no dedicated

--- a/src/api/context-loader.ts
+++ b/src/api/context-loader.ts
@@ -16,7 +16,7 @@ import { parseBigIntJSON, stringifyBigIntJSON } from "../utils/json-bigint.js";
 import { authFetch } from "./auth-fetch.js";
 import { buildHeaders } from "./headers.js";
 import { request } from "./http.js";
-import { withManagedLifecycle } from "./lifecycle.js";
+import { requireKnownLifecycleCapability, withManagedLifecycle } from "./lifecycle.js";
 import { tlsFetch } from "./tls.js";
 import type { OperationReceipt } from "./trace-lifecycle.js";
 
@@ -181,7 +181,7 @@ function receiptFrom(structuredContent: unknown): OperationReceipt | undefined {
   const candidate = content?.bkn_receipt ?? content?.receipt;
   if (candidate === undefined) return undefined;
   if (!isOperationReceipt(candidate)) {
-    throw new Error("Context-loader returned an invalid operation receipt.");
+    throw new ToolError("Context-loader returned an invalid operation receipt.", "receipt_invalid");
   }
   return candidate;
 }
@@ -332,12 +332,6 @@ function callerContextMatchesTrace(
   return business as BusinessContextIds;
 }
 
-function assertTraceBusinessContext(ctx: RequestContext): void {
-  if (ctx.trace?.interactionId && !ctx.trace.conversationId) {
-    throw new InputError("BKN interaction id requires a conversation id.");
-  }
-}
-
 function receiptMatchesBusinessContext(
   result: UnwrappedToolResult,
   businessContext: BusinessContextIds | undefined,
@@ -428,9 +422,9 @@ async function callToolResult(
   name: string,
   args: Record<string, unknown>,
   options?: ToolCallOptions,
+  requireReceipt = false,
 ): Promise<UnwrappedToolResult> {
   if (LIFECYCLE_TOOLS.has(name)) return callToolRawResult(ctx, knId, name, args, options);
-  assertTraceBusinessContext(ctx);
   const callerContext = callerContextMatchesTrace(ctx, args);
   // A caller that built its own `bkn_context` gets it through untouched, and no
   // session is opened on its behalf. `ManagedTrace.runOperation` pre-registers
@@ -443,14 +437,20 @@ async function callToolResult(
       callerContext,
     );
   }
-  return withManagedLifecycle(ctx, knId, questionFor(name, args), (bknContext) =>
-    callToolRawResult(
-      ctx,
-      knId,
-      name,
-      bknContext ? { ...args, bkn_context: bknContext } : args,
-      options,
-    ).then((result) => receiptMatchesBusinessContext(result, bknContext)),
+  if (requireReceipt) await requireKnownLifecycleCapability(ctx);
+  return withManagedLifecycle(
+    ctx,
+    knId,
+    questionFor(name, args),
+    (bknContext, requestContext) =>
+      callToolRawResult(
+        requestContext,
+        knId,
+        name,
+        bknContext ? { ...args, bkn_context: bknContext } : args,
+        options,
+      ).then((result) => receiptMatchesBusinessContext(result, bknContext)),
+    requireReceipt,
   );
 }
 
@@ -477,9 +477,12 @@ export async function callManagedTool<T = unknown>(
   args: Record<string, unknown>,
   options?: ToolCallOptions,
 ): Promise<ManagedToolResult<T>> {
-  const result = await callToolResult(ctx, knId, name, args, options);
+  const result = await callToolResult(ctx, knId, name, args, options, true);
   if (!result.receipt) {
-    throw new Error("Context-loader managed tool response did not include bkn_receipt");
+    throw new ToolError(
+      "Context-loader managed tool response did not include bkn_receipt",
+      "receipt_missing",
+    );
   }
   return { value: result.value as T, receipt: result.receipt };
 }

--- a/src/api/context-loader.ts
+++ b/src/api/context-loader.ts
@@ -332,6 +332,17 @@ function callerContextMatchesTrace(
   return business as BusinessContextIds;
 }
 
+/**
+ * A complete caller-owned `bkn_context` is authoritative for the business
+ * operation. Do not also send an interaction-only header: it is an incomplete
+ * second context channel and the body already names the same interaction.
+ */
+function requestContextForCallerContext(ctx: RequestContext): RequestContext {
+  if (!ctx.trace?.interactionId || ctx.trace.conversationId) return ctx;
+  const { interactionId: _interactionId, ...trace } = ctx.trace;
+  return { ...ctx, trace };
+}
+
 function receiptMatchesBusinessContext(
   result: UnwrappedToolResult,
   businessContext: BusinessContextIds | undefined,
@@ -433,7 +444,7 @@ async function callToolResult(
   // `parent_operation_id` / `causation_event_ids` would be dropped with it.
   if (callerContext) {
     return receiptMatchesBusinessContext(
-      await callToolRawResult(ctx, knId, name, args, options),
+      await callToolRawResult(requestContextForCallerContext(ctx), knId, name, args, options),
       callerContext,
     );
   }

--- a/src/api/context-loader.ts
+++ b/src/api/context-loader.ts
@@ -16,7 +16,11 @@ import { parseBigIntJSON, stringifyBigIntJSON } from "../utils/json-bigint.js";
 import { authFetch } from "./auth-fetch.js";
 import { buildHeaders } from "./headers.js";
 import { request } from "./http.js";
-import { requireKnownLifecycleCapability, withManagedLifecycle } from "./lifecycle.js";
+import {
+  requestContextForBusinessContext,
+  requireKnownLifecycleCapability,
+  withManagedLifecycle,
+} from "./lifecycle.js";
 import { tlsFetch } from "./tls.js";
 import type { OperationReceipt } from "./trace-lifecycle.js";
 
@@ -332,17 +336,6 @@ function callerContextMatchesTrace(
   return business as BusinessContextIds;
 }
 
-/**
- * A complete caller-owned `bkn_context` is authoritative for the business
- * operation. Do not also send an interaction-only header: it is an incomplete
- * second context channel and the body already names the same interaction.
- */
-function requestContextForCallerContext(ctx: RequestContext): RequestContext {
-  if (!ctx.trace?.interactionId || ctx.trace.conversationId) return ctx;
-  const { interactionId: _interactionId, ...trace } = ctx.trace;
-  return { ...ctx, trace };
-}
-
 function receiptMatchesBusinessContext(
   result: UnwrappedToolResult,
   businessContext: BusinessContextIds | undefined,
@@ -444,7 +437,13 @@ async function callToolResult(
   // `parent_operation_id` / `causation_event_ids` would be dropped with it.
   if (callerContext) {
     return receiptMatchesBusinessContext(
-      await callToolRawResult(requestContextForCallerContext(ctx), knId, name, args, options),
+      await callToolRawResult(
+        requestContextForBusinessContext(ctx, callerContext),
+        knId,
+        name,
+        args,
+        options,
+      ),
       callerContext,
     );
   }

--- a/src/api/knowledge-networks.ts
+++ b/src/api/knowledge-networks.ts
@@ -11,7 +11,11 @@
 import type { RequestContext } from "../types.js";
 import { parseBigIntJSON } from "../utils/json-bigint.js";
 import { request } from "./http.js";
-import { type BknContext, withManagedLifecycle } from "./lifecycle.js";
+import {
+  type BknContext,
+  requestContextForBusinessContext,
+  withManagedLifecycle,
+} from "./lifecycle.js";
 
 const ONTOLOGY_BASE = "/api/bkn-backend/v1/knowledge-networks";
 const ONTOLOGY_QUERY_BASE = "/api/ontology-query/v1/knowledge-networks";
@@ -466,10 +470,14 @@ export function searchInstance(
   opts: SearchInstanceOptions = {},
 ): Promise<unknown> {
   if (opts.bknContext) {
-    return request(ctx, `${RETRIEVAL_BASE}/search_instance`, {
-      method: "POST",
-      body: { ...searchBody(knId, query, opts), bkn_context: opts.bknContext },
-    });
+    return request(
+      requestContextForBusinessContext(ctx, opts.bknContext),
+      `${RETRIEVAL_BASE}/search_instance`,
+      {
+        method: "POST",
+        body: { ...searchBody(knId, query, opts), bkn_context: opts.bknContext },
+      },
+    );
   }
   return withManagedLifecycle(ctx, knId, query, (bknContext, requestContext) =>
     request(requestContext, `${RETRIEVAL_BASE}/search_instance`, {

--- a/src/api/knowledge-networks.ts
+++ b/src/api/knowledge-networks.ts
@@ -471,8 +471,8 @@ export function searchInstance(
       body: { ...searchBody(knId, query, opts), bkn_context: opts.bknContext },
     });
   }
-  return withManagedLifecycle(ctx, knId, query, (bknContext) =>
-    request(ctx, `${RETRIEVAL_BASE}/search_instance`, {
+  return withManagedLifecycle(ctx, knId, query, (bknContext, requestContext) =>
+    request(requestContext, `${RETRIEVAL_BASE}/search_instance`, {
       method: "POST",
       body: {
         ...searchBody(knId, query, opts),

--- a/src/api/lifecycle.ts
+++ b/src/api/lifecycle.ts
@@ -160,7 +160,12 @@ const UNKNOWN_LIFECYCLE: Lifecycle = {
   startWantsConversationMode: false,
 };
 
-export function lifecycleFor(ctx: RequestContext): Promise<Lifecycle> {
+/**
+ * The raw catalog probe. Receipt callers need an authentication failure to stay
+ * actionable, while ordinary calls preserve their longstanding best-effort
+ * fallback through {@link lifecycleFor} below.
+ */
+function lifecycleProbeFor(ctx: RequestContext): Promise<Lifecycle> {
   const failureKey = `${ctx.baseUrl}\0${identityOf(ctx)}`;
   const failedAt = probeFailures.get(failureKey);
   if (failedAt !== undefined) {
@@ -171,7 +176,14 @@ export function lifecycleFor(ctx: RequestContext): Promise<Lifecycle> {
   if (!pending) {
     pending = mcpInfo(ctx).then((info): Lifecycle => {
       const names = toolNames(info);
-      if (!names) return UNKNOWN_LIFECYCLE;
+      if (!names) {
+        // A malformed 200 response is as inconclusive as a rejected probe. Do
+        // not let it decide a long-lived process permanently, but avoid a new
+        // doomed round trip for every business call in this short window.
+        contracts.delete(failureKey);
+        probeFailures.set(failureKey, Date.now());
+        return UNKNOWN_LIFECYCLE;
+      }
       const startWantsConversationMode = requiresArgument(info, V2_MARKER, "conversation_mode");
       if (names.includes(V1_MARKER)) {
         return { contract: "managed-v1", capability: "managed", startWantsConversationMode };
@@ -194,7 +206,11 @@ export function lifecycleFor(ctx: RequestContext): Promise<Lifecycle> {
       if (!isAuthFailure(err)) probeFailures.set(failureKey, Date.now());
     });
   }
-  return pending.catch((): Lifecycle => UNKNOWN_LIFECYCLE);
+  return pending;
+}
+
+export function lifecycleFor(ctx: RequestContext): Promise<Lifecycle> {
+  return lifecycleProbeFor(ctx).catch((): Lifecycle => UNKNOWN_LIFECYCLE);
 }
 
 /** Kept for callers that only care which contract a deploy speaks. */
@@ -229,12 +245,17 @@ function toolNames(info: unknown): string[] | undefined {
 }
 
 export async function requireKnownLifecycleCapability(ctx: RequestContext): Promise<void> {
-  if ((await lifecycleFor(ctx)).capability === "unknown") {
-    throw new ToolError(
-      "Context-loader lifecycle capability is unavailable; retry when the catalog can be read.",
-      "lifecycle_capability_unknown",
-    );
+  try {
+    if ((await lifecycleProbeFor(ctx)).capability !== "unknown") return;
+  } catch (err) {
+    // Do not turn a credential failure into a generic retry hint. HttpError
+    // carries the CLI's established authentication diagnosis and exit status.
+    if (isAuthFailure(err)) throw err;
   }
+  throw new ToolError(
+    "Context-loader lifecycle capability is unavailable; retry when the catalog can be read.",
+    "lifecycle_capability_unknown",
+  );
 }
 
 /**

--- a/src/api/lifecycle.ts
+++ b/src/api/lifecycle.ts
@@ -539,7 +539,12 @@ function contextFor(
   };
 }
 
-function requestContextForManagedLifecycle(
+/**
+ * A complete business context is authoritative for its operation. An
+ * interaction-only trace header is a second, incomplete context channel, so
+ * omit it for every path that supplies a full `bkn_context`.
+ */
+export function requestContextForBusinessContext(
   ctx: RequestContext,
   bknContext: BknContext | undefined,
 ): RequestContext {
@@ -607,7 +612,7 @@ export async function withManagedLifecycle<T>(
 ): Promise<T> {
   const first = await bknContextFor(ctx, knId, question, requireKnownCapability);
   try {
-    return await send(first, requestContextForManagedLifecycle(ctx, first));
+    return await send(first, requestContextForBusinessContext(ctx, first));
   } catch (err) {
     const code = serverErrorCode(err);
     // Only a session we opened is ours to reopen. A caller-supplied
@@ -617,7 +622,7 @@ export async function withManagedLifecycle<T>(
     sessions.delete(sessionKey(ctx, knId));
     const reopened = await bknContextFor(ctx, knId, question, requireKnownCapability);
     if (!reopened) throw err;
-    return await send(reopened, requestContextForManagedLifecycle(ctx, reopened));
+    return await send(reopened, requestContextForBusinessContext(ctx, reopened));
   }
 }
 

--- a/src/api/lifecycle.ts
+++ b/src/api/lifecycle.ts
@@ -33,7 +33,7 @@
  */
 import { createHash, randomUUID } from "node:crypto";
 import type { RequestContext } from "../types.js";
-import { HttpError, InputError, ToolError } from "../utils/errors.js";
+import { HttpError, ToolError } from "../utils/errors.js";
 import { callToolRaw, mcpInfo } from "./context-loader.js";
 
 /** The body field the lifecycle middleware reads. Snake_case: it goes on the wire. */
@@ -46,6 +46,7 @@ export interface BknContext {
 
 /** Which lifecycle contract a deploy speaks, decided from its tool catalog. */
 type Contract = "none" | "managed-v1" | "managed-v2";
+type LifecycleCapability = "managed" | "unsupported" | "unknown";
 
 /**
  * What the catalog says about opening an interaction, beyond which tools exist.
@@ -64,6 +65,7 @@ type Contract = "none" | "managed-v1" | "managed-v2";
  */
 interface Lifecycle {
   contract: Contract;
+  capability: LifecycleCapability;
   startWantsConversationMode: boolean;
 }
 
@@ -142,29 +144,40 @@ export function resetLifecycleCaches(): void {
 
 /**
  * Which contract does this deploy speak? Answered from the global tool catalog,
- * which is a plain GET — no MCP session, no KN, one call per process. A probe
- * that fails answers "none": an unreachable catalog must not turn into a hard
- * error on a request that might have succeeded without any context.
+ * which is a plain GET — no MCP session, no KN, one call per process. An
+ * unreachable or malformed catalog is distinct from a catalog that explicitly
+ * lacks lifecycle tools: ordinary calls preserve the old best-effort fallback,
+ * while receipt-required calls must not mistake uncertainty for legacy support.
  */
-const NO_LIFECYCLE: Lifecycle = { contract: "none", startWantsConversationMode: false };
+const NO_LIFECYCLE: Lifecycle = {
+  contract: "none",
+  capability: "unsupported",
+  startWantsConversationMode: false,
+};
+const UNKNOWN_LIFECYCLE: Lifecycle = {
+  contract: "none",
+  capability: "unknown",
+  startWantsConversationMode: false,
+};
 
 export function lifecycleFor(ctx: RequestContext): Promise<Lifecycle> {
   const failureKey = `${ctx.baseUrl}\0${identityOf(ctx)}`;
   const failedAt = probeFailures.get(failureKey);
   if (failedAt !== undefined) {
-    if (Date.now() - failedAt < PROBE_FAILURE_TTL_MS) return Promise.resolve(NO_LIFECYCLE);
+    if (Date.now() - failedAt < PROBE_FAILURE_TTL_MS) return Promise.resolve(UNKNOWN_LIFECYCLE);
     probeFailures.delete(failureKey);
   }
   let pending = contracts.get(failureKey);
   if (!pending) {
     pending = mcpInfo(ctx).then((info): Lifecycle => {
       const names = toolNames(info);
+      if (!names) return UNKNOWN_LIFECYCLE;
       const startWantsConversationMode = requiresArgument(info, V2_MARKER, "conversation_mode");
       if (names.includes(V1_MARKER)) {
-        return { contract: "managed-v1", startWantsConversationMode };
+        return { contract: "managed-v1", capability: "managed", startWantsConversationMode };
       }
       return names.includes(V2_MARKER)
-        ? { contract: "managed-v2", startWantsConversationMode }
+        ? { contract: "managed-v2", capability: "managed", startWantsConversationMode }
         : NO_LIFECYCLE;
     });
     contracts.set(failureKey, pending);
@@ -181,9 +194,7 @@ export function lifecycleFor(ctx: RequestContext): Promise<Lifecycle> {
       if (!isAuthFailure(err)) probeFailures.set(failureKey, Date.now());
     });
   }
-  // Degrade for this call regardless: an unreachable catalog must not turn into
-  // a hard error on a request that might have succeeded without any context.
-  return pending.catch((): Lifecycle => NO_LIFECYCLE);
+  return pending.catch((): Lifecycle => UNKNOWN_LIFECYCLE);
 }
 
 /** Kept for callers that only care which contract a deploy speaks. */
@@ -211,10 +222,19 @@ function isAuthFailure(err: unknown): boolean {
   return err instanceof HttpError && (err.status === 401 || err.status === 403);
 }
 
-function toolNames(info: unknown): string[] {
+function toolNames(info: unknown): string[] | undefined {
   const tools = (info as { tools?: Array<{ name?: unknown }> } | undefined)?.tools;
-  if (!Array.isArray(tools)) return [];
+  if (!Array.isArray(tools)) return undefined;
   return tools.flatMap((tool) => (typeof tool?.name === "string" ? [tool.name] : []));
+}
+
+export async function requireKnownLifecycleCapability(ctx: RequestContext): Promise<void> {
+  if ((await lifecycleFor(ctx)).capability === "unknown") {
+    throw new ToolError(
+      "Context-loader lifecycle capability is unavailable; retry when the catalog can be read.",
+      "lifecycle_capability_unknown",
+    );
+  }
 }
 
 /**
@@ -498,16 +518,27 @@ function contextFor(
   };
 }
 
+function requestContextForManagedLifecycle(
+  ctx: RequestContext,
+  bknContext: BknContext | undefined,
+): RequestContext {
+  if (!bknContext || !ctx.trace?.interactionId || ctx.trace.conversationId) return ctx;
+  const { interactionId: _interactionId, ...trace } = ctx.trace;
+  return { ...ctx, trace };
+}
+
 /** Resolve a `bkn_context` for one call, or `undefined` when no managed contract exists. */
 export async function bknContextFor(
   ctx: RequestContext,
   knId: string,
   question: string,
+  requireKnownCapability = false,
 ): Promise<BknContext | undefined> {
-  if (ctx.trace?.interactionId && !ctx.trace.conversationId) {
-    throw new InputError("BKN interaction id requires a conversation id.");
-  }
   const lifecycle = await lifecycleFor(ctx);
+  if (lifecycle.capability === "unknown") {
+    if (requireKnownCapability) await requireKnownLifecycleCapability(ctx);
+    return undefined;
+  }
   const { contract } = lifecycle;
   if (contract === "none") return undefined;
 
@@ -550,11 +581,12 @@ export async function withManagedLifecycle<T>(
   ctx: RequestContext,
   knId: string,
   question: string,
-  send: (bknContext: BknContext | undefined) => Promise<T>,
+  send: (bknContext: BknContext | undefined, requestContext: RequestContext) => Promise<T>,
+  requireKnownCapability = false,
 ): Promise<T> {
-  const first = await bknContextFor(ctx, knId, question);
+  const first = await bknContextFor(ctx, knId, question, requireKnownCapability);
   try {
-    return await send(first);
+    return await send(first, requestContextForManagedLifecycle(ctx, first));
   } catch (err) {
     const code = serverErrorCode(err);
     // Only a session we opened is ours to reopen. A caller-supplied
@@ -562,9 +594,9 @@ export async function withManagedLifecycle<T>(
     // detach the evidence from the business conversation it was meant for.
     if (!first || callerOwnedSession(ctx) || !code || !STALE_SESSION_CODES.has(code)) throw err;
     sessions.delete(sessionKey(ctx, knId));
-    const reopened = await bknContextFor(ctx, knId, question);
+    const reopened = await bknContextFor(ctx, knId, question, requireKnownCapability);
     if (!reopened) throw err;
-    return await send(reopened);
+    return await send(reopened, requestContextForManagedLifecycle(ctx, reopened));
   }
 }
 

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -346,13 +346,13 @@ rewriting it with \`run-sql\` produces a number the platform will not agree with
       "--schema",
       "print the named tool's argument schema from the deploy instead of calling it",
     )
-    .option("--receipt", "return the validated operation receipt (requires --json)")
+    .option("--receipt", "return the validated operation receipt (requires --json or --compact)")
     .action(async (knId: string, name: string, opts, cmd: Command) => {
       if (opts.receipt && opts.schema) {
         throw new InputError("--receipt cannot be combined with --schema");
       }
-      if (opts.receipt && !cmd.optsWithGlobals().json) {
-        throw new InputError("--receipt requires --json");
+      if (opts.receipt && !cmd.optsWithGlobals().json && !cmd.optsWithGlobals().compact) {
+        throw new InputError("--receipt requires --json or --compact");
       }
       if (opts.schema) return printToolSchema(cmd, knId, name);
       if (opts.receipt) {

--- a/test/unit/context-command.test.ts
+++ b/test/unit/context-command.test.ts
@@ -29,7 +29,7 @@ function program(json = false): Command {
 afterEach(() => vi.restoreAllMocks());
 
 describe("openbkn context tool-call receipt output", () => {
-  it("rejects --receipt without --json before calling the deploy", async () => {
+  it("rejects --receipt without machine-readable output before calling the deploy", async () => {
     await expect(
       program().parseAsync([
         "node",
@@ -40,7 +40,7 @@ describe("openbkn context tool-call receipt output", () => {
         "search_schema",
         "--receipt",
       ]),
-    ).rejects.toThrow("--receipt requires --json");
+    ).rejects.toThrow("--receipt requires --json or --compact");
   });
 
   it("rejects --receipt with --schema", async () => {
@@ -117,10 +117,9 @@ describe("openbkn context tool-call receipt output", () => {
     });
     const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 
-    await program(true).parseAsync([
+    await program().parseAsync([
       "node",
       "openbkn",
-      "--json",
       "--compact",
       "context",
       "tool-call",

--- a/test/unit/context-loader.test.ts
+++ b/test/unit/context-loader.test.ts
@@ -11,6 +11,7 @@ import {
   getObjectTypes,
   getRelationTypes,
 } from "../../src/api/context-loader.js";
+import { resetLifecycleCaches } from "../../src/api/lifecycle.js";
 import type { RequestContext } from "../../src/types.js";
 import { formatError } from "../../src/utils/errors.js";
 
@@ -79,6 +80,7 @@ function toolCallHeaders(f: typeof fetch): Headers {
 
 // A fresh kn per test avoids the module-level session cache masking the initialize POST.
 afterEach(() => {
+  resetLifecycleCaches();
   vi.useRealTimers();
   vi.unstubAllGlobals();
 });
@@ -489,7 +491,7 @@ describe("managed MCP tool calls", () => {
     expect(rpcCalls(f)).toHaveLength(0);
   });
 
-  it("rejects an interaction-only Trace context before a caller context can bypass it", async () => {
+  it("allows a caller-owned context to complete an interaction-only Trace context", async () => {
     const f = mockMcp();
     await expect(
       callTool(
@@ -511,8 +513,12 @@ describe("managed MCP tool calls", () => {
           },
         },
       ),
-    ).rejects.toThrow("BKN interaction id requires a conversation id.");
-    expect(rpcCalls(f)).toHaveLength(0);
+    ).resolves.toEqual({ ok: true });
+    expect(toolCallBody(f).arguments.bkn_context).toEqual({
+      conversation_id: "conversation_supply_chain",
+      interaction_id: "interaction-only",
+    });
+    expect(toolCallHeaders(f).get("bkn-interaction-id")).toBe("interaction-only");
   });
 
   it("omits business trace headers when caller context is the only business source", async () => {
@@ -636,8 +642,10 @@ describe("managed MCP tool calls", () => {
     });
     vi.stubGlobal(
       "fetch",
-      vi.fn(
-        async () => new Response(body, { status: 200, headers: { "mcp-session-id": "error-s1" } }),
+      vi.fn(async (input: string | URL) =>
+        String(input).endsWith("/mcp/info")
+          ? new Response(JSON.stringify({ tools: [] }))
+          : new Response(body, { status: 200, headers: { "mcp-session-id": "error-s1" } }),
       ),
     );
 
@@ -666,9 +674,10 @@ describe("managed MCP tool calls", () => {
     });
     vi.stubGlobal(
       "fetch",
-      vi.fn(
-        async () =>
-          new Response(body, { status: 200, headers: { "mcp-session-id": "error-raw-s1" } }),
+      vi.fn(async (input: string | URL) =>
+        String(input).endsWith("/mcp/info")
+          ? new Response(JSON.stringify({ tools: [] }))
+          : new Response(body, { status: 200, headers: { "mcp-session-id": "error-raw-s1" } }),
       ),
     );
 
@@ -733,8 +742,10 @@ describe("managed MCP tool calls", () => {
     });
     vi.stubGlobal(
       "fetch",
-      vi.fn(
-        async () => new Response(body, { status: 200, headers: { "mcp-session-id": "error-s2" } }),
+      vi.fn(async (input: string | URL) =>
+        String(input).endsWith("/mcp/info")
+          ? new Response(JSON.stringify({ tools: [] }))
+          : new Response(body, { status: 200, headers: { "mcp-session-id": "error-s2" } }),
       ),
     );
 
@@ -759,17 +770,45 @@ describe("managed MCP tool calls", () => {
     });
     vi.stubGlobal(
       "fetch",
-      vi.fn(
-        async () =>
-          new Response(body, { status: 200, headers: { "mcp-session-id": "missing-receipt-s1" } }),
+      vi.fn(async (input: string | URL) =>
+        String(input).endsWith("/mcp/info")
+          ? new Response(JSON.stringify({ tools: [] }))
+          : new Response(body, {
+              status: 200,
+              headers: { "mcp-session-id": "missing-receipt-s1" },
+            }),
       ),
     );
 
-    await expect(
-      callManagedTool(ctx, "kn-managed", "search_schema", {
-        query: "6月份需求预测",
-      }),
-    ).rejects.toThrow("Context-loader managed tool response did not include bkn_receipt");
+    const error = await callManagedTool(ctx, "kn-managed", "search_schema", {
+      query: "6月份需求预测",
+    }).catch((reason) => reason);
+    expect(error).toMatchObject({ code: "receipt_missing" });
+    expect(formatError(error)).toContain("did not include bkn_receipt");
+  });
+
+  it("reports malformed receipts with a stable code", async () => {
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { structuredContent: { bkn_receipt: { receipt_id: "missing-required-fields" } } },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(body, { status: 200, headers: { "mcp-session-id": "invalid-receipt-s1" } }),
+      ),
+    );
+
+    const error = await callManagedTool(ctx, "kn-invalid-receipt", "search_schema", {
+      query: "forecast",
+      bkn_context: {
+        conversation_id: "conversation_supply_chain",
+        interaction_id: "interaction_june_forecast",
+      },
+    }).catch((reason) => reason);
+    expect(error).toMatchObject({ code: "receipt_invalid" });
   });
 
   it("returns the business value together with the trusted operation receipt", async () => {

--- a/test/unit/context-loader.test.ts
+++ b/test/unit/context-loader.test.ts
@@ -491,7 +491,7 @@ describe("managed MCP tool calls", () => {
     expect(rpcCalls(f)).toHaveLength(0);
   });
 
-  it("allows a caller-owned context to complete an interaction-only Trace context", async () => {
+  it("does not forward an orphan interaction header beside a caller-owned context", async () => {
     const f = mockMcp();
     await expect(
       callTool(
@@ -518,7 +518,7 @@ describe("managed MCP tool calls", () => {
       conversation_id: "conversation_supply_chain",
       interaction_id: "interaction-only",
     });
-    expect(toolCallHeaders(f).get("bkn-interaction-id")).toBe("interaction-only");
+    expect(toolCallHeaders(f).get("bkn-interaction-id")).toBeNull();
   });
 
   it("omits business trace headers when caller context is the only business source", async () => {

--- a/test/unit/help-contract.test.ts
+++ b/test/unit/help-contract.test.ts
@@ -71,6 +71,6 @@ describe("command tree", () => {
     const toolCall = context?.commands.find((command) => command.name() === "tool-call");
     const help = toolCall?.helpInformation() ?? "";
     expect(help).toContain("--receipt");
-    expect(help).toContain("requires --json");
+    expect(help).toContain("requires --json or --compact");
   });
 });

--- a/test/unit/lifecycle.test.ts
+++ b/test/unit/lifecycle.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See the LICENSE file in the project root.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { callTool, searchSchema } from "../../src/api/context-loader.js";
+import { callManagedTool, callTool, searchSchema } from "../../src/api/context-loader.js";
 import { searchInstance } from "../../src/api/knowledge-networks.js";
 import { releaseLifecycleSessions, resetLifecycleCaches } from "../../src/api/lifecycle.js";
 import type { RequestContext } from "../../src/types.js";
@@ -46,6 +46,7 @@ function freshCtx(extra: Partial<RequestContext> = {}): RequestContext {
 
 interface MockOptions {
   catalog?: unknown;
+  infoStatus?: number;
   /** Server replies for the retrieval POST, in order; a string body means an error. */
   retrieval?: Array<{ status: number; body: unknown }>;
   /** Tool name → error code the deploy answers with on its first call only. */
@@ -77,7 +78,7 @@ function mockDeploy(opts: MockOptions = {}): Recorded {
 
       if (url.endsWith("/mcp/info")) {
         recorded.infoCount += 1;
-        return new Response(JSON.stringify(catalog), { status: 200 });
+        return new Response(JSON.stringify(catalog), { status: opts.infoStatus ?? 200 });
       }
 
       if (url.endsWith("/v1/mcp")) {
@@ -198,24 +199,50 @@ describe("managed lifecycle on semantic search", () => {
     expect(recorded.infoCount).toBe(2);
   });
 
-  it("rejects an interaction id that has no conversation before sending MCP", async () => {
+  it("keeps an interaction-only trace on the automatic handshake path", async () => {
     const recorded = mockDeploy({ catalog: V2_CATALOG });
+    await searchInstance(
+      freshCtx({
+        trace: {
+          requestId: "req-interaction-only",
+          traceparent: "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
+          interactionId: "int-orphan",
+        },
+      }),
+      "kn-interaction-only",
+      "物料",
+    );
+
+    expect(recorded.toolCalls.map((call) => call.name)).toEqual(["bkn_start_interaction"]);
+    expect(recorded.retrievalBodies).toHaveLength(1);
+    const headers = new Headers(
+      (fetch as unknown as { mock: { calls: Array<[string, RequestInit]> } }).mock.calls.find(
+        ([url, init]) => String(url).includes("/kn/search_instance") && init.method === "POST",
+      )?.[1]?.headers,
+    );
+    expect(headers.get("bkn-interaction-id")).toBeNull();
+    expect(recorded.retrievalBodies[0]?.bkn_context).toEqual({
+      conversation_id: "conv_1",
+      interaction_id: "int_1",
+    });
+  });
+
+  it("rejects receipt-required calls before a business request when catalog capability is unknown", async () => {
+    const recorded = mockDeploy({ catalog: { unexpected: "shape" } });
+
     await expect(
-      searchInstance(
-        freshCtx({
-          trace: {
-            requestId: "req-interaction-only",
-            traceparent: "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
-            interactionId: "int-orphan",
-          },
-        }),
-        "kn-interaction-only",
-        "物料",
-      ),
-    ).rejects.toThrow("BKN interaction id requires a conversation id.");
-    expect(recorded.infoCount).toBe(0);
+      callManagedTool(freshCtx(), "kn-unknown-capability", "search_schema", { query: "物料" }),
+    ).rejects.toMatchObject({ code: "lifecycle_capability_unknown" });
     expect(recorded.toolCalls).toHaveLength(0);
-    expect(recorded.retrievalBodies).toHaveLength(0);
+  });
+
+  it("rejects receipt-required calls before a business request when catalog lookup fails", async () => {
+    const recorded = mockDeploy({ infoStatus: 503 });
+
+    await expect(
+      callManagedTool(freshCtx(), "kn-unavailable-capability", "search_schema", { query: "物料" }),
+    ).rejects.toMatchObject({ code: "lifecycle_capability_unknown" });
+    expect(recorded.toolCalls).toHaveLength(0);
   });
 
   it("omits bkn_context on a deploy without the lifecycle tools", async () => {
@@ -225,6 +252,15 @@ describe("managed lifecycle on semantic search", () => {
     expect(recorded.toolCalls).toHaveLength(0);
     expect(recorded.retrievalBodies[0]).not.toHaveProperty("bkn_context");
     expect(recorded.retrievalBodies[0]?.query).toBe("物料");
+  });
+
+  it("lets an unsupported deploy run a receipt-requested business tool once", async () => {
+    const recorded = mockDeploy({ catalog: LEGACY_CATALOG });
+
+    await expect(
+      callManagedTool(freshCtx(), "kn-legacy-receipt", "search_schema", { query: "物料" }),
+    ).rejects.toMatchObject({ code: "receipt_missing" });
+    expect(recorded.toolCalls.map((call) => call.name)).toEqual(["search_schema"]);
   });
 
   it("omits bkn_context when the catalog probe fails", async () => {

--- a/test/unit/lifecycle.test.ts
+++ b/test/unit/lifecycle.test.ts
@@ -785,6 +785,34 @@ describe("managed lifecycle on semantic search", () => {
     expect(recorded.retrievalBodies[0]?.bkn_context).toEqual(owned);
   });
 
+  it("does not forward an orphan interaction header beside a caller-built REST context", async () => {
+    const recorded = mockDeploy({ catalog: V2_CATALOG });
+    const owned = {
+      conversation_id: "conv_owned",
+      interaction_id: "int_owned",
+      operation_key: "op:pre-registered",
+    };
+    await searchInstance(
+      freshCtx({
+        trace: {
+          requestId: "req-interaction-only",
+          traceparent: "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
+          interactionId: "int_owned",
+        },
+      }),
+      "kn-managed",
+      "物料",
+      { bknContext: owned },
+    );
+
+    const calls = (fetch as unknown as { mock: { calls: Array<[string, RequestInit]> } }).mock
+      .calls;
+    const retrieval = calls.find(([url]) => String(url).includes("/kn/search_instance"));
+    expect(new Headers(retrieval?.[1].headers).get("bkn-interaction-id")).toBeNull();
+    expect(recorded.retrievalBodies[0]?.bkn_context).toEqual(owned);
+    expect(recorded.toolCalls).toHaveLength(0);
+  });
+
   it("reopens the session once when the interaction has died, then retries", async () => {
     const recorded = mockDeploy({
       retrieval: [

--- a/test/unit/lifecycle.test.ts
+++ b/test/unit/lifecycle.test.ts
@@ -245,6 +245,35 @@ describe("managed lifecycle on semantic search", () => {
     expect(recorded.toolCalls).toHaveLength(0);
   });
 
+  it("preserves catalog authentication failures for receipt-required calls", async () => {
+    const recorded = mockDeploy({ infoStatus: 401 });
+
+    await expect(
+      callManagedTool(freshCtx(), "kn-auth-required", "search_schema", { query: "物料" }),
+    ).rejects.toMatchObject({ status: 401 });
+    expect(recorded.toolCalls).toHaveLength(0);
+  });
+
+  it("retries a malformed catalog probe after the failure window", async () => {
+    const recorded = mockDeploy({ catalog: { unexpected: "shape" } });
+    const ctx = freshCtx();
+
+    await expect(
+      callManagedTool(ctx, "kn-malformed-catalog", "search_schema", { query: "物料" }),
+    ).rejects.toMatchObject({ code: "lifecycle_capability_unknown" });
+    await expect(
+      callManagedTool(ctx, "kn-malformed-catalog", "search_schema", { query: "物料" }),
+    ).rejects.toMatchObject({ code: "lifecycle_capability_unknown" });
+    expect(recorded.infoCount).toBe(1);
+
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(30_001);
+    await expect(
+      callManagedTool(ctx, "kn-malformed-catalog", "search_schema", { query: "物料" }),
+    ).rejects.toMatchObject({ code: "lifecycle_capability_unknown" });
+    expect(recorded.infoCount).toBe(2);
+  });
+
   it("omits bkn_context on a deploy without the lifecycle tools", async () => {
     const recorded = mockDeploy({ catalog: LEGACY_CATALOG });
     await searchInstance(freshCtx(), "kn-legacy", "物料");


### PR DESCRIPTION
# Pull Request

## What Changed

- Preserved legacy interaction-only trace input while preventing a conflicting interaction header after automatic lifecycle creation.
- Allowed `--receipt` with compact output and documented its machine-readable contract.
- Added managed/unsupported/unknown capability handling and stable receipt error codes.
- Updated ContextLoader, lifecycle, HTTP retrieval, CLI, documentation, and focused unit coverage.

## Why

- Related Issue: Closes #93
- Related Feature: #68
- Background: compatibility follow-up after design #87 and implementation #89.

## How

- Keep the three lifecycle capability states internal; receipt-required calls fail before the business request only when capability is unknown.
- Pass a lifecycle-reconciled request context to the MCP and HTTP business paths.
- Retain the established behavior for ordinary tool calls and fully caller-owned `bkn_context`.

Breaking changes: none. No public type, wire schema, API field, server configuration, or migration is introduced.

## Testing

- [x] Unit tests passed locally: 618 passed, 1 skipped (existing live Claude rubric test).
- [x] Static checks passed locally: dependency check, Biome, and TypeScript.
- [ ] Integration tests passed locally: not applicable; this change is covered with mocked SDK unit tests.
- [ ] Verified in test environment: pending CI / reviewer validation.

## Risk & Rollback

- Risk: an explicitly unsupported deployment can execute the business call once without a receipt; the documented `receipt_missing` result must not be retried solely for receipt creation.
- Rollback: revert this single commit. No data migration or server-side rollback is needed.

## Additional Notes

This is a focused compatibility correction rather than a reopening of the merged #68 or #88 work.