### PR TITLE
feat(sdk): validate DataProperty mask rules before push

### DIFF
--- a/docs/exec-plans/completed/2026-09-06-data-property-mask-rule.md
+++ b/docs/exec-plans/completed/2026-09-06-data-property-mask-rule.md
@@ -1,0 +1,11 @@
+# DataProperty mask-rule implementation plan
+
+Date: 2026-09-06
+Status: completed
+
+1. Added and exported the discriminated mask-rule contract and DataProperty type.
+2. Added parsing and validation for optional `Mask Rule` JSON cells in object-type `.bkn` files.
+3. Made `kn.push` fail locally before network I/O when validation fails.
+4. Added focused Vitest coverage for every kind, boundaries, Unicode, invalid JSON, type mismatch, legacy files, and push preflight behavior.
+5. Updated the knowledge-network product spec.
+6. Verified with `npm run lint`, focused Vitest tests, the full test suite with two workers, and `npm run build`.

--- a/docs/product-specs/knowledge-networks.md
+++ b/docs/product-specs/knowledge-networks.md
@@ -16,6 +16,14 @@ Work with Business Knowledge Networks: list/inspect networks, query their schema
 - `openbkn bkn get <id>` — one network, summary + schema pointers.
 - `openbkn bkn query <id> ...` — query object types / instances (default limit 50).
 - `openbkn bkn push <dir>` / `openbkn bkn pull <id>` — upload/download a BKN package; optional encoding detection (`--no-detect-encoding`, `--source-encoding`).
+- An object type's `### Data Properties` table may include an optional `Mask Rule`
+  column containing one compact JSON object. The supported discriminated rules
+  are `fixed`, `partial`, and `email` for string-like properties; `round` for
+  numeric properties; and `date_granularity` for date/time properties. Legacy
+  tables without this column remain valid.
+- `bkn push` validates mask-rule JSON, required parameters, bounds, property-type
+  compatibility, and kind-specific fields before packaging or making a network
+  request. `bkn pull` preserves the `.bkn` payload unchanged.
 - When the lifecycle catalog requires `conversation_mode`, managed retrieval
   sends `new` without a conversation ID or `continue` with one. If that
   handshake fails, the SDK surfaces the lifecycle error and does not send an

