### PR TITLE
feat(sdk): enforce platform version compatibility

### DIFF
--- a/docs/exec-plans/completed/2026-09-03-server-version-check.md
+++ b/docs/exec-plans/completed/2026-09-03-server-version-check.md
@@ -1,0 +1,13 @@
+# Server version check implementation plan
+
+1. Add version-check state to the request context and a focused compatibility
+   module that reads `/api/bkn-backend/v1/health`, normalizes SemVer, and reports actionable
+   failures.
+2. Add a per-platform 60-second CLI cache to the existing local config store;
+   construct CLI clients in that mode while library clients stay memory-only.
+3. Gate shared typed requests and raw calls before their business request while
+   preserving version-endpoint recursion exemption and dry-run zero-network behavior.
+4. Add unit tests for matching, prerelease normalization, mismatch blocking,
+   missing version failure, one-check client cache, CLI TTL cache, and dry run.
+5. Run formatting, focused tests, lint, and the full unit suite; move this plan
+   to `completed/` only after verification.

--- a/docs/superpowers/specs/2026-09-03-server-version-check-design.md
+++ b/docs/superpowers/specs/2026-09-03-server-version-check-design.md
@@ -1,0 +1,50 @@
+# Server version check design
+
+## Goal
+
+On an unstable `0.x` platform, do not send SDK business requests to a platform
+whose release version differs from the SDK's `major.minor.patch` version.
+
+## Source of truth
+
+The BKN backend's public `GET /api/bkn-backend/v1/health` endpoint exposes `ServerVersion`. The
+current release process gives every service the same version, so the SDK treats
+that value as the platform version. This is deliberately separate from any
+future independent service-version scheme.
+
+## Compatibility rule
+
+Both values must be valid SemVer strings (an optional leading `v` is accepted).
+Prerelease and build metadata are ignored, then `major.minor.patch` must match
+exactly. Thus SDK `0.1.5-rc.1` is compatible with server `0.1.5`; SDK `0.1.4`
+is not compatible with server `0.1.5`.
+
+## Request behavior
+
+`createClient()` remains synchronous and has no network side effects. The
+shared HTTP request layer performs a lazy preflight before the first business
+request. The check calls `GET <baseUrl>/api/bkn-backend/v1/health`, parses `ServerVersion`, and
+only then sends the requested API call. The health request itself is exempt to
+avoid recursion. Absolute URLs are supported only when they have the same origin
+as `baseUrl`; a request cannot apply one platform's successful check or credentials
+to another platform.
+
+A programmatic client stores its successful check in memory for its lifetime.
+The CLI persists a successful result per normalized base URL for 60 seconds so
+separate command processes do not repeatedly probe health. Failed checks are
+never cached. Dry runs make no health request because they must not send any
+network traffic.
+
+## Failures
+
+A mismatched, missing, invalid, or unreachable server version blocks the
+business request. Errors state the SDK version, server version when known, and
+the action to take. The behavior is intentionally fail-closed for `0.x`.
+
+## Scope and boundaries
+
+The check lives in the API layer, not individual commands or resources. Raw
+`call()` follows the same rule, except for the version endpoint itself and with
+the same-origin restriction for absolute URLs. CLI-only persistent
+caching stays in the config store; library callers receive no filesystem side
+effects.

--- a/src/api/bkn-backend.ts
+++ b/src/api/bkn-backend.ts
@@ -12,6 +12,7 @@ import { authFetch } from "./auth-fetch.js";
 import { buildHeaders } from "./headers.js";
 import { request } from "./http.js";
 import { tlsFetch } from "./tls.js";
+import { ensureCompatible } from "./version-check.js";
 
 const BASE = "/api/bkn-backend/v1/knowledge-networks";
 const BKNS = "/api/bkn-backend/v1/bkns";
