### PR TITLE
fix(python): preserve Function parent operations in BKN reads

### DIFF
--- a/docs/exec-plans/active/2026-09-05-function-trace-parent.md
+++ b/docs/exec-plans/active/2026-09-05-function-trace-parent.md
@@ -1,0 +1,12 @@
+# Function Trace parent propagation
+
+Companion to openbkn-ai/bkn-foundry#1319. Base: GitHub main, 669cb0fc8c87c3a461e4553772ee50fd66508f05.
+
+- [x] Add optional parent_operation_id to resolved Context and caller-owned Interaction.
+- [x] Inherit BKN_PARENT_OPERATION_ID only when the resolved turn matches the environment turn.
+- [x] Send the parent through both typed MCP reads and the kn HTTP facade without adding business parameters.
+- [x] Test multiple reads, subsequent invocations, absent parent, and explicit turn override.
+- [x] Run 412 unit tests (32 live tests skipped), Ruff, mypy and package build/install verification.
+- [ ] Publish reviewed commit, then update Foundry sandbox image dependency pin and perform deployed integration validation.
+
+No Function business code or calculation changes. Parent context is optional; ordinary calls keep the existing two-ID envelope. The full cross-module design and validation are recorded in Foundry docs/plans/2026-09-05-1319-function-trace-parent.md.

--- a/python/README.md
+++ b/python/README.md
@@ -420,3 +420,10 @@ populated type that has relations to walk. Credentials resolve as they do for
 any caller, so `openbkn auth login` is enough. Run it against more than one
 deploy: the two this SDK was built against have disagreed about route names,
 metrics, and which reads their data resources can serve.
+
+### Function Trace parent
+
+When the sandbox supplies `BKN_PARENT_OPERATION_ID` together with its conversation
+and interaction IDs, internal reads send it as `bkn_context.parent_operation_id`.
+Each read keeps its own operation and receipt. An explicit override to a different
+turn does not inherit the sandbox's parent. Business functions need no new argument.