--- a/docs/superpowers/specs/2026-09-06-data-property-mask-rule-design.md
+++ b/docs/superpowers/specs/2026-09-06-data-property-mask-rule-design.md
@@ -1,0 +1,25 @@
+# DataProperty mask-rule SDK design
+
+Date: 2026-09-06
+
+## Intent
+
+Expose the optional, strongly typed DataProperty `mask_rule` contract and make local `.bkn` validation reject invalid rules before upload. The accepted platform design remains the source of truth: [bkn-foundry#1314](https://github.com/openbkn-ai/bkn-foundry/issues/1314), implemented by [bkn-foundry#1343](https://github.com/openbkn-ai/bkn-foundry/issues/1343).
+
+## Chosen representation
+
+- Export a discriminated TypeScript union keyed by `kind` for `fixed`, `partial`, `email`, `round`, and `date_granularity`.
+- Represent the optional `.bkn` table field as compact JSON in a `Mask Rule` column. JSON keeps the wire names and value types identical to REST; the backend export escapes table delimiters inside JSON strings.
+- Validate the JSON shape, property-type compatibility, Unicode replacement length/printability, and numeric/date bounds offline.
+- Run the same offline validation inside SDK `push` before creating the tar or sending a request.
+
+## Compatibility
+
+The column and REST field are optional. Existing `.bkn` directories and object types without `mask_rule` remain valid and round-trip unchanged. Logic properties are not extended.
+
+## Affected layers
+
+- `types.ts`: public mask-rule and DataProperty types.
+- `utils/bkn-validate.ts`: `.bkn` table parsing and rule validation.
+- `resources/knowledge-networks.ts`: preflight validation before push.
+- Unit tests and knowledge-network product documentation.

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,17 @@
  * No external side effects on import; required runtime APIs are validated synchronously.
  */
 export { createClient, type BknClient } from "./client.js";
-export type { ClientOptions, RequestContext } from "./types.js";
+export type {
+  ClientOptions,
+  DataPropertyDefinition,
+  DataPropertyMaskRule,
+  DateGranularityMaskRule,
+  EmailMaskRule,
+  FixedMaskRule,
+  PartialMaskRule,
+  RequestContext,
+  RoundMaskRule,
+} from "./types.js";
 export { DEFAULT_LIST_LIMIT, DEFAULT_QUERY_LIMIT } from "./types.js";
 export { HttpError, InputError, NonJsonResponseError, ToolError } from "./utils/errors.js";
 // The shape `kn.createFromCatalog` stamps onto a failure

--- a/src/resources/knowledge-networks.ts
+++ b/src/resources/knowledge-networks.ts
@@ -64,6 +64,8 @@ import { configureResourceIndex } from "../api/resources.js";
 import { createBuildTask } from "../api/vega.js";
 import type { RequestContext } from "../types.js";
 import { collectIndexTargets } from "../utils/bkn-index.js";
+import { validateBknDirectory } from "../utils/bkn-validate.js";
+import { InputError } from "../utils/errors.js";
 import { extractTarToDirectory, packDirectoryToTar } from "../utils/tar.js";
 import { type CreateFromCatalogOptions, createFromCatalog } from "./bkn-create.js";
 
@@ -145,6 +147,10 @@ export function kn(ctx: RequestContext) {
       dir: string,
       opts?: { branch?: string; build?: boolean; embeddingModel?: string },
     ) => {
+      const validation = validateBknDirectory(dir);
+      if (!validation.valid) {
+        throw new InputError(`BKN validation failed:\n${validation.errors.join("\n")}`);
+      }
       const upload = await uploadBkn(ctx, packDirectoryToTar(dir), { branch: opts?.branch });
       if (!opts?.build) return upload;
       const targets = collectIndexTargets(dir);

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,6 +114,59 @@ export interface TraceContext {
   baggage?: Record<string, string>;
 }
 
+export interface FixedMaskRule {
+  kind: "fixed";
+  replacement: string;
+}
+
+export interface PartialMaskRule {
+  kind: "partial";
+  keep_start: number;
+  keep_end: number;
+  replacement: string;
+}
+
+export interface EmailMaskRule {
+  kind: "email";
+  local_keep_start: number;
+  preserve_domain: boolean;
+  replacement: string;
+}
+
+export interface RoundMaskRule {
+  kind: "round";
+  step: number;
+}
+
+export interface DateGranularityMaskRule {
+  kind: "date_granularity";
+  granularity: "year" | "month" | "day" | "hour";
+}
+
+/** Optional masking contract carried by a DataProperty definition. */
+export type DataPropertyMaskRule =
+  | FixedMaskRule
+  | PartialMaskRule
+  | EmailMaskRule
+  | RoundMaskRule
+  | DateGranularityMaskRule;
+
+/** REST/SDK representation of an object type data property. */
+export interface DataPropertyDefinition {
+  name: string;
+  display_name: string;
+  type: string;
+  comment?: string;
+  mapped_field?: {
+    name: string;
+    type?: string;
+    display_name?: string;
+    comment?: string;
+  };
+  mask_rule?: DataPropertyMaskRule;
+  condition_operations?: string[];
+}
+
 /** Default list/query limits — see AGENTS.md conventions. */
 export const DEFAULT_LIST_LIMIT = 30;
 export const DEFAULT_QUERY_LIMIT = 50;

--- a/src/utils/bkn-validate.ts
+++ b/src/utils/bkn-validate.ts
@@ -192,7 +192,7 @@ function validateDataPropertyMaskRules(text: string, rel: string): string[] {
     const rawRule = row["Mask Rule"]?.trim();
     if (!rawRule) continue;
     const propertyName = row.Name?.trim() || "<unnamed>";
-    const propertyType = row.Type?.trim() || "";
+    const propertyType = row.Type?.trim().toLowerCase() || "";
     let parsed: DataPropertyMaskRule;
     try {
       parsed = JSON.parse(rawRule) as DataPropertyMaskRule;

--- a/src/utils/bkn-validate.ts
+++ b/src/utils/bkn-validate.ts
@@ -10,6 +10,7 @@
  */
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
+import type { DataPropertyMaskRule } from "../types.js";
 
 // validateObjectName parity: ISF caps BKN object names at 40 utf-8 codepoints.
 export const BKN_OBJECT_NAME_MAX_LENGTH = 40;
@@ -27,6 +28,22 @@ interface Frontmatter {
   id?: string;
   name?: string;
 }
+
+interface DataPropertyRow {
+  Name?: string;
+  Type?: string;
+  "Mask Rule"?: string;
+}
+
+const STRING_MASK_TYPES = new Set(["string", "text", "keyword"]);
+const NUMBER_MASK_TYPES = new Set(["integer", "unsigned integer", "float", "decimal"]);
+const DATE_MASK_GRANULARITIES: Readonly<Record<string, ReadonlySet<string>>> = {
+  date: new Set(["year", "month"]),
+  time: new Set(["hour"]),
+  datetime: new Set(["year", "month", "day", "hour"]),
+  timestamp: new Set(["year", "month", "day", "hour"]),
+};
+const PRINTABLE_CODE_POINT = /^[\p{L}\p{M}\p{N}\p{P}\p{S}\p{Zs}]$/u;
 
 /** Parse a leading `--- ... ---` YAML-ish frontmatter block (flat scalars only). */
 function parseFrontmatter(text: string): Frontmatter | null {
@@ -47,6 +64,148 @@ function bknFiles(dir: string): string[] {
   return readdirSync(dir)
     .filter((f) => f.endsWith(".bkn"))
     .map((f) => join(dir, f));
+}
+
+function markdownSection(text: string, heading: string): string | undefined {
+  const pattern = new RegExp(`^###\\s+${heading}\\s*$`, "m");
+  const match = pattern.exec(text);
+  if (!match) return undefined;
+  const after = text.slice(match.index + match[0].length);
+  const next = /^###\s+/m.exec(after);
+  return next ? after.slice(0, next.index) : after;
+}
+
+function markdownTable(section: string): Array<Record<string, string>> {
+  const lines = section
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("|"));
+  if (lines.length < 2) return [];
+
+  const split = (line: string): string[] =>
+    line
+      .replace(/^\|/, "")
+      .replace(/\|$/, "")
+      .split("|")
+      .map((cell) => cell.trim());
+  const headers = split(lines[0] ?? "");
+  const divider = /^:?-+:?$/;
+  const dataStart = split(lines[1] ?? "").every((cell) => divider.test(cell)) ? 2 : 1;
+
+  return lines.slice(dataStart).map((line) => {
+    const cells = split(line);
+    return Object.fromEntries(headers.map((header, index) => [header, cells[index] ?? ""]));
+  });
+}
+
+function expectKeys(rule: Record<string, unknown>, allowed: readonly string[]): string | undefined {
+  const allowedSet = new Set(["kind", ...allowed]);
+  const unknown = Object.keys(rule).find((key) => !allowedSet.has(key));
+  return unknown ? `unknown field '${unknown}'` : undefined;
+}
+
+function replacementError(value: unknown): string | undefined {
+  if (typeof value !== "string") return "replacement must be a string";
+  const codePoints = [...value];
+  if (codePoints.length < 1 || codePoints.length > 8) {
+    return "replacement must contain 1 to 8 Unicode code points";
+  }
+  if (!codePoints.every((codePoint) => PRINTABLE_CODE_POINT.test(codePoint))) {
+    return "replacement must contain only printable Unicode code points";
+  }
+  return undefined;
+}
+
+function boundedIntegerError(name: string, value: unknown): string | undefined {
+  if (!Number.isInteger(value) || (value as number) < 0 || (value as number) > 64) {
+    return `${name} must be an integer between 0 and 64`;
+  }
+  return undefined;
+}
+
+function incompatible(kind: string, propertyType: string): string {
+  return `mask rule kind '${kind}' does not support property type '${propertyType}'`;
+}
+
+function validateMaskRule(propertyType: string, value: unknown): string | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return "Mask Rule must be a JSON object";
+  }
+  const rule = value as Record<string, unknown>;
+  const kind = rule.kind;
+  if (typeof kind !== "string") return "kind is required and must be a string";
+
+  let error: string | undefined;
+  switch (kind) {
+    case "fixed":
+      if (!STRING_MASK_TYPES.has(propertyType)) return incompatible(kind, propertyType);
+      return expectKeys(rule, ["replacement"]) ?? replacementError(rule.replacement);
+    case "partial":
+      if (!STRING_MASK_TYPES.has(propertyType)) return incompatible(kind, propertyType);
+      error = expectKeys(rule, ["keep_start", "keep_end", "replacement"]);
+      if (error) return error;
+      return (
+        boundedIntegerError("keep_start", rule.keep_start) ??
+        boundedIntegerError("keep_end", rule.keep_end) ??
+        replacementError(rule.replacement)
+      );
+    case "email":
+      if (!STRING_MASK_TYPES.has(propertyType)) return incompatible(kind, propertyType);
+      error = expectKeys(rule, ["local_keep_start", "preserve_domain", "replacement"]);
+      if (error) return error;
+      if (typeof rule.preserve_domain !== "boolean") {
+        return "preserve_domain is required and must be a boolean";
+      }
+      return (
+        boundedIntegerError("local_keep_start", rule.local_keep_start) ??
+        replacementError(rule.replacement)
+      );
+    case "round":
+      if (!NUMBER_MASK_TYPES.has(propertyType)) return incompatible(kind, propertyType);
+      error = expectKeys(rule, ["step"]);
+      if (error) return error;
+      if (typeof rule.step !== "number" || !Number.isFinite(rule.step) || rule.step <= 0) {
+        return "step must be a finite number greater than 0";
+      }
+      return undefined;
+    case "date_granularity": {
+      const granularities = DATE_MASK_GRANULARITIES[propertyType];
+      if (!granularities) return incompatible(kind, propertyType);
+      error = expectKeys(rule, ["granularity"]);
+      if (error) return error;
+      if (typeof rule.granularity !== "string" || !granularities.has(rule.granularity)) {
+        return `granularity '${String(rule.granularity ?? "")}' is not coarser than property type '${propertyType}'`;
+      }
+      return undefined;
+    }
+    default:
+      return `unsupported mask rule kind '${kind}'`;
+  }
+}
+
+function validateDataPropertyMaskRules(text: string, rel: string): string[] {
+  const section = markdownSection(text, "Data Properties");
+  if (!section) return [];
+
+  const errors: string[] = [];
+  for (const row of markdownTable(section) as DataPropertyRow[]) {
+    const rawRule = row["Mask Rule"]?.trim();
+    if (!rawRule) continue;
+    const propertyName = row.Name?.trim() || "<unnamed>";
+    const propertyType = row.Type?.trim() || "";
+    let parsed: DataPropertyMaskRule;
+    try {
+      parsed = JSON.parse(rawRule) as DataPropertyMaskRule;
+    } catch (cause) {
+      const detail = cause instanceof Error ? cause.message : String(cause);
+      errors.push(`${rel}: data property '${propertyName}' has invalid Mask Rule JSON: ${detail}`);
+      continue;
+    }
+    const error = validateMaskRule(propertyType, parsed);
+    if (error)
+      errors.push(`${rel}: data property '${propertyName}' has invalid Mask Rule: ${error}.`);
+  }
+  return errors;
 }
 
 /** Pull (source, target) object-type ids out of a relation file's Endpoint table. */
@@ -106,7 +265,8 @@ export function validateBknDirectory(dirPath: string): ValidationResult {
   const otIds = new Set<string>();
   const otFiles = bknFiles(join(dir, "object_types"));
   for (const file of otFiles) {
-    const fm = parseFrontmatter(readFileSync(file, "utf8"));
+    const text = readFileSync(file, "utf8");
+    const fm = parseFrontmatter(text);
     const rel = file.slice(dir.length + 1);
     if (!fm || fm.type !== "object_type") {
       errors.push(`${rel}: not a valid object_type (missing/wrong frontmatter type).`);
@@ -123,6 +283,7 @@ export function validateBknDirectory(dirPath: string): ValidationResult {
       if (otIds.has(fm.id)) errors.push(`Duplicate object_type id '${fm.id}'.`);
       otIds.add(fm.id);
     }
+    errors.push(...validateDataPropertyMaskRules(text, rel));
   }
 
   // Relation types — validate frontmatter + endpoint references.

--- a/test/unit/bkn-validate.test.ts
+++ b/test/unit/bkn-validate.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { markVersionCompatibleForTest } from "../../src/api/version-check.js";
 import { kn } from "../../src/resources/knowledge-networks.js";
 import type { RequestContext } from "../../src/types.js";
 import { validateBknDirectory } from "../../src/utils/bkn-validate.js";
@@ -33,6 +34,15 @@ const otWithMaskRules = (rows: Array<[string, string, string]>) => `${ot("a", "A
 | Name | Display Name | Type | Description | Mapped Field | Mask Rule |
 |------|--------------|------|-------------|--------------|-----------|
 ${rows.map(([name, type, rule]) => `| ${name} | ${name} | ${type} | | ${name} | ${rule} |`).join("\n")}
+`;
+const legacyOtWithoutMaskRule = `${ot("a", "Alpha")}
+## ObjectType: Alpha
+
+### Data Properties
+
+| Name | Display Name | Type | Description | Mapped Field |
+|------|--------------|------|-------------|--------------|
+| secret | Secret | String | | secret |
 `;
 
 describe("bkn validate", () => {
@@ -85,7 +95,7 @@ describe("bkn validate", () => {
     const dir = bkn({
       "network.bkn": network,
       "object_types/a.bkn": otWithMaskRules([
-        ["secret", "string", `{"kind":"fixed","replacement":"保密🔒"}`],
+        ["secret", "String", `{"kind":"fixed","replacement":"保密"}`],
         [
           "account",
           "keyword",
@@ -97,7 +107,7 @@ describe("bkn validate", () => {
           `{"kind":"email","local_keep_start":64,"preserve_domain":false,"replacement":"●"}`,
         ],
         ["amount", "decimal", `{"kind":"round","step":0.000001}`],
-        ["created_at", "timestamp", `{"kind":"date_granularity","granularity":"day"}`],
+        ["created_at", "DATETIME", `{"kind":"date_granularity","granularity":"day"}`],
       ]),
     });
 
@@ -142,5 +152,29 @@ describe("bkn validate", () => {
 
     await expect(kn(ctx).push(dir)).rejects.toBeInstanceOf(InputError);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("allows a legacy package without a Mask Rule column to reach upload", async () => {
+    const dir = bkn({
+      "network.bkn": network,
+      "object_types/a.bkn": legacyOtWithoutMaskRule,
+    });
+    const fetchMock = vi.fn(
+      async (_url: string | URL, _init?: RequestInit) =>
+        new Response('{"id":"kn1"}', { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const ctx: RequestContext = {
+      baseUrl: "https://demo.example.com",
+      token: "token",
+      insecure: false,
+    };
+    markVersionCompatibleForTest(ctx);
+
+    await expect(kn(ctx).push(dir)).resolves.toEqual({ id: "kn1" });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const uploadUrl = fetchMock.mock.calls[0]?.[0];
+    expect(uploadUrl).toBeDefined();
+    expect(new URL(uploadUrl as string | URL).pathname).toBe("/api/bkn-backend/v1/bkns");
   });
 });

--- a/test/unit/bkn-validate.test.ts
+++ b/test/unit/bkn-validate.test.ts
@@ -1,8 +1,11 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { kn } from "../../src/resources/knowledge-networks.js";
+import type { RequestContext } from "../../src/types.js";
 import { validateBknDirectory } from "../../src/utils/bkn-validate.js";
+import { InputError } from "../../src/utils/errors.js";
 
 const temps: string[] = [];
 function bkn(files: Record<string, string>): string {
@@ -17,9 +20,20 @@ function bkn(files: Record<string, string>): string {
 }
 afterEach(() => {
   for (const d of temps.splice(0)) rmSync(d, { recursive: true, force: true });
+  vi.unstubAllGlobals();
 });
 
 const ot = (id: string, name: string) => `---\ntype: object_type\nid: ${id}\nname: ${name}\n---\n`;
+const network = "---\ntype: knowledge_network\nid: kn1\nname: KN One\n---\n";
+const otWithMaskRules = (rows: Array<[string, string, string]>) => `${ot("a", "Alpha")}
+## ObjectType: Alpha
+
+### Data Properties
+
+| Name | Display Name | Type | Description | Mapped Field | Mask Rule |
+|------|--------------|------|-------------|--------------|-----------|
+${rows.map(([name, type, rule]) => `| ${name} | ${name} | ${type} | | ${name} | ${rule} |`).join("\n")}
+`;
 
 describe("bkn validate", () => {
   it("accepts a well-formed network", () => {
@@ -65,5 +79,68 @@ describe("bkn validate", () => {
     const r = validateBknDirectory(dir);
     expect(r.valid).toBe(true); // unknown endpoint is a warning, not an error
     expect(r.warnings.some((w) => w.includes("ghost"))).toBe(true);
+  });
+
+  it("accepts every supported mask-rule kind and Unicode boundaries", () => {
+    const dir = bkn({
+      "network.bkn": network,
+      "object_types/a.bkn": otWithMaskRules([
+        ["secret", "string", `{"kind":"fixed","replacement":"保密🔒"}`],
+        [
+          "account",
+          "keyword",
+          `{"kind":"partial","keep_start":0,"keep_end":64,"replacement":"\\u007c"}`,
+        ],
+        [
+          "email",
+          "text",
+          `{"kind":"email","local_keep_start":64,"preserve_domain":false,"replacement":"●"}`,
+        ],
+        ["amount", "decimal", `{"kind":"round","step":0.000001}`],
+        ["created_at", "timestamp", `{"kind":"date_granularity","granularity":"day"}`],
+      ]),
+    });
+
+    expect(validateBknDirectory(dir).errors).toEqual([]);
+  });
+
+  it.each([
+    ["malformed JSON", "string", "{"],
+    ["unknown kind", "string", `{"kind":"regex","replacement":"*"}`],
+    ["unknown field", "string", `{"kind":"fixed","replacement":"*","keep_strat":1}`],
+    ["type mismatch", "boolean", `{"kind":"fixed","replacement":"*"}`],
+    ["keep bound", "string", `{"kind":"partial","keep_start":65,"keep_end":0,"replacement":"*"}`],
+    ["non-printable replacement", "string", JSON.stringify({ kind: "fixed", replacement: "\n" })],
+    ["round step", "integer", `{"kind":"round","step":0}`],
+    ["date precision", "date", `{"kind":"date_granularity","granularity":"day"}`],
+    ["unsupported property type", "vector", `{"kind":"fixed","replacement":"*"}`],
+  ])("rejects an invalid mask rule: %s", (_name, type, rule) => {
+    const dir = bkn({
+      "network.bkn": network,
+      "object_types/a.bkn": otWithMaskRules([["secret", type, rule]]),
+    });
+
+    const result = validateBknDirectory(dir);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((error) => error.includes("data property 'secret'"))).toBe(true);
+  });
+
+  it("rejects an invalid mask rule before push performs network I/O", async () => {
+    const dir = bkn({
+      "network.bkn": network,
+      "object_types/a.bkn": otWithMaskRules([
+        ["secret", "json", `{"kind":"fixed","replacement":"*"}`],
+      ]),
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const ctx: RequestContext = {
+      baseUrl: "https://demo.example.com",
+      token: "token",
+      insecure: false,
+    };
+
+    await expect(kn(ctx).push(dir)).rejects.toBeInstanceOf(InputError);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Added and exported a strongly typed DataProperty mask_rule union for fixed, partial, email, round, and date_granularity rules.
- [x] Added offline .bkn validation for rule JSON shape, property-type compatibility, Unicode and numeric bounds, and kind-specific fields.
- [x] Made kn.push fail before archive creation or network I/O when a package contains an invalid masking rule, while preserving legacy packages without the optional column.

---

## Why

- Related Issue: Closes openbkn-ai/bkn-foundry#1343
- Related Feature: [Property-level authorization and server-side dynamic masking](https://github.com/openbkn-ai/bkn-foundry/issues/1314)
- Background: SDK callers and .bkn workflows need the same typed masking contract and write-time validation as bkn-backend so invalid rules never reach model upload.

---

## How

- Key implementation points:
  - Exposes a discriminated TypeScript union and DataProperty definition through the public SDK entry point.
  - Parses the optional Mask Rule JSON cell from Data Properties tables and validates all five rule kinds locally.
  - Reuses directory validation as a preflight in the programmatic kn.push path before packaging and upload.
  - Documents the optional column and keeps pull behavior byte-preserving.
- Breaking changes (API, config, database, etc.): None. The field and .bkn column are optional; existing packages remain valid. Invalid packages that bkn-backend would reject now fail earlier on push.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — N/A; validation and push preflight are covered with hermetic unit tests and mocked network I/O.
- [ ] Verified in test environment — N/A; no deployment or environment mutation was required.

Test notes:

- npm run lint
- NODE_OPTIONS=--max-old-space-size=2560 npm test -- --maxWorkers=2 — 654 passed, 1 skipped.
- NODE_OPTIONS=--max-old-space-size=3072 npm run build
- git diff --check

---

## Risk & Rollback

- Potential risks: The local Markdown-table parser must remain aligned with bkn-backend's optional Mask Rule JSON representation. Focused tests cover all supported kinds, invalid JSON, unknown fields, type mismatches, Unicode boundaries, legacy tables, and the no-network-on-failure guarantee.
- Rollback plan: Revert this commit. No persisted data, configuration, or server contract is changed by this repository.

---

## Additional Notes

- Companion backend implementation: [openbkn-ai/bkn-foundry branch](https://github.com/openbkn-ai/bkn-foundry/tree/feature/1343-data-property-mask-rule).
- Runtime masking is intentionally out of scope; this change defines and validates the model contract only.