@@ -32,6 +33,7 @@ export async function uploadBkn(
 ): Promise<unknown> {
   const url = new URL(`${ctx.baseUrl}${BKNS}`);
   url.searchParams.set("branch", opts.branch ?? "main");
+  await ensureCompatible(ctx, url);
   const form = new FormData();
   form.append(
     "file",
@@ -58,6 +60,7 @@ export async function downloadBkn(
 ): Promise<Buffer> {
   const url = new URL(`${ctx.baseUrl}${BKNS}/${encodeURIComponent(knId)}`);
   url.searchParams.set("branch", opts.branch ?? "main");
+  await ensureCompatible(ctx, url);
   const res = await authFetch(ctx, () =>
     tlsFetch(ctx.insecure, url, { method: "GET", headers: buildHeaders(ctx) }),
   );

--- a/src/api/call.ts
+++ b/src/api/call.ts
@@ -11,6 +11,7 @@ import type { RequestContext } from "../types.js";
 import { authFetch } from "./auth-fetch.js";
 import { buildHeaders } from "./headers.js";
 import { tlsFetch } from "./tls.js";
+import { ensureCompatible } from "./version-check.js";
 
 export interface RawCallOptions {
   method?: string;
@@ -57,6 +58,7 @@ export async function rawCall(
   opts: RawCallOptions = {},
 ): Promise<RawCallResult> {
   const url = resolveUrl(ctx, path);
+  await ensureCompatible(ctx, new URL(url));
   const extra: Record<string, string> = {};
   for (const h of opts.header ?? []) {
     const parsed = parseHeader(h);

--- a/src/api/context-loader.ts
+++ b/src/api/context-loader.ts
@@ -23,6 +23,7 @@ import {
 } from "./lifecycle.js";
 import { tlsFetch } from "./tls.js";
 import type { OperationReceipt } from "./trace-lifecycle.js";
+import { ensureCompatible, inheritVersionCheck } from "./version-check.js";
 
 const MCP_PATH = "/api/agent-retrieval/v1/mcp";
 const PROTOCOL = "2024-11-05";
@@ -48,7 +49,9 @@ function transportSessionKey(ctx: RequestContext, knId: string): string {
 }
 
 function operationContext(ctx: RequestContext): RequestContext {
-  return ctx.trace ? { ...ctx, trace: createOperationTraceContext(ctx.trace) } : ctx;
+  return ctx.trace
+    ? inheritVersionCheck(ctx, { ...ctx, trace: createOperationTraceContext(ctx.trace) })
+    : ctx;
 }
 
 /**
@@ -93,6 +96,7 @@ async function post(
   body: unknown,
   timeoutMs?: number,
 ) {
+  await ensureCompatible(ctx, new URL(mcpUrl(ctx)));
   // Unbounded by default: a tool call can legitimately run long, and this
   // transport has never imposed a deadline. Callers that run somewhere a hang
   // would strand the process — a release on the way out — pass one in.

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -11,6 +11,7 @@ import { HttpError, NonJsonResponseError } from "../utils/errors.js";
 import { stringifyBigIntJSON } from "../utils/json-bigint.js";
 import { buildHeaders } from "./headers.js";
 import { tlsFetch } from "./tls.js";
+import { ensureCompatible } from "./version-check.js";
 
 export interface RequestInitEx {
   method?: string;
@@ -49,6 +50,8 @@ export async function request<T = unknown>(
       url.searchParams.set(k, String(v));
     }
   }
+
+  await ensureCompatible(ctx, url);
 
   const hasBody = init.body !== undefined;
   const controller = new AbortController();

--- a/src/api/lifecycle.ts
+++ b/src/api/lifecycle.ts
@@ -35,6 +35,7 @@ import { createHash, randomUUID } from "node:crypto";
 import type { RequestContext } from "../types.js";
 import { HttpError, ToolError } from "../utils/errors.js";
 import { callToolRaw, mcpInfo } from "./context-loader.js";
+import { inheritVersionCheck } from "./version-check.js";
 
 /** The body field the lifecycle middleware reads. Snake_case: it goes on the wire. */
 export interface BknContext {
@@ -483,7 +484,7 @@ function ensureSession(
     ? openSession(ctx, knId, lifecycle, question).catch((err: unknown) => {
         if (!refusesThisConversation(err)) throw err;
         const { rememberedConversationId: _dropped, ...fresh } = ctx;
-        return openSession(fresh, knId, lifecycle, question);
+        return openSession(inheritVersionCheck(ctx, fresh), knId, lifecycle, question);
       })
     : openSession(ctx, knId, lifecycle, question);
   // Report only a conversation this call minted. One the caller named is
@@ -550,7 +551,7 @@ export function requestContextForBusinessContext(
 ): RequestContext {
   if (!bknContext || !ctx.trace?.interactionId || ctx.trace.conversationId) return ctx;
   const { interactionId: _interactionId, ...trace } = ctx.trace;
-  return { ...ctx, trace };
+  return inheritVersionCheck(ctx, { ...ctx, trace });
 }
 
 /** Resolve a `bkn_context` for one call, or `undefined` when no managed contract exists. */

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -12,6 +12,7 @@ import { authFetch } from "./auth-fetch.js";
 import { buildHeaders } from "./headers.js";
 import { request } from "./http.js";
 import { tlsFetch } from "./tls.js";
+import { ensureCompatible } from "./version-check.js";
 
 const MANAGER = "/api/mf-model-manager/v1";
 const API = "/api/mf-model-api/v1";
@@ -181,6 +182,7 @@ export async function chatCompletionsStream(
   messages: ChatMessage[],
   onDelta: (text: string) => void,
 ): Promise<string> {
+  await ensureCompatible(ctx, new URL(`${ctx.baseUrl}${API}/chat/completions`));
   const res = await authFetch(ctx, () =>
     tlsFetch(ctx.insecure, `${ctx.baseUrl}${API}/chat/completions`, {
       method: "POST",

--- a/src/api/skills.ts
+++ b/src/api/skills.ts
@@ -13,6 +13,7 @@ import { buildHeaders } from "./headers.js";
 import { request } from "./http.js";
 import { sandboxBudgetMs } from "./sandbox-budget.js";
 import { tlsFetch } from "./tls.js";
+import { ensureCompatible } from "./version-check.js";
 
 const BASE = "/api/agent-operator-integration/v1";
 
@@ -22,6 +23,7 @@ export async function registerSkillZip(
   bytes: Uint8Array,
   opts: { filename?: string; source?: string; extendInfo?: unknown } = {},
 ): Promise<unknown> {
+  await ensureCompatible(ctx, new URL(`${ctx.baseUrl}${BASE}/skills`));
   const form = new FormData();
   form.set("file_type", "zip");
   form.set("file", new Blob([bytes]), opts.filename ?? "skill.zip");
@@ -46,6 +48,10 @@ export async function updateSkillPackageZip(
   bytes: Uint8Array,
   filename = "skill.zip",
 ): Promise<unknown> {
+  await ensureCompatible(
+    ctx,
+    new URL(`${ctx.baseUrl}${BASE}/skills/${encodeURIComponent(skillId)}/package`),
+  );
   const form = new FormData();
   form.set("file_type", "zip");
   form.set("file", new Blob([bytes]), filename);
@@ -82,6 +88,7 @@ export async function downloadSkill(
   skillId: string,
   view: SkillView = "published",
 ): Promise<Uint8Array> {
+  await ensureCompatible(ctx, new URL(`${ctx.baseUrl}${skillPath(skillId, view, "download")}`));
   const res = await authFetch(ctx, () =>
     tlsFetch(ctx.insecure, `${ctx.baseUrl}${skillPath(skillId, view, "download")}`, {
       headers: buildHeaders(ctx),

--- a/src/api/toolboxes.ts
+++ b/src/api/toolboxes.ts
@@ -15,6 +15,7 @@ import { type FunctionDefinition, functionInputBody } from "./functions.js";
 import { buildHeaders } from "./headers.js";
 import { request } from "./http.js";
 import { tlsFetch } from "./tls.js";
+import { ensureCompatible } from "./version-check.js";
 
 const PATH = "/api/agent-operator-integration/v1/tool-box";
 
@@ -27,6 +28,10 @@ export async function exportConfig(
   id: string,
   type: ImpexType = "toolbox",
 ): Promise<Uint8Array> {
+  await ensureCompatible(
+    ctx,
+    new URL(`${ctx.baseUrl}${IMPEX}/export/${encodeURIComponent(type)}/${encodeURIComponent(id)}`),
+  );
   const res = await authFetch(ctx, () =>
     tlsFetch(
       ctx.insecure,
@@ -48,6 +53,7 @@ export async function importConfig(
   type: ImpexType = "toolbox",
 ): Promise<unknown> {
   const buf = await readFile(filePath);
+  await ensureCompatible(ctx, new URL(`${ctx.baseUrl}${IMPEX}/import/${encodeURIComponent(type)}`));
   const form = new FormData();
   form.append("data", new Blob([new Uint8Array(buf)]), basename(filePath));
   const res = await authFetch(ctx, () =>
@@ -77,6 +83,7 @@ export async function uploadTool(
   metadataType = "openapi",
 ): Promise<unknown> {
   const buf = await readFile(filePath);
+  await ensureCompatible(ctx, new URL(`${ctx.baseUrl}${PATH}/${encodeURIComponent(boxId)}/tool`));
   const form = new FormData();
   form.append("metadata_type", metadataType);
   form.append("data", new Blob([new Uint8Array(buf)]), basename(filePath));

--- a/src/api/version-check.ts
+++ b/src/api/version-check.ts
@@ -1,0 +1,188 @@
+// Copyright (c) 2026 OpenBKN. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the project root.
+
+/** Platform-version preflight shared by typed requests and the raw call escape hatch. */
+import pkg from "../../package.json" with { type: "json" };
+import { readVersionCheckCache, writeVersionCheckCache } from "../config/store.js";
+import type { RequestContext } from "../types.js";
+import { isDryRun } from "../utils/dry-run.js";
+import { tlsFetch } from "./tls.js";
+
+const VERSION_PATH = "/api/bkn-backend/v1/health";
+const CLI_CACHE_TTL_MS = 60_000;
+const HEALTH_TIMEOUT_MS = 5_000;
+
+type VersionCheckMode = "memory" | "cli";
+
+interface VersionCheckState {
+  mode: VersionCheckMode;
+  verified?: true;
+  verifying?: Promise<void>;
+}
+
+// Keep verification state out of the public RequestContext contract. A caller
+// that uses the low-level public APIs must not be able to forge `verified`.
+const states = new WeakMap<RequestContext, VersionCheckState>();
+
+/** Register the request mode while constructing an SDK or CLI context. */
+export function configureVersionCheck(ctx: RequestContext, mode: VersionCheckMode): void {
+  states.set(ctx, { mode });
+}
+
+/** Preserve one client's private state when an internal helper derives a context. */
+export function inheritVersionCheck(from: RequestContext, to: RequestContext): RequestContext {
+  const state = states.get(from);
+  if (state) states.set(to, state);
+  return to;
+}
+
+/** Test-only hook for unit tests that isolate an API's business wire contract. */
+export function markVersionCompatibleForTest(ctx: RequestContext): void {
+  stateFor(ctx).verified = true;
+}
+
+/** Thrown before a business request when an unstable-platform version cannot be trusted. */
+export class VersionCompatibilityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "VersionCompatibilityError";
+  }
+}
+
+/** Ensure the target platform matches this SDK's base SemVer version. */
+export async function ensureCompatible(ctx: RequestContext, target: URL): Promise<void> {
+  // Credentials and compatibility state belong to one configured platform.  A
+  // raw absolute URL must not use this platform's successful check to reach a
+  // different server.
+  if (target.origin !== new URL(ctx.baseUrl).origin) {
+    throw new VersionCompatibilityError(
+      `Cannot send a request to ${target.origin}: it differs from the configured platform ${new URL(ctx.baseUrl).origin}.`,
+    );
+  }
+
+  // Low-level public APIs also accept manually constructed contexts. Their
+  // first request uses the default in-memory mode.
+  const state = stateFor(ctx);
+  if (state.verified || isDryRun() || isVersionUrl(target)) return;
+  if (state.verifying) return state.verifying;
+
+  const checking = checkCompatibility(ctx);
+  state.verifying = checking;
+  try {
+    await checking;
+    state.verified = true;
+  } finally {
+    if (state.verifying === checking) state.verifying = undefined;
+  }
+}
+
+function isVersionUrl(url: URL): boolean {
+  return url.pathname.replace(/\/+$/, "") === VERSION_PATH;
+}
+
+async function checkCompatibility(ctx: RequestContext): Promise<void> {
+  const sdkVersion = baseVersion(pkg.version);
+  if (!sdkVersion) {
+    throw new VersionCompatibilityError(`SDK version '${pkg.version}' is not valid SemVer.`);
+  }
+
+  if (stateFor(ctx).mode === "cli") {
+    const cached = readVersionCheckCache(ctx.baseUrl);
+    if (cached && isFresh(cached.checkedAt) && compatible(sdkVersion, cached.serverVersion)) return;
+  }
+
+  const serverVersion = await readServerVersion(ctx);
+  if (!compatible(sdkVersion, serverVersion)) {
+    throw new VersionCompatibilityError(
+      `SDK version ${pkg.version} is incompatible with platform version ${serverVersion}. ` +
+        `Install SDK ${serverVersion}, or connect to a platform running version ${sdkVersion}.`,
+    );
+  }
+
+  if (stateFor(ctx).mode === "cli") {
+    // The cache only saves one health request on a later CLI invocation. A
+    // read-only config directory must not prevent an otherwise valid request.
+    try {
+      writeVersionCheckCache(ctx.baseUrl, { serverVersion, checkedAt: new Date().toISOString() });
+    } catch {
+      // Best-effort cache persistence.
+    }
+  }
+}
+
+function stateFor(ctx: RequestContext): VersionCheckState {
+  let state = states.get(ctx);
+  if (!state) {
+    state = { mode: "memory" };
+    states.set(ctx, state);
+  }
+  return state;
+}
+
+function isFresh(checkedAt: string): boolean {
+  const checked = Date.parse(checkedAt);
+  return (
+    Number.isFinite(checked) && checked <= Date.now() && Date.now() - checked < CLI_CACHE_TTL_MS
+  );
+}
+
+async function readServerVersion(ctx: RequestContext): Promise<string> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), HEALTH_TIMEOUT_MS);
+  try {
+    const response = await tlsFetch(ctx.insecure, `${ctx.baseUrl}${VERSION_PATH}`, {
+      method: "GET",
+      signal: controller.signal,
+    });
+    const body = await response.text();
+    if (!response.ok) {
+      throw new VersionCompatibilityError(
+        `Cannot verify platform version: GET ${VERSION_PATH} returned HTTP ${response.status}. The request was not sent.`,
+      );
+    }
+    let payload: unknown;
+    try {
+      payload = JSON.parse(body);
+    } catch {
+      throw new VersionCompatibilityError(
+        `Cannot verify platform version: GET ${VERSION_PATH} did not return JSON. The request was not sent.`,
+      );
+    }
+    const version = serverVersionOf(payload);
+    if (!version || !baseVersion(version)) {
+      throw new VersionCompatibilityError(
+        `Cannot verify platform version: GET ${VERSION_PATH} did not return a valid ServerVersion. The request was not sent.`,
+      );
+    }
+    return version;
+  } catch (error) {
+    if (error instanceof VersionCompatibilityError) throw error;
+    throw new VersionCompatibilityError(
+      `Cannot verify platform version from GET ${VERSION_PATH}: ${error instanceof Error ? error.message : "request failed"}. The request was not sent.`,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function serverVersionOf(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== "object") return undefined;
+  const outer = payload as Record<string, unknown>;
+  const nested =
+    outer.data && typeof outer.data === "object" ? (outer.data as Record<string, unknown>) : outer;
+  const version = nested.ServerVersion ?? nested.serverVersion;
+  return typeof version === "string" ? version : undefined;
+}
+
+function compatible(sdkBaseVersion: string, serverVersion: string): boolean {
+  return sdkBaseVersion === baseVersion(serverVersion);
+}
+
+/** Strip prerelease/build metadata; `0.x` compatibility remains exact at patch level. */
+export function baseVersion(version: string): string | undefined {
+  const match =
+    /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.exec(
+      version,
+    );
+  return match ? `${match[1]}.${match[2]}.${match[3]}` : undefined;
+}

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -92,6 +92,7 @@ export function clientFrom(cmd: Command): BknClient {
     token: o.token,
     user: o.user,
     insecure: o.insecure,
+    versionCheckMode: "cli",
     ...(trace ? { trace } : {}),
     ...(remembered.source === "stored" && remembered.id
       ? { rememberedConversationId: remembered.id }

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -642,6 +642,7 @@ export function adminCommand(): Command {
           token: g.token,
           user: g.user,
           insecure: g.insecure,
+          versionCheckMode: "cli",
         }),
         url,
         { method: opts.request, header: opts.header, data: opts.data },

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -300,6 +300,7 @@ export function registerAuthLeaves(cmd: Command): void {
         token: g.token,
         user: g.user,
         insecure: g.insecure,
+        versionCheckMode: "cli",
       });
       const account = opts.account ?? (await promptLine("Account: "));
       const oldPassword = opts.oldPassword ?? (await promptLine("Current password: ", true));

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -20,7 +20,7 @@ export function callCommand(): Command {
   const cmd = new Command("call")
     .alias("curl")
     .description("Call any platform API endpoint directly (auth added)")
-    .argument("<url>", "API path (e.g. /api/...) or absolute URL")
+    .argument("<url>", "API path (e.g. /api/...) or absolute URL on the current platform")
     .option("-X, --request <method>", "HTTP method")
     .option("-H, --header <header>", 'extra header "Name: value" (repeatable)', collect, [])
     .option("-d, --data <body>", "request body (sets JSON content-type if unset)")
@@ -40,6 +40,7 @@ export function callCommand(): Command {
         token: g.token,
         user: g.user,
         insecure: g.insecure,
+        versionCheckMode: "cli",
         ...(trace ? { trace } : {}),
       });
       const res = await rawCall(ctx, url, {

--- a/src/config/resolve.ts
+++ b/src/config/resolve.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 OpenBKN. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See the LICENSE file in the project root.
 
+import { configureVersionCheck } from "../api/version-check.js";
 import { createTraceContext } from "../trace-context.js";
 import type { ClientOptions, RequestContext } from "../types.js";
 import { trimTrailingSlashes } from "../utils/base-url.js";
@@ -72,7 +73,7 @@ export function resolveContext(opts: ClientOptions = {}): RequestContext {
         }
       : undefined;
 
-  return {
+  const ctx: RequestContext = {
     baseUrl: normalized,
     token,
     insecure,
@@ -92,4 +93,6 @@ export function resolveContext(opts: ClientOptions = {}): RequestContext {
       : {}),
     ...(opts.onConversationOpened ? { onConversationOpened: opts.onConversationOpened } : {}),
   };
+  configureVersionCheck(ctx, opts.versionCheckMode ?? "memory");
+  return ctx;
 }

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -8,6 +8,7 @@
  * legacy layout — reimplemented slim, no legacy-migration paths:
  *
  *   <root>/state.json                      (or profiles/<BKN_PROFILE>/state.json)
+ *   <root>/platforms/<base64url(baseUrl)>/version-check.json
  *   <root>/platforms/<base64url(baseUrl)>/users/<userId>/token.json
  *   <root>/platforms/<base64url(baseUrl)>/users/<userId>/config.json
  *
@@ -62,6 +63,12 @@ export interface PlatformConfig {
   conversationId?: string;
   /** When it was opened, so `openbkn context conversation` can report its age. */
   conversationOpenedAt?: string;
+}
+
+/** Non-sensitive, platform-scoped CLI version-check cache. */
+export interface VersionCheckCache {
+  serverVersion: string;
+  checkedAt: string;
 }
 
 interface StoreState {
@@ -209,6 +216,23 @@ export function readPlatformConfig(
       ? { conversationOpenedAt: stored.conversationOpenedAt }
       : {}),
   };
+}
+
+function isVersionCheck(value: unknown): value is VersionCheckCache {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.serverVersion === "string" && typeof candidate.checkedAt === "string";
+}
+
+/** Read the shared (not identity-scoped) CLI platform-version cache. */
+export function readVersionCheckCache(baseUrl: string): VersionCheckCache | undefined {
+  const cached = readJson<unknown>(join(platformDir(baseUrl), "version-check.json"));
+  return isVersionCheck(cached) ? cached : undefined;
+}
+
+/** Persist a successful CLI platform-version check without storing credentials. */
+export function writeVersionCheckCache(baseUrl: string, cache: VersionCheckCache): void {
+  writeJson(join(platformDir(baseUrl), "version-check.json"), cache);
 }
 
 export function writePlatformConfig(baseUrl: string, config: PlatformConfig): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,8 @@ export interface ClientOptions {
    * nothing written to disk.
    */
   onConversationOpened?: (conversationId: string) => void;
+  /** @internal CLI clients persist successful version checks for a short TTL. */
+  versionCheckMode?: "memory" | "cli";
 }
 
 /** Fully resolved request context — every field is known. */

--- a/test/setup/verified-context.ts
+++ b/test/setup/verified-context.ts
@@ -1,0 +1,8 @@
+import { markVersionCompatibleForTest } from "../../src/api/version-check.js";
+import type { RequestContext } from "../../src/types.js";
+
+/** Mark a mock context verified when a unit test isolates a business API's wire contract. */
+export function verifiedContext<T extends RequestContext>(ctx: T): T {
+  markVersionCompatibleForTest(ctx);
+  return ctx;
+}

--- a/test/unit/app-keys.test.ts
+++ b/test/unit/app-keys.test.ts
@@ -10,12 +10,13 @@ import {
 import { request } from "../../src/api/http.js";
 import type { RequestContext } from "../../src/types.js";
 import { HttpError, formatError } from "../../src/utils/errors.js";
+import { verifiedContext } from "../setup/verified-context.js";
 
-const ctx: RequestContext = {
+const ctx = verifiedContext<RequestContext>({
   baseUrl: "https://demo.example.com",
   token: "t",
   insecure: false,
-};
+});
 
 type CallArgs = [string, RequestInit];
 function mockFetch(): typeof fetch {
@@ -109,7 +110,7 @@ describe("appkey 401 → re-issue guidance (OPE-22)", () => {
 
   it("a bak_ AppKey 401 carries re-issue guidance, not auth-login", async () => {
     mock401();
-    const appKeyCtx: RequestContext = { ...ctx, token: "bak_keyid_secret" };
+    const appKeyCtx = verifiedContext({ ...ctx, token: "bak_keyid_secret" });
     const err = await request(appKeyCtx, "/api/agent-retrieval/v1/mcp/info").catch((e) => e);
     expect(err).toBeInstanceOf(HttpError);
     expect((err as HttpError).hint).toMatch(/re-issue/i);
@@ -120,7 +121,7 @@ describe("appkey 401 → re-issue guidance (OPE-22)", () => {
 
   it("a non-AppKey (OAuth) 401 keeps the default auth-login guidance", async () => {
     mock401();
-    const oauthCtx: RequestContext = { ...ctx, token: "ory_at_xyz" };
+    const oauthCtx = verifiedContext({ ...ctx, token: "ory_at_xyz" });
     const err = await request(oauthCtx, "/api/agent-retrieval/v1/mcp/info").catch((e) => e);
     expect((err as HttpError).hint).toBeUndefined();
     expect(formatError(err)).toContain("auth login");

--- a/test/unit/bkn-create.test.ts
+++ b/test/unit/bkn-create.test.ts
@@ -5,12 +5,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createFromCatalog } from "../../src/resources/bkn-create.js";
 import type { RequestContext } from "../../src/types.js";
 import { HttpError, InputError } from "../../src/utils/errors.js";
+import { verifiedContext } from "../setup/verified-context.js";
 
-const ctx: RequestContext = {
+const ctx = verifiedContext<RequestContext>({
   baseUrl: "https://demo.example.com",
   token: "t",
   insecure: false,
-};
+});
 
 type Route = (url: URL, init: RequestInit) => unknown | undefined;
 

--- a/test/unit/call.test.ts
+++ b/test/unit/call.test.ts
@@ -1,14 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { parseFormField, parseHeader, rawCall } from "../../src/api/call.js";
 import type { RequestContext } from "../../src/types.js";
+import { verifiedContext } from "../setup/verified-context.js";
 
 function ctx(over: Partial<RequestContext> = {}): RequestContext {
-  return {
+  return verifiedContext({
     baseUrl: "https://demo.example.com",
     token: "OLD",
     insecure: false,
     ...over,
-  };
+  });
 }
 
 describe("parseHeader", () => {
@@ -43,6 +44,9 @@ describe("rawCall refresh-on-401", () => {
     const auths: (string | null)[] = [];
     let persisted: string | undefined;
     const f = vi.fn(async (url: string, init?: RequestInit) => {
+      if (String(url).endsWith("/api/bkn-backend/v1/health")) {
+        return new Response(JSON.stringify({ ServerVersion: "0.1.5" }), { status: 200 });
+      }
       if (String(url).endsWith("/oauth2/token")) {
         return new Response(JSON.stringify({ access_token: "NEW" }), { status: 200 });
       }
@@ -73,10 +77,14 @@ describe("rawCall refresh-on-401", () => {
   });
 
   it("does not retry a 401 without stored refresh credentials", async () => {
-    const f = vi.fn(async () => new Response("denied", { status: 401 }));
+    const f = vi.fn(async (url: string) =>
+      String(url).endsWith("/api/bkn-backend/v1/health")
+        ? new Response(JSON.stringify({ ServerVersion: "0.1.5" }), { status: 200 })
+        : new Response("denied", { status: 401 }),
+    );
     vi.stubGlobal("fetch", f);
     const res = await rawCall(ctx(), "/api/x"); // no ctx.refresh
     expect(res.status).toBe(401);
-    expect(f).toHaveBeenCalledTimes(1); // single shot, surfaces the 401
+    expect(f).toHaveBeenCalledTimes(1); // single business shot
   });
 });

--- a/test/unit/context-loader.test.ts
+++ b/test/unit/context-loader.test.ts
@@ -14,8 +14,9 @@ import {
 import { resetLifecycleCaches } from "../../src/api/lifecycle.js";
 import type { RequestContext } from "../../src/types.js";
 import { formatError } from "../../src/utils/errors.js";
+import { verifiedContext } from "../setup/verified-context.js";
 
-const ctx: RequestContext = {
+const ctx = verifiedContext<RequestContext>({
   baseUrl: "https://demo.example.com",
   token: "t",
   insecure: false,
@@ -28,7 +29,7 @@ const ctx: RequestContext = {
     attempt: 1,
     observedAt: "2026-07-27T09:00:00.000Z",
   },
-};
+});
 
 /** Mock the MCP endpoint: every POST returns a session id + a JSON-RPC result. */
 function mockMcp(): typeof fetch {
@@ -107,7 +108,7 @@ describe("progressive KN detail (get_kn_detail)", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-27T09:00:00.000Z"));
     const f = mockMcp();
-    const longLivedCtx = {
+    const longLivedCtx = verifiedContext({
       ...ctx,
       trace: {
         requestId: ctx.trace?.requestId ?? "",
@@ -115,7 +116,7 @@ describe("progressive KN detail (get_kn_detail)", () => {
         conversationId: ctx.trace?.conversationId,
         interactionId: ctx.trace?.interactionId,
       },
-    };
+    });
 
     await getKnDetail(longLivedCtx, "kn-long-lived-a");
     vi.setSystemTime(new Date("2026-07-27T09:01:00.000Z"));
@@ -220,7 +221,11 @@ describe("managed MCP tool calls", () => {
 
     await expect(
       callManagedTool(
-        { baseUrl: "https://managed-auto.example.com", token: "receipt-token", insecure: false },
+        verifiedContext({
+          baseUrl: "https://managed-auto.example.com",
+          token: "receipt-token",
+          insecure: false,
+        }),
         "kn-auto-receipt",
         "search_schema",
         { query: "forecast" },
@@ -429,9 +434,22 @@ describe("managed MCP tool calls", () => {
         });
       }),
     );
-    const base = { baseUrl: "https://identity-cache.example.com", insecure: false };
-    await callTool({ ...base, token: "alice" }, "kn-identity-cache", "bkn_get_operation", {});
-    await callTool({ ...base, token: "bob" }, "kn-identity-cache", "bkn_get_operation", {});
+    const base = {
+      baseUrl: "https://identity-cache.example.com",
+      insecure: false,
+    };
+    await callTool(
+      verifiedContext({ ...base, token: "alice" }),
+      "kn-identity-cache",
+      "bkn_get_operation",
+      {},
+    );
+    await callTool(
+      verifiedContext({ ...base, token: "bob" }),
+      "kn-identity-cache",
+      "bkn_get_operation",
+      {},
+    );
 
     expect(initialized).toBe(2);
     expect(businessSessions).toEqual(["identity-session-1", "identity-session-2"]);
@@ -455,14 +473,14 @@ describe("managed MCP tool calls", () => {
     const f = mockMcp();
     await expect(
       callTool(
-        {
+        verifiedContext({
           ...ctx,
           trace: {
             requestId: "request-conversation-only",
             traceparent: "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
             conversationId: "conversation_supply_chain",
           },
-        },
+        }),
         "kn-caller-interaction",
         "search_schema",
         {
@@ -495,14 +513,14 @@ describe("managed MCP tool calls", () => {
     const f = mockMcp();
     await expect(
       callTool(
-        {
+        verifiedContext({
           ...ctx,
           trace: {
             requestId: "request-interaction-only",
             traceparent: "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
             interactionId: "interaction-only",
           },
-        },
+        }),
         "kn-interaction-only-caller",
         "search_schema",
         {
@@ -524,13 +542,13 @@ describe("managed MCP tool calls", () => {
   it("omits business trace headers when caller context is the only business source", async () => {
     const f = mockMcp();
     await callTool(
-      {
+      verifiedContext({
         ...ctx,
         trace: {
           requestId: ctx.trace?.requestId ?? "",
           traceparent: ctx.trace?.traceparent ?? "",
         },
-      },
+      }),
       "kn-caller-context",
       "search_schema",
       {

--- a/test/unit/functions.test.ts
+++ b/test/unit/functions.test.ts
@@ -6,12 +6,13 @@ import {
   listDependencyVersions,
 } from "../../src/api/functions.js";
 import type { RequestContext } from "../../src/types.js";
+import { verifiedContext } from "../setup/verified-context.js";
 
-const ctx: RequestContext = {
+const ctx = verifiedContext<RequestContext>({
   baseUrl: "https://demo.example.com",
   token: "t",
   insecure: false,
-};
+});
 
 type CallArgs = [string, RequestInit];
 function mockFetch(body = "{}"): typeof fetch {

--- a/test/unit/http.test.ts
+++ b/test/unit/http.test.ts
@@ -2,12 +2,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { request } from "../../src/api/http.js";
 import type { RequestContext } from "../../src/types.js";
 import { HttpError, NonJsonResponseError, ToolError, formatError } from "../../src/utils/errors.js";
+import { verifiedContext } from "../setup/verified-context.js";
 
-const ctx: RequestContext = {
+const ctx = verifiedContext<RequestContext>({
   baseUrl: "https://demo.example.com",
   token: "t",
   insecure: false,
-};
+});
 
 function respond(body: string, init: ResponseInit): void {
   vi.stubGlobal(
@@ -40,9 +41,10 @@ describe("non-JSON responses", () => {
       status: 401,
       headers: { "content-type": "text/html" },
     });
-    const err = await request({ ...ctx, token: "bak_123" }, "/api/vega-backend/v1/resources").catch(
-      (e) => e,
-    );
+    const err = await request(
+      verifiedContext({ ...ctx, token: "bak_123" }),
+      "/api/vega-backend/v1/resources",
+    ).catch((e) => e);
     // Both diagnoses apply: the gateway ate the request AND the key is the thing
     // to re-issue. Neither may hide the other.
     expect((err as HttpError).hint).toMatch(/did not reach the service/);

--- a/test/unit/knowledge-networks.test.ts
+++ b/test/unit/knowledge-networks.test.ts
@@ -19,12 +19,13 @@ import {
 import { resetLifecycleCaches } from "../../src/api/lifecycle.js";
 import { readBody } from "../../src/commands/_shared.js";
 import type { RequestContext } from "../../src/types.js";
+import { verifiedContext } from "../setup/verified-context.js";
 
-const ctx: RequestContext = {
+const ctx = verifiedContext<RequestContext>({
   baseUrl: "https://demo.example.com",
   token: "t",
   insecure: false,
-};
+});
 
 type CallArgs = [string, RequestInit];
 

--- a/test/unit/lifecycle.test.ts
+++ b/test/unit/lifecycle.test.ts
@@ -7,6 +7,7 @@ import { searchInstance } from "../../src/api/knowledge-networks.js";
 import { releaseLifecycleSessions, resetLifecycleCaches } from "../../src/api/lifecycle.js";
 import type { RequestContext } from "../../src/types.js";
 import { HttpError, ToolError } from "../../src/utils/errors.js";
+import { verifiedContext } from "../setup/verified-context.js";
 
 const V1_CATALOG = {
   tools: [{ name: "bkn_create_conversation" }, { name: "bkn_start_interaction" }],
@@ -36,12 +37,12 @@ const V2_CATALOG_WITH_MODE = {
 let hostSeq = 0;
 function freshCtx(extra: Partial<RequestContext> = {}): RequestContext {
   hostSeq += 1;
-  return {
+  return verifiedContext({
     baseUrl: `https://deploy-${hostSeq}.example.com`,
     token: "t",
     insecure: false,
     ...extra,
-  };
+  });
 }
 
 interface MockOptions {
@@ -193,8 +194,12 @@ describe("managed lifecycle on semantic search", () => {
   it("probes lifecycle capabilities separately for each identity", async () => {
     const recorded = mockDeploy({ catalog: V2_CATALOG });
     const base = freshCtx();
-    await searchInstance({ ...base, token: "alice" }, "kn-identity-catalog", "物料");
-    await searchInstance({ ...base, token: "bob" }, "kn-identity-catalog", "物料");
+    await searchInstance(
+      verifiedContext({ ...base, token: "alice" }),
+      "kn-identity-catalog",
+      "物料",
+    );
+    await searchInstance(verifiedContext({ ...base, token: "bob" }), "kn-identity-catalog", "物料");
 
     expect(recorded.infoCount).toBe(2);
   });
@@ -490,8 +495,16 @@ describe("managed lifecycle on semantic search", () => {
     const recorded = mockDeploy({ catalog: V2_CATALOG });
     // Same deploy, same identity, same KN — only the wanted conversation differs.
     const base = freshCtx();
-    await searchInstance({ ...base, rememberedConversationId: "conv_a" }, "kn-managed", "物料");
-    await searchInstance({ ...base, rememberedConversationId: "conv_b" }, "kn-managed", "物料");
+    await searchInstance(
+      verifiedContext({ ...base, rememberedConversationId: "conv_a" }),
+      "kn-managed",
+      "物料",
+    );
+    await searchInstance(
+      verifiedContext({ ...base, rememberedConversationId: "conv_b" }),
+      "kn-managed",
+      "物料",
+    );
 
     // A caller that asked for B must not be handed the session opened on A —
     // the guarantee `sessionKey` already documents for a named conversation.
@@ -625,16 +638,16 @@ describe("managed lifecycle on semantic search", () => {
       requestId: "req_1",
       traceparent: "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
     };
-    const a: RequestContext = {
+    const a = verifiedContext<RequestContext>({
       ...freshCtx(),
       baseUrl: host,
       trace: { ...trace, conversationId: "conv_A" },
-    };
-    const b: RequestContext = {
+    });
+    const b = verifiedContext<RequestContext>({
       ...freshCtx(),
       baseUrl: host,
       trace: { ...trace, conversationId: "conv_B" },
-    };
+    });
     await searchInstance(a, "kn-1", "物料");
     await searchInstance(b, "kn-1", "供应商");
 
@@ -705,8 +718,8 @@ describe("managed lifecycle on semantic search", () => {
   it("keeps one session per caller rather than sharing across tokens", async () => {
     const recorded = mockDeploy();
     const host = `https://shared-${Date.now()}.example.com`;
-    const alice: RequestContext = { ...freshCtx(), baseUrl: host, token: "alice" };
-    const bob: RequestContext = { ...freshCtx(), baseUrl: host, token: "bob" };
+    const alice = verifiedContext({ ...freshCtx(), baseUrl: host, token: "alice" });
+    const bob = verifiedContext({ ...freshCtx(), baseUrl: host, token: "bob" });
     await searchInstance(alice, "kn-managed", "物料");
     await searchInstance(bob, "kn-managed", "物料");
 
@@ -757,8 +770,8 @@ describe("managed lifecycle on semantic search", () => {
     );
 
     const host = `https://tenants-${hostSeq}.example.com`;
-    const alice: RequestContext = { ...freshCtx(), baseUrl: host, token: "stale" };
-    const bob: RequestContext = { ...freshCtx(), baseUrl: host, token: "good" };
+    const alice = verifiedContext({ ...freshCtx(), baseUrl: host, token: "stale" });
+    const bob = verifiedContext({ ...freshCtx(), baseUrl: host, token: "good" });
     await searchInstance(alice, "kn-1", "物料");
     const bobBody = await searchInstance(bob, "kn-1", "物料").then(() =>
       lastRetrievalBody(fetch as unknown as typeof fetch),

--- a/test/unit/models.test.ts
+++ b/test/unit/models.test.ts
@@ -13,12 +13,13 @@ import {
   setDefaultSmallModel,
 } from "../../src/api/models.js";
 import type { RequestContext } from "../../src/types.js";
+import { verifiedContext } from "../setup/verified-context.js";
 
-const ctx: RequestContext = {
+const ctx = verifiedContext<RequestContext>({
   baseUrl: "https://demo.example.com",
   token: "t",
   insecure: false,
-};
+});
 
 type CallArgs = [string, RequestInit];
 function mockFetch(): typeof fetch {

--- a/test/unit/resources.test.ts
+++ b/test/unit/resources.test.ts
@@ -22,12 +22,13 @@ import {
 import type { ResourceLocalStatus } from "../../src/index.js";
 import type { RequestContext } from "../../src/types.js";
 import { HttpError, InputError } from "../../src/utils/errors.js";
+import { verifiedContext } from "../setup/verified-context.js";
 
-const ctx: RequestContext = {
+const ctx = verifiedContext<RequestContext>({
   baseUrl: "https://demo.example.com",
   token: "t",
   insecure: false,
-};
+});
 
 type CallArgs = [string, RequestInit];
 

--- a/test/unit/safe.test.ts
+++ b/test/unit/safe.test.ts
@@ -23,12 +23,13 @@ import {
   updateUserSafe,
 } from "../../src/api/safe.js";
 import type { RequestContext } from "../../src/types.js";
+import { verifiedContext } from "../setup/verified-context.js";
 
-const ctx: RequestContext = {
+const ctx = verifiedContext<RequestContext>({
   baseUrl: "https://demo.example.com",
   token: "t",
   insecure: false,
-};
+});
 
 type Call = [string, RequestInit];
 function mockFetch(body: unknown = {}): typeof fetch {

--- a/test/unit/skill-execute-command.test.ts
+++ b/test/unit/skill-execute-command.test.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { skillCommand } from "../../src/commands/skill.js";
+import { writeVersionCheckCache } from "../../src/config/store.js";
 
 /** Root with the global flags the skill commands read through `optsWithGlobals`. */
 function cli(): Command {
@@ -40,6 +41,15 @@ afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
   process.exitCode = undefined;
+});
+
+// These command tests isolate command rendering and body construction. The
+// version preflight has dedicated coverage in version-check.test.ts.
+beforeEach(() => {
+  writeVersionCheckCache("https://demo.example.com", {
+    serverVersion: "0.1.5",
+    checkedAt: new Date().toISOString(),
+  });
 });
 
 describe("skill execute", () => {

--- a/test/unit/skill-raw-read.test.ts
+++ b/test/unit/skill-raw-read.test.ts
@@ -2,12 +2,13 @@ import JSZip from "jszip";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { skills } from "../../src/resources/skills.js";
 import type { RequestContext } from "../../src/types.js";
+import { verifiedContext } from "../setup/verified-context.js";
 
-const ctx: RequestContext = {
+const ctx = verifiedContext<RequestContext>({
   baseUrl: "https://demo.example.com",
   token: "t",
   insecure: false,
-};
+});
 
 async function archive(files: Record<string, string | Uint8Array>): Promise<Uint8Array> {
   const zip = new JSZip();
@@ -81,8 +82,8 @@ describe("raw file reads", () => {
     const { calls } = mockDeploy({ archiveBytes: await archive({ "a.md": "A" }) });
     // The cache lives on the client, so a second identity re-fetches under its
     // own credential instead of reading bytes the first one was granted.
-    await skills({ ...ctx, token: "alice" }).readFileRaw("shared-1", "a.md");
-    await skills({ ...ctx, token: "bob" }).readFileRaw("shared-1", "a.md");
+    await skills(verifiedContext({ ...ctx, token: "alice" })).readFileRaw("shared-1", "a.md");
+    await skills(verifiedContext({ ...ctx, token: "bob" })).readFileRaw("shared-1", "a.md");
     expect(calls.filter((p) => p.endsWith("/download"))).toHaveLength(2);
   });
 

--- a/test/unit/skills.test.ts
+++ b/test/unit/skills.test.ts
@@ -10,12 +10,13 @@ import {
   readSkillFile,
 } from "../../src/api/skills.js";
 import type { RequestContext } from "../../src/types.js";
+import { verifiedContext } from "../setup/verified-context.js";
 
-const ctx: RequestContext = {
+const ctx = verifiedContext<RequestContext>({
   baseUrl: "https://demo.example.com",
   token: "t",
   insecure: false,
-};
+});
 
 type CallArgs = [string, RequestInit];
 function mockFetch(): typeof fetch {

--- a/test/unit/toolboxes.test.ts
+++ b/test/unit/toolboxes.test.ts
@@ -8,12 +8,13 @@ import {
   updateTool,
 } from "../../src/api/toolboxes.js";
 import type { RequestContext } from "../../src/types.js";
+import { verifiedContext } from "../setup/verified-context.js";
 
-const ctx: RequestContext = {
+const ctx = verifiedContext<RequestContext>({
   baseUrl: "https://demo.example.com",
   token: "t",
   insecure: false,
-};
+});
 
 type CallArgs = [string, RequestInit];
 function sent(f: typeof fetch): {

--- a/test/unit/trace-lifecycle.test.ts
+++ b/test/unit/trace-lifecycle.test.ts
@@ -11,12 +11,13 @@ import {
 } from "../../src/api/trace-lifecycle.js";
 import type { RequestContext } from "../../src/types.js";
 import { HttpError } from "../../src/utils/errors.js";
+import { verifiedContext } from "../setup/verified-context.js";
 
-const ctx: RequestContext = {
+const ctx = verifiedContext<RequestContext>({
   baseUrl: "https://demo.example.com",
   token: "token",
   insecure: false,
-};
+});
 
 type CallArgs = [string, RequestInit];
 

--- a/test/unit/trace.test.ts
+++ b/test/unit/trace.test.ts
@@ -19,12 +19,13 @@ import type { RawSpan } from "../../src/api/trace.js";
 import { assembleTraceTree } from "../../src/bkn-trace/diagnose.js";
 import { trace } from "../../src/resources/trace.js";
 import type { RequestContext } from "../../src/types.js";
+import { verifiedContext } from "../setup/verified-context.js";
 
-const ctx: RequestContext = {
+const ctx = verifiedContext<RequestContext>({
   baseUrl: "https://demo.example.com",
   token: "t",
   insecure: false,
-};
+});
 
 type CallArgs = [string, RequestInit];
 function mockFetchSeq(bodies: unknown[]): typeof fetch {
@@ -178,10 +179,10 @@ describe("emitEvidenceEvents", () => {
 
 describe("BKN Trace 2.2 business runs and artifacts", () => {
   it("sends the dedicated ingest token only to evidence write endpoints", async () => {
-    const ingestCtx = {
+    const ingestCtx = verifiedContext({
       ...ctx,
       evidenceIngestToken: "producer-ingest-token",
-    } as RequestContext;
+    });
     const artifact = {
       artifact_id: "art_auth_001",
       artifact_type: "question" as const,

--- a/test/unit/vega-command.test.ts
+++ b/test/unit/vega-command.test.ts
@@ -1,7 +1,8 @@
 import { Command } from "commander";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { vegaCommand } from "../../src/commands/vega.js";
+import { writeVersionCheckCache } from "../../src/config/store.js";
 
 function cli(): Command {
   const root = new Command("openbkn")
@@ -15,6 +16,15 @@ function cli(): Command {
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+});
+
+// These command tests isolate argument mapping. Version preflight behavior is
+// covered independently, so their business-endpoint mocks use a fresh CLI cache.
+beforeEach(() => {
+  writeVersionCheckCache("https://demo.example.com", {
+    serverVersion: "0.1.5",
+    checkedAt: new Date().toISOString(),
+  });
 });
 
 function mockFetch(body: unknown = {}): ReturnType<typeof vi.fn> {

--- a/test/unit/vega-discovery.test.ts
+++ b/test/unit/vega-discovery.test.ts
@@ -10,12 +10,13 @@ import {
   updateDiscoverSchedule,
 } from "../../src/api/vega-discovery.js";
 import type { RequestContext } from "../../src/types.js";
+import { verifiedContext } from "../setup/verified-context.js";
 
-const ctx: RequestContext = {
+const ctx = verifiedContext<RequestContext>({
   baseUrl: "https://demo.example.com",
   token: "t",
   insecure: false,
-};
+});
 
 type CallArgs = [string, RequestInit];
 function mockFetch(body: unknown = {}): typeof fetch {

--- a/test/unit/vega-semantic.test.ts
+++ b/test/unit/vega-semantic.test.ts
@@ -6,12 +6,13 @@ import {
   listSemanticUnderstandingTasks,
 } from "../../src/api/vega-semantic.js";
 import type { RequestContext } from "../../src/types.js";
+import { verifiedContext } from "../setup/verified-context.js";
 
-const ctx: RequestContext = {
+const ctx = verifiedContext<RequestContext>({
   baseUrl: "https://demo.example.com",
   token: "t",
   insecure: false,
-};
+});
 type CallArgs = [string, RequestInit];
 function mockFetch(body: unknown = {}): typeof fetch {
   const fn = vi.fn(async () => new Response(JSON.stringify(body), { status: 200 }));

--- a/test/unit/vega.test.ts
+++ b/test/unit/vega.test.ts
@@ -26,12 +26,13 @@ import {
 } from "../../src/api/vega.js";
 import { vega } from "../../src/resources/vega.js";
 import type { RequestContext } from "../../src/types.js";
+import { verifiedContext } from "../setup/verified-context.js";
 
-const ctx: RequestContext = {
+const ctx = verifiedContext<RequestContext>({
   baseUrl: "https://demo.example.com",
   token: "t",
   insecure: false,
-};
+});
 
 type CallArgs = [string, RequestInit];
 function mockFetch(body: unknown = { entries: [], total_count: 0 }): typeof fetch {

--- a/test/unit/version-check-cli-command.test.ts
+++ b/test/unit/version-check-cli-command.test.ts
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 OpenBKN. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the project root.
+
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { adminCommand } from "../../src/commands/admin.js";
+import { authCommand } from "../../src/commands/auth.js";
+import { callCommand } from "../../src/commands/call.js";
+import { writeVersionCheckCache } from "../../src/config/store.js";
+
+const BASE = "https://cli-version-check.example.com";
+
+function cli(): Command {
+  const root = new Command("openbkn")
+    .exitOverride()
+    .option("--base-url <url>")
+    .option("--token <token>");
+  root.addCommand(callCommand());
+  root.addCommand(adminCommand());
+  root.addCommand(authCommand());
+  return root;
+}
+
+beforeEach(() => {
+  writeVersionCheckCache(BASE, { serverVersion: "0.1.5", checkedAt: new Date().toISOString() });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 })),
+  );
+  vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("direct CLI commands use the version-check cache", () => {
+  it.each([
+    ["call", ["call", "/api/x"]],
+    ["admin call", ["admin", "call", "/api/x"]],
+    [
+      "auth change-password",
+      [
+        "auth",
+        "change-password",
+        "--account",
+        "admin",
+        "--old-password",
+        "old",
+        "--new-password",
+        "new",
+      ],
+    ],
+  ])("uses the CLI cache for %s", async (_name, args) => {
+    await cli().parseAsync(["--base-url", BASE, "--token", "token", ...args], { from: "user" });
+
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(
+      String((fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]?.[0]),
+    ).not.toContain("/api/bkn-backend/v1/health");
+  });
+});

--- a/test/unit/version-check-dry-run.test.ts
+++ b/test/unit/version-check-dry-run.test.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 OpenBKN. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the project root.
+
+import { describe, expect, it, vi } from "vitest";
+import { request } from "../../src/api/http.js";
+import { configureVersionCheck } from "../../src/api/version-check.js";
+import type { RequestContext } from "../../src/types.js";
+import { DryRunSignal, enableDryRun } from "../../src/utils/dry-run.js";
+
+describe("version preflight under --dry-run", () => {
+  it("does not probe health and previews the intended business request", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    enableDryRun();
+    const ctx: RequestContext = {
+      baseUrl: "https://demo.example.com",
+      token: "token",
+      insecure: false,
+    };
+    configureVersionCheck(ctx, "cli");
+
+    const error = await request(ctx, "/api/vega-backend/v1/catalogs", {
+      body: { name: "demo" },
+    }).catch((reason) => reason);
+
+    expect(error).toBeInstanceOf(DryRunSignal);
+    expect((error as DryRunSignal).request.url).toContain("/api/vega-backend/v1/catalogs");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/version-check.test.ts
+++ b/test/unit/version-check.test.ts
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 OpenBKN. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the project root.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { rawCall } from "../../src/api/call.js";
+import { request } from "../../src/api/http.js";
+import {
+  VersionCompatibilityError,
+  baseVersion,
+  configureVersionCheck,
+} from "../../src/api/version-check.js";
+import { readVersionCheckCache, writeVersionCheckCache } from "../../src/config/store.js";
+import type { RequestContext } from "../../src/types.js";
+
+function ctx(
+  mode: "memory" | "cli" = "memory",
+  baseUrl = "https://demo.example.com",
+): RequestContext {
+  const context: RequestContext = {
+    baseUrl,
+    token: "token",
+    insecure: false,
+  };
+  configureVersionCheck(context, mode);
+  return context;
+}
+
+function route(version = "0.1.5", business = { ok: true }) {
+  return vi.fn(async (input: string | URL) => {
+    const path = new URL(String(input)).pathname;
+    if (path === "/api/bkn-backend/v1/health")
+      return new Response(JSON.stringify({ ServerVersion: version }), { status: 200 });
+    return new Response(JSON.stringify(business), { status: 200 });
+  });
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("platform version preflight", () => {
+  it("accepts a matching platform version and sends the business request", async () => {
+    const fetch = route();
+    vi.stubGlobal("fetch", fetch);
+
+    await expect(request(ctx(), "/api/bkn-backend/v1/knowledge-networks")).resolves.toEqual({
+      ok: true,
+    });
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(new URL(String(fetch.mock.calls[0]?.[0])).pathname).toBe("/api/bkn-backend/v1/health");
+    expect(new URL(String(fetch.mock.calls[1]?.[0])).pathname).toBe(
+      "/api/bkn-backend/v1/knowledge-networks",
+    );
+  });
+
+  it("treats the SDK prerelease as compatible with its stable base version", async () => {
+    expect(baseVersion("0.1.5-rc.1")).toBe("0.1.5");
+    const fetch = route("0.1.5");
+    vi.stubGlobal("fetch", fetch);
+
+    await expect(request(ctx(), "/api/x")).resolves.toEqual({ ok: true });
+  });
+
+  it("reads ServerVersion from the standard response envelope", async () => {
+    const fetch = vi.fn(async (input: string | URL) => {
+      const body =
+        new URL(String(input)).pathname === "/api/bkn-backend/v1/health"
+          ? { data: { ServerVersion: "0.1.5" } }
+          : { ok: true };
+      return new Response(JSON.stringify(body), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetch);
+
+    await expect(request(ctx(), "/api/x")).resolves.toEqual({ ok: true });
+  });
+
+  it("blocks the business request on a version mismatch", async () => {
+    const fetch = route("0.1.4");
+    vi.stubGlobal("fetch", fetch);
+
+    const error = await request(ctx(), "/api/x").catch((reason) => reason);
+    expect(error).toBeInstanceOf(VersionCompatibilityError);
+    expect((error as Error).message).toMatch(/SDK version 0\.1\.5-rc\.1.*platform version 0\.1\.4/);
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(new URL(String(fetch.mock.calls[0]?.[0])).pathname).toBe("/api/bkn-backend/v1/health");
+  });
+
+  it("blocks when health does not return a valid server version", async () => {
+    const fetch = vi.fn(
+      async () => new Response(JSON.stringify({ status: "ok" }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetch);
+
+    await expect(request(ctx(), "/api/x")).rejects.toThrow(/did not return a valid ServerVersion/);
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it("checks a programmatic client only once", async () => {
+    const fetch = route();
+    vi.stubGlobal("fetch", fetch);
+    const client = ctx();
+
+    await request(client, "/api/one");
+    await request(client, "/api/two");
+
+    expect(fetch).toHaveBeenCalledTimes(3); // health once, then two business requests
+  });
+
+  it("also gates the raw call escape hatch", async () => {
+    const fetch = route();
+    vi.stubGlobal("fetch", fetch);
+
+    await expect(rawCall(ctx(), "/api/x")).resolves.toMatchObject({ status: 200 });
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("initializes version state for a manually constructed public context", async () => {
+    const fetch = route();
+    vi.stubGlobal("fetch", fetch);
+    const publicCtx: RequestContext = {
+      baseUrl: "https://demo.example.com",
+      token: "token",
+      insecure: false,
+    };
+
+    await expect(request(publicCtx, "/api/x")).resolves.toEqual({ ok: true });
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects an absolute URL for another platform before checking or sending", async () => {
+    const fetch = route();
+    vi.stubGlobal("fetch", fetch);
+
+    await expect(request(ctx(), "https://other.example.com/api/x")).rejects.toThrow(
+      /differs from the configured platform/,
+    );
+    await expect(rawCall(ctx(), "https://other.example.com/api/x")).rejects.toThrow(
+      /differs from the configured platform/,
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("reuses a successful CLI check for 60 seconds across clients", async () => {
+    const fetch = route();
+    vi.stubGlobal("fetch", fetch);
+
+    await request(ctx("cli"), "/api/one");
+    await request(ctx("cli"), "/api/two");
+
+    expect(fetch).toHaveBeenCalledTimes(3); // health once, then two business requests
+    expect(readVersionCheckCache("https://demo.example.com")?.serverVersion).toBe("0.1.5");
+  });
+
+  it("rechecks the CLI version after its cache expires", async () => {
+    writeVersionCheckCache("https://demo.example.com", {
+      serverVersion: "0.1.5",
+      checkedAt: new Date(Date.now() - 60_001).toISOString(),
+    });
+    const fetch = route();
+    vi.stubGlobal("fetch", fetch);
+
+    await request(ctx("cli"), "/api/x");
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("continues when the optional CLI cache cannot be written", async () => {
+    const root = mkdtempSync(join(tmpdir(), "bkn-version-check-"));
+    const blocked = join(root, "not-a-directory");
+    writeFileSync(blocked, "blocked");
+    const previous = process.env.BKN_CONFIG_DIR;
+    process.env.BKN_CONFIG_DIR = blocked;
+    const fetch = route();
+    vi.stubGlobal("fetch", fetch);
+
+    try {
+      await expect(
+        request(ctx("cli", "https://cache-write-fails.example.com"), "/api/x"),
+      ).resolves.toEqual({
+        ok: true,
+      });
+      expect(fetch).toHaveBeenCalledTimes(2);
+    } finally {
+      if (previous === undefined) delete process.env.BKN_CONFIG_DIR;
+      else process.env.BKN_CONFIG_DIR = previous;
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
## What Changed

- [x] Add a BKN health preflight that requires an exact base SemVer match.
- [x] Apply the check to all SDK business transports and the raw-call escape hatch.
- [x] Cache a successful CLI check for 60 seconds; retain one in-memory check per SDK client.
- [x] Add compatibility, cache, dry-run, cross-origin, and context-propagation regression coverage.

---

## Why

- Related Issue: Closes #91
- Background: 0.x releases are intentionally incompatible. SDK 0.1.5-rc.1 may access platform 0.1.5 only after prerelease metadata is stripped.

---

## How

- Version state is private to each request context via `WeakMap`, preventing public-context callers from forging a successful check.
- The version source is `GET /api/bkn-backend/v1/health` and reads `ServerVersion` from either a direct or gateway-wrapped response.
- Direct absolute URLs are limited to the configured platform origin.
- Breaking changes: business requests now fail closed when platform version verification fails or differs.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable; unit suite is fully mocked)
- [ ] Verified in test environment (not run)

Test notes:

- `npm test` — 640 passed, 1 skipped.
- `npm run lint`
- `npm run build`

---

## Risk & Rollback

- Potential risks: a platform with no exposed BKN health endpoint, invalid version payload, or a mismatched version is intentionally blocked.
- Rollback plan: revert this PR to restore the prior request behavior.

---

## Additional Notes

- This depends on the Foundry health-endpoint PR that exposes the version source through the standard API prefix.