--- a/python/README.zh.md
+++ b/python/README.zh.md
@@ -289,3 +289,9 @@ BKN_E2E=1 BKN_E2E_KN=ecommerce_ops_bkn_public BKN_BASE_URL=https://your-platform
 ```
 
 `BKN_E2E_OBJECT_TYPE` 指定被测的类；不给就自动挑一个有数据、且有关系可走的类。凭据的解析和任何调用方一样，所以 `openbkn auth login` 就够了。**建议对多个部署各跑一遍**：这个 SDK 依托开发的两台在路由名、指标、以及各自数据资源能服务哪些读上都出现过分歧。
+
+### 函数内部调用的 Trace 父操作
+
+沙箱同时注入会话、交互 ID 和 `BKN_PARENT_OPERATION_ID` 时，内部读取会将父 ID
+作为 `bkn_context.parent_operation_id` 传递。每次读取仍保留自己的操作与回执。
+显式切换到其他交互时不继承原父 ID；业务函数不需要增加参数。

--- a/python/bkn_osdk/config.py
+++ b/python/bkn_osdk/config.py
@@ -87,6 +87,8 @@ class Context:
     interaction_id: str | None = None
     #: Route reads through MCP inside a managed interaction, keeping the receipt.
     traced: bool = False
+    #: Persisted Function operation whose reads join the caller-owned turn.
+    parent_operation_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -291,6 +293,19 @@ def resolve_context() -> Context:
 
     timeout = pick("timeout")
 
+    conversation_id = pick("conversation_id") or os.environ.get("BKN_CONVERSATION_ID") or None
+    interaction_id = pick("interaction_id") or os.environ.get("BKN_INTERACTION_ID") or None
+    # An environment parent belongs only to the execution's own turn. Explicit
+    # session overrides must never attach a different turn to that parent.
+    parent_operation_id = None
+    if (
+        conversation_id
+        and interaction_id
+        and conversation_id == os.environ.get("BKN_CONVERSATION_ID")
+        and interaction_id == os.environ.get("BKN_INTERACTION_ID")
+    ):
+        parent_operation_id = os.environ.get("BKN_PARENT_OPERATION_ID", "").strip() or None
+
     return Context(
         base_url=base_url,
         token=token,
@@ -302,8 +317,9 @@ def resolve_context() -> Context:
         # A host that already owns a business turn passes it in the environment —
         # the sandbox injects both per execution. Joining it is what keeps the
         # evidence on the caller's turn instead of an anonymous one of our own.
-        conversation_id=pick("conversation_id") or os.environ.get("BKN_CONVERSATION_ID") or None,
-        interaction_id=pick("interaction_id") or os.environ.get("BKN_INTERACTION_ID") or None,
+        conversation_id=conversation_id,
+        interaction_id=interaction_id,
+        parent_operation_id=parent_operation_id,
     )
 
 

--- a/python/bkn_osdk/lifecycle.py
+++ b/python/bkn_osdk/lifecycle.py
@@ -14,8 +14,8 @@ is the opposite of the point.
 
 The deploy this was built against speaks the contract where
 `bkn_start_interaction` alone mints both ids — there is no separate
-`bkn_create_conversation` in its catalog — and `bkn_context` accepts only those
-two ids.
+`bkn_create_conversation` in its catalog. Ordinary reads carry those two ids;
+Function reads also carry the parent operation supplied by the host.
 """
 
 from __future__ import annotations
@@ -83,13 +83,19 @@ class Interaction:
     receipts: list[dict[str, Any]] = field(default_factory=list)
     #: True when the caller handed us this turn. Never finish someone else's.
     caller_owned: bool = False
+    parent_operation_id: str | None = None
 
     @property
     def bkn_context(self) -> dict[str, str]:
-        """Exactly the two ids. This contract rejects anything else outright."""
+        """Join the turn, optionally linking a Function read to its parent operation."""
         return {
             "conversation_id": self.conversation_id,
             "interaction_id": self.interaction_id,
+            **(
+                {"parent_operation_id": self.parent_operation_id}
+                if self.parent_operation_id
+                else {}
+            ),
         }
 
 
@@ -136,7 +142,13 @@ def _start(ctx: Context, kn_id: str, question: str = DEFAULT_QUESTION) -> Intera
     asked for.
     """
     if ctx.conversation_id and ctx.interaction_id:
-        return Interaction(kn_id, ctx.conversation_id, ctx.interaction_id, caller_owned=True)
+        return Interaction(
+            kn_id,
+            ctx.conversation_id,
+            ctx.interaction_id,
+            caller_owned=True,
+            parent_operation_id=ctx.parent_operation_id,
+        )
 
     catalog = _catalog(ctx)
     tools = catalog.tools

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -13,7 +13,16 @@ import pytest
 
 import bkn_osdk
 
-_ENV_VARS = ("BKN_TOKEN", "BKN_BASE_URL", "BKN_USER", "BKN_PROFILE", "BKN_CONFIG_DIR")
+_ENV_VARS = (
+    "BKN_TOKEN",
+    "BKN_BASE_URL",
+    "BKN_USER",
+    "BKN_PROFILE",
+    "BKN_CONFIG_DIR",
+    "BKN_CONVERSATION_ID",
+    "BKN_INTERACTION_ID",
+    "BKN_PARENT_OPERATION_ID",
+)
 
 
 @pytest.fixture(autouse=True)

--- a/python/tests/test_traced.py
+++ b/python/tests/test_traced.py
@@ -828,3 +828,43 @@ def test_a_delay_the_platform_names_is_capped(monkeypatch: pytest.MonkeyPatch) -
         mcp_module.call_tool(Context(base_url=PLATFORM, token="t-1"), KN, "search_schema", {})
 
     assert slept and max(slept) <= mcp_module.RETRY_MAX_WAIT_SECONDS
+
+
+def test_function_queries_inherit_parent_per_execution(
+    deploy: Deploy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from bkn_osdk import kn
+
+    monkeypatch.setenv("BKN_CONVERSATION_ID", "host-conv")
+    monkeypatch.setenv("BKN_INTERACTION_ID", "host-int")
+    for parent in ("op_function_a", "op_function_b", ""):
+        monkeypatch.setenv("BKN_PARENT_OPERATION_ID", parent)
+        with session(traced=True):
+            # Typed MCP and the Function's kn facade must agree on ancestry.
+            Tournaments.objects().page(limit=1)
+            Tournaments.objects().page(limit=1)
+            kn.query_object_instance(KN, "tournaments", limit=1)
+        contexts = [
+            call["bkn_context"] for call in tool_calls(deploy, "query_object_instance")[-2:]
+        ] + [deploy.rest_bodies[-1]["bkn_context"]]
+        for context in contexts:
+            assert context.get("parent_operation_id", "") == parent
+            assert context["interaction_id"] == "host-int"
+            assert "operation_id" not in context
+            assert "operation_key" not in context
+    assert tool_calls(deploy, "bkn_start_interaction") == []
+    assert tool_calls(deploy, "bkn_finish_interaction") == []
+
+
+def test_function_parent_does_not_cross_explicit_turn_override(
+    deploy: Deploy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("BKN_CONVERSATION_ID", "host-conv")
+    monkeypatch.setenv("BKN_INTERACTION_ID", "host-int")
+    monkeypatch.setenv("BKN_PARENT_OPERATION_ID", "op_function")
+    with session(traced=True, conversation_id="other-conv", interaction_id="other-int"):
+        Tournaments.objects().page(limit=1)
+    assert tool_calls(deploy, "query_object_instance")[0]["bkn_context"] == {
+        "conversation_id": "other-conv",
+        "interaction_id": "other-int",
+    }


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Preserve the host Function operation as `parent_operation_id` for Python OSDK reads through both MCP and the `kn` HTTP facade.
- [x] Inherit the environment parent only when the resolved conversation and interaction match the host turn.
- [x] Add regression tests and document the optional Function context.

---

## Why

- Related Issue: openbkn-ai/bkn-foundry#1319
- Related Feature: Function execution Trace ancestry.
- Background: Function reads already join the caller's interaction, but omit the operation that invoked the Function. This leaves internal reads unlinked from their parent operation.

---

## How

- Add an optional parent to the resolved context and caller-owned interaction. Include it in `bkn_context` without adding business parameters or reusing child operation IDs.
- Clear ancestry naturally when no environment parent is provided; explicit overrides to another turn do not inherit the host parent.
- Breaking changes: None. Calls without a parent retain the existing two-ID envelope. No database migration.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- Full Python suite: 412 passed, 32 live tests skipped.
- Traced-path regression suite rerun before commit: 43 passed.
- Ruff passed; mypy passed for 46 source files.
- Wheel and sdist built. Installed the wheel in an isolated environment and verified parent context outside the source directory.
- Regression coverage includes multiple internal reads, successive Function invocations, absent parent, and explicit turn override.
- Live cross-service execution and persistence validation remain pending deployment.

---

## Risk & Rollback

- Potential risks: The companion Foundry change and rebuilt sandbox images are required to inject the parent environment variable. Old hosts continue to send no parent.
- Rollback plan: Revert this commit and restore the previous sandbox SDK dependency pin. No historical data changes are required.

---

## Additional Notes

- Companion Foundry PR: https://github.com/openbkn-ai/bkn-foundry/pull/1321. It pins the sandbox dependency to this commit. Merge this SDK PR first; if review changes the final SDK commit, update the Foundry pin before merging.
- Design and validation: `docs/exec-plans/active/2026-09-05-function-trace-parent.md`.
- No deployment performed.
