### PR TITLE
feat(sdk, cli): move off find_skills to search_capabilities

### DIFF
--- a/docs/design-docs/cli-command-design.md
+++ b/docs/design-docs/cli-command-design.md
@@ -28,7 +28,7 @@ openbkn
   resource  (res)  list | find | get | query | delete
   vega      health | stats | inspect | catalog | resource | dataset | query | sql | connector-type
   context   (context-loader)  search-schema | query-object-instance | query-instance-subgraph
-            | get-logic-properties | get-action-info | find-skills | tools | resources | resource
+            | get-logic-properties | get-action-info | search-capabilities | tools | resources | resource
             | templates | prompts | prompt | tool-call [--receipt --json]
 
   # models, skills, trace

--- a/docs/superpowers/specs/2026-08-11-python-osdk-design.md
+++ b/docs/superpowers/specs/2026-08-11-python-osdk-design.md
@@ -529,7 +529,7 @@ Three emission rules:
   two APIs for one capability.
 
 What remains is genuine net gain: `run_sql`, `search_schema`, `describe_resource`,
-`list_resources`, `find_skills`, `get_action_info`, `execute_action`, `get_skill_content`,
+`list_resources`, `search_capabilities`, `get_action_info`, `execute_action`, `get_skill_content`,
 `execute_skill`, `list_action_executions`.
 
 This does not contradict [What the Python side does not replicate](#what-the-python-side-does-not-replicate).

--- a/python/README.md
+++ b/python/README.md
@@ -386,9 +386,9 @@ than read a stale attribute.
 ## Not in this release
 
 Writes and action execution, aggregation over an object set (no endpoint exists —
-see above), typed wrappers for the rest of the catalog's tools — `find_skills`,
-`describe_resource`, `query_instance_subgraph` and the others reachable today
-only through `call_tool` — an async client, and offline generation from a local
+see above), typed wrappers for the catalog's MCP-only tools — the lifecycle
+pair and the sandbox tools, reachable today only through `call_tool` — an async
+client, and offline generation from a local
 `.bkn` directory. Each has a section in
 [the design](../docs/superpowers/specs/2026-08-11-python-osdk-design.md)
 describing the shape it takes when it lands.

--- a/python/README.zh.md
+++ b/python/README.zh.md
@@ -268,7 +268,7 @@ kn.query_object_instance(KN_ID, "order", limit=10, response_format="json")
 
 ## 这个版本没有的
 
-写入与行动执行、对象集上的聚合（没有对应端点，见上）、catalog 里其余工具的类型化包装 —— `find_skills`、`describe_resource`、`query_instance_subgraph` 等目前只能通过 `call_tool` 触达 —— 异步客户端，以及从本地 `.bkn` 目录离线生成。每一项在[设计文档](../docs/superpowers/specs/2026-08-11-python-osdk-design.md)里都有一节，写明它落地时会长成什么样。
+写入与行动执行、对象集上的聚合（没有对应端点，见上）、catalog 里只走 MCP 的那些工具的类型化包装 —— 生命周期两条与沙箱工具，目前只能通过 `call_tool` 触达 —— 异步客户端，以及从本地 `.bkn` 目录离线生成。每一项在[设计文档](../docs/superpowers/specs/2026-08-11-python-osdk-design.md)里都有一节，写明它落地时会长成什么样。
 
 ## 开发
 

--- a/python/bkn_osdk/codegen/kn_rest.py
+++ b/python/bkn_osdk/codegen/kn_rest.py
@@ -128,8 +128,14 @@ def _function(op: dict[str, Any]) -> str:
         signature += [
             f"{_safe(f['name'])}: {ANNOTATION[f['type']]} | None = None" for f in optional
         ]
-    trailing = "context: Context | None = None"
-    signature.append(trailing if optional else f"*, {trailing}")
+    # The keyword-only marker is always its own line. Folding it onto `context` reads fine until
+    # a route has no optional fields at all — `execute_tool` is the first — and then the emitter
+    # produces `*, context: ...` on one line, which `ruff format` splits. The generated file is
+    # asserted to be exactly what the generator produces, so an emitter that disagrees with the
+    # formatter cannot be fixed by formatting the file.
+    if not optional:
+        signature.append("*")
+    signature.append("context: Context | None = None")
 
     def mapping(fields: list[dict[str, Any]]) -> str:
         if not fields:

--- a/python/bkn_osdk/kn.py
+++ b/python/bkn_osdk/kn.py
@@ -24,8 +24,8 @@ __all__ = [
     "describe_resource",
     "execute_action",
     "execute_skill",
+    "execute_tool",
     "explore_subgraph",
-    "find_skills",
     "get_action_execution",
     "get_action_info",
     "get_kn_detail",
@@ -42,6 +42,7 @@ __all__ = [
     "query_object_instance",
     "read_skill_file",
     "run_sql",
+    "search_capabilities",
     "search_instance",
     "search_schema",
 ]
@@ -165,6 +166,7 @@ def execute_skill(
     仍被识别，用于兼容已按旧名配置的部署。）
 
     Args:
+        kn_id: 知识网络 ID。Skill 必须已挂载到该网络才能读取/执行，未挂载返回 400。
         entry_shell: 沙箱内执行的入口命令，取自 SKILL.md 声明的入口。技能包已解压到工作目录，
             命令相对该目录执行。
         timeout: 执行超时秒数。
@@ -177,9 +179,48 @@ def execute_skill(
         kn_id,
         {},
         {
+            "kn_id": kn_id,
             "skill_id": skill_id,
             "entry_shell": entry_shell,
             "timeout": timeout,
+        },
+        context,
+    )
+
+
+def execute_tool(
+    kn_id: str,
+    toolbox_id: str,
+    tool_id: str,
+    arguments: dict[str, Any],
+    *, context: Context | None = None,
+) -> Any:
+    """执行一个已发布函数工具.
+
+    以调用者身份执行工具，返回工具的原始响应。 `toolbox_id` 与 `tool_id` 必须取自
+    `search_capabilities`（`owner_id` / `capability_id`）；`arguments` 按其返回的
+    `input_schema` 填，只放业务参数——令牌、会话 id 等传输信息由平台携带，写进 `arguments`
+    既不生效也会被记进调用参数。 **函数自身报错同样是
+    200**：调用成功不等于业务成功，需读响应体判断。
+    工具已停用、所属工具箱未发布，或当前账户无权访问时返回 400，`message` 说明原因，
+    请求不会打到执行代理。
+
+    Args:
+        kn_id: 知识网络 ID，须与 `search_capabilities` 所用一致。工具必须已挂载到该网络才可调用。
+        toolbox_id: 工具箱 ID，取自 `search_capabilities` 的 `owner_id`。
+        tool_id: 工具 ID，取自 `search_capabilities` 的 `capability_id`。
+        arguments: 工具的业务入参，按 `search_capabilities` 返回的 `input_schema` 填写。
+
+    """
+    return _send(
+        "/api/agent-retrieval/v1/kn/execute_tool",
+        kn_id,
+        {},
+        {
+            "kn_id": kn_id,
+            "toolbox_id": toolbox_id,
+            "tool_id": tool_id,
+            "arguments": arguments,
         },
         context,
     )
@@ -259,60 +300,6 @@ def explore_subgraph(
             "sort": sort,
             "offset": offset,
             "search_after": search_after,
-        },
-        context,
-    )
-
-
-def find_skills(
-    kn_id: str,
-    object_type_id: str,
-    *,
-    response_format: str | None = None,
-    instance_identities: list[Any] | None = None,
-    skill_query: str | None = None,
-    top_k: int | None = None,
-    context: Context | None = None,
-) -> Any:
-    """按业务上下文召回 Skill.
-
-    **召回模式由参数自动决定，不用显式指定**： | 传入参数 | 模式 | |---|---| | `kn_id` +
-    `object_type_id` | 对象类级：沿对象类与 `skills` 之间的关系路径召回 | | 再加
-    `instance_identities` | 实例级：从具体实例出发召回，并补充对象类级结果 | **`skill_query`
-    的检索方式随索引能力降级**：对 `skills` 实例的 `name` / `description` 追加文本过滤——BKN
-    已建向量索引时用 `knn`，已建全文索引时用 `match`，都没有时退化为 `like`。 `skills`
-    对象类至少要有 `skill_id` 与 `name` 两个数据属性，`description` 可选；不满足时返回 400
-    并在 `details` 里列出缺失属性。 **空结果是 200 不是错误**：没有匹配时返回 `entries:
-    []`，并可能带一个 `message` 说明为什么为空（如该对象类未绑定任何 Skill）以及下一步建议。
-
-    实测：网络没有绑定技能时返回 404
-    BknBackend.ObjectType.ObjectTypeNotFound(“对象类不存在”)。对象类是存在的，这个错误码指错了方向。
-
-    Args:
-        kn_id: 知识网络 ID。
-        object_type_id: 业务对象类 ID（取自 `search_schema` 返回的概念 ID）。必填，且必须存在于
-            该知识网络中。
-        instance_identities: 对象实例标识列表，**必须从 `query_object_instance` 或
-            `query_instance_subgraph` 结果里的 `_instance_identity`
-            取，不可自拼**。 传入即切换到实例级召回。
-        skill_query: Skill 语义过滤词，对 `skills` 实例的 `name` / `description` 追加文本过滤。
-            检索方式按索引能力降级：向量索引用 `knn`，全文索引用 `match`，否则 `like`。
-        top_k: 最多返回的 Skill 数量。
-
-    Returns the platform's own payload: entries, message.
-    """
-    return _send(
-        "/api/agent-retrieval/v1/kn/find_skills",
-        kn_id,
-        {
-            "response_format": response_format,
-        },
-        {
-            "kn_id": kn_id,
-            "object_type_id": object_type_id,
-            "instance_identities": instance_identities,
-            "skill_query": skill_query,
-            "top_k": top_k,
         },
         context,
     )
@@ -524,7 +511,9 @@ def get_skill_content(
     说明。
 
     Args:
-        skill_id: Skill ID，取自 `find_skills` 或 `list_skills`。
+        kn_id: 知识网络 ID。Skill 必须已挂载到该网络才能读取/执行，未挂载返回 400。
+        skill_id: Skill ID。取自 `search_capabilities`（当前网络已挂载的）或
+            `list_skills`（平台目录， 未必已挂载到本网络）。
 
     Returns the platform's own payload: content, files, message, skill_id, status, truncated.
     """
@@ -535,6 +524,7 @@ def get_skill_content(
             "response_format": response_format,
         },
         {
+            "kn_id": kn_id,
             "skill_id": skill_id,
         },
         context,
@@ -689,9 +679,10 @@ def list_skills(
 ) -> Any:
     """浏览已发布 Skill.
 
-    翻已发布 Skill 列表，不需要知识网络上下文。与 `find_skills` 互补：那条按对象类 /
-    实例召回，这条按名称或分类分页浏览。 只返回**已发布**状态的 Skill；草稿态不出现在这里。
-    **空结果是 200 不是错误**：无匹配时 `entries: []` 并带 `message` 说明。
+    翻已发布 Skill 列表，不需要知识网络上下文。与 `search_capabilities` 互补：那条在
+    某个网络已挂载的能力里按相关度召回，这条按名称或分类分页浏览整个平台目录。
+    只返回**已发布**状态的 Skill；草稿态不出现在这里。 **空结果是 200 不是错误**：无匹配时
+    `entries: []` 并带 `message` 说明。
 
     Args:
         name: 按 Skill 名称模糊过滤。
@@ -972,6 +963,7 @@ def read_skill_file(
     5 MiB 返回 413。
 
     Args:
+        kn_id: 知识网络 ID。Skill 必须已挂载到该网络才能读取/执行，未挂载返回 400。
         rel_path: 技能包内相对路径，取自 `get_skill_content` 的 `files[].rel_path`。 包外路径（含
             `../`）返回 400。
 
@@ -985,6 +977,7 @@ def read_skill_file(
             "response_format": response_format,
         },
         {
+            "kn_id": kn_id,
             "skill_id": skill_id,
             "rel_path": rel_path,
         },
@@ -1033,6 +1026,66 @@ def run_sql(
         {
             "sql": sql,
             "query_timeout": query_timeout,
+        },
+        context,
+    )
+
+
+def search_capabilities(
+    kn_id: str,
+    *,
+    response_format: str | None = None,
+    query: str | None = None,
+    types: list[Any] | None = None,
+    metadata_types: list[Any] | None = None,
+    owner_id: str | None = None,
+    limit: int | None = None,
+    context: Context | None = None,
+) -> Any:
+    """检索该知识网络已挂载的全部能力.
+
+    在一个排序空间里返回该知识网络已挂载、且当前账户可见的能力：Skill、函数工具、 API 工具与
+    MCP 工具混排，按相关度给出，而不是每类一段。 每条带
+    `capability_type`，据此决定下一步：`function` 与 `mcp_tool` 用 `execute_tool`
+    调用（命中带裁剪过的 `input_schema`，只保留业务入参，服务地址等 传输信息不下发），`skill`
+    用 `get_skill_content` 读取、`execute_skill` 执行。 `types` 按能力类型收窄；函数工具还可用
+    `metadata_types` 再分 `openapi`（API 工具） 与
+    `function`。两者都只在挂载集内收窄，越不出去。 `limit` 默认 20、上限
+    100：工具类命中都带一份入参 schema，调大会显著占用上下文。 命中数超过 `limit` 时
+    `truncated=true` 并给出 `message`。 回填 schema
+    时单个工具箱取列表失败会跳过该箱而不是整体失败：一个被撤销或损坏的
+    工具箱不该让调用方看不到其余所有能力。 **不带 `query`
+    时成员集由挂载决定，不由索引决定**：没有查询词就没有要排序的东西，
+    此时按绑定顺序列出挂载集，索引只用来补名称、说明与 `metadata_type`，索引没收录
+
+    Args:
+        kn_id: 知识网络 ID。范围取自该网络的能力绑定；未挂载任何能力时返回空列表并给出提示。
+        query: 可选。在该网络已挂载的能力内按名称与说明排序。留空则按绑定顺序列出全部，
+            此时不依赖检索索引。
+        types: 可选。收窄到某几类能力，留空为全部。只在挂载集内收窄，越不出去。
+        metadata_types: 可选。把 `function` 类再分开：`openapi` 是 API 工具，`function` 是函数。
+            留空为两者都要。与 `types`
+            是并且关系。这一项只有检索索引答得出，索引不可用时
+            本接口报错，不会当作没传。
+        owner_id: 可选。只看某个来源：函数工具的工具箱、MCP 工具的 Server。Skill 没有来源，
+            传了这个就不会返回 Skill。取自本接口此前返回的 `owner_id`。
+        limit: 可选。最多返回多少条。工具类命中都带入参 schema。
+
+    Returns the platform's own payload: capabilities, message, total_matched, truncated.
+    """
+    return _send(
+        "/api/agent-retrieval/v1/kn/search_capabilities",
+        kn_id,
+        {
+            "response_format": response_format,
+        },
+        {
+            "kn_id": kn_id,
+            "query": query,
+            "types": types,
+            "metadata_types": metadata_types,
+            "owner_id": owner_id,
+            "limit": limit,
         },
         context,
     )

--- a/python/bkn_osdk/kn.py
+++ b/python/bkn_osdk/kn.py
@@ -193,7 +193,8 @@ def execute_tool(
     toolbox_id: str,
     tool_id: str,
     arguments: dict[str, Any],
-    *, context: Context | None = None,
+    *,
+    context: Context | None = None,
 ) -> Any:
     """执行一个已发布函数工具.
 

--- a/python/contracts/kn-rest.json
+++ b/python/contracts/kn-rest.json
@@ -96,6 +96,12 @@
       "query": [],
       "body": [
         {
+          "name": "kn_id",
+          "type": "string",
+          "required": true,
+          "description": "知识网络 ID。Skill 必须已挂载到该网络才能读取/执行，未挂载返回 400。"
+        },
+        {
           "name": "skill_id",
           "type": "string",
           "required": true,
@@ -127,6 +133,43 @@
         "work_dir"
       ],
       "source": "skill.yaml"
+    },
+    {
+      "path": "/api/agent-retrieval/v1/kn/execute_tool",
+      "method": "POST",
+      "operation": "execute_tool",
+      "summary": "执行一个已发布函数工具",
+      "description": "以调用者身份执行工具，返回工具的原始响应。 `toolbox_id` 与 `tool_id` 必须取自 `search_capabilities`（`owner_id` / `capability_id`）；`arguments` 按其返回的 `input_schema` 填，只放业务参数——令牌、会话 id 等传输信息由平台携带，写进 `arguments` 既不生效也会被记进调用参数。 **函数自身报错同样是 200**：调用成功不等于业务成功，需读响应体判断。 工具已停用、所属工具箱未发布，或当前账户无权访问时返回 400，`message` 说明原因， 请求不会打到执行代理。",
+      "query": [],
+      "body": [
+        {
+          "name": "kn_id",
+          "type": "string",
+          "required": true,
+          "description": "知识网络 ID，须与 `search_capabilities` 所用一致。工具必须已挂载到该网络才可调用。"
+        },
+        {
+          "name": "toolbox_id",
+          "type": "string",
+          "required": true,
+          "description": "工具箱 ID，取自 `search_capabilities` 的 `owner_id`。"
+        },
+        {
+          "name": "tool_id",
+          "type": "string",
+          "required": true,
+          "description": "工具 ID，取自 `search_capabilities` 的 `capability_id`。"
+        },
+        {
+          "name": "arguments",
+          "type": "object",
+          "required": true,
+          "description": "工具的业务入参，按 `search_capabilities` 返回的 `input_schema` 填写。"
+        }
+      ],
+      "declares_context": true,
+      "returns": [],
+      "source": "tool.yaml"
     },
     {
       "path": "/api/agent-retrieval/v1/kn/explore_subgraph",
@@ -240,64 +283,6 @@
         "total_count"
       ],
       "source": "instance-subgraph.yaml"
-    },
-    {
-      "path": "/api/agent-retrieval/v1/kn/find_skills",
-      "method": "POST",
-      "operation": "find_skills",
-      "note": "实测：网络没有绑定技能时返回 404 BknBackend.ObjectType.ObjectTypeNotFound(“对象类不存在”)。对象类是存在的，这个错误码指错了方向。",
-      "summary": "按业务上下文召回 Skill",
-      "description": "**召回模式由参数自动决定，不用显式指定**： | 传入参数 | 模式 | |---|---| | `kn_id` + `object_type_id` | 对象类级：沿对象类与 `skills` 之间的关系路径召回 | | 再加 `instance_identities` | 实例级：从具体实例出发召回，并补充对象类级结果 | **`skill_query` 的检索方式随索引能力降级**：对 `skills` 实例的 `name` / `description` 追加文本过滤——BKN 已建向量索引时用 `knn`，已建全文索引时用 `match`，都没有时退化为 `like`。 `skills` 对象类至少要有 `skill_id` 与 `name` 两个数据属性，`description` 可选；不满足时返回 400 并在 `details` 里列出缺失属性。 **空结果是 200 不是错误**：没有匹配时返回 `entries: []`，并可能带一个 `message` 说明为什么为空（如该对象类未绑定任何 Skill）以及下一步建议。",
-      "query": [
-        {
-          "name": "response_format",
-          "type": "string",
-          "required": false,
-          "description": "",
-          "enum": [
-            "json",
-            "toon"
-          ]
-        }
-      ],
-      "body": [
-        {
-          "name": "kn_id",
-          "type": "string",
-          "required": true,
-          "description": "知识网络 ID。"
-        },
-        {
-          "name": "object_type_id",
-          "type": "string",
-          "required": true,
-          "description": "业务对象类 ID（取自 `search_schema` 返回的概念 ID）。必填，且必须存在于 该知识网络中。"
-        },
-        {
-          "name": "instance_identities",
-          "type": "array",
-          "required": false,
-          "description": "对象实例标识列表，**必须从 `query_object_instance` 或 `query_instance_subgraph` 结果里的 `_instance_identity` 取，不可自拼**。 传入即切换到实例级召回。"
-        },
-        {
-          "name": "skill_query",
-          "type": "string",
-          "required": false,
-          "description": "Skill 语义过滤词，对 `skills` 实例的 `name` / `description` 追加文本过滤。 检索方式按索引能力降级：向量索引用 `knn`，全文索引用 `match`，否则 `like`。"
-        },
-        {
-          "name": "top_k",
-          "type": "integer",
-          "required": false,
-          "description": "最多返回的 Skill 数量。"
-        }
-      ],
-      "declares_context": true,
-      "returns": [
-        "entries",
-        "message"
-      ],
-      "source": "skill.yaml"
     },
     {
       "path": "/api/agent-retrieval/v1/kn/get_action_execution",
@@ -551,10 +536,16 @@
       ],
       "body": [
         {
+          "name": "kn_id",
+          "type": "string",
+          "required": true,
+          "description": "知识网络 ID。Skill 必须已挂载到该网络才能读取/执行，未挂载返回 400。"
+        },
+        {
           "name": "skill_id",
           "type": "string",
           "required": true,
-          "description": "Skill ID，取自 `find_skills` 或 `list_skills`。"
+          "description": "Skill ID。取自 `search_capabilities`（当前网络已挂载的）或 `list_skills`（平台目录， 未必已挂载到本网络）。"
         }
       ],
       "declares_context": true,
@@ -778,7 +769,7 @@
       "method": "POST",
       "operation": "list_skills",
       "summary": "浏览已发布 Skill",
-      "description": "翻已发布 Skill 列表，不需要知识网络上下文。与 `find_skills` 互补：那条按对象类 / 实例召回，这条按名称或分类分页浏览。 只返回**已发布**状态的 Skill；草稿态不出现在这里。 **空结果是 200 不是错误**：无匹配时 `entries: []` 并带 `message` 说明。",
+      "description": "翻已发布 Skill 列表，不需要知识网络上下文。与 `search_capabilities` 互补：那条在 某个网络已挂载的能力里按相关度召回，这条按名称或分类分页浏览整个平台目录。 只返回**已发布**状态的 Skill；草稿态不出现在这里。 **空结果是 200 不是错误**：无匹配时 `entries: []` 并带 `message` 说明。",
       "query": [
         {
           "name": "response_format",
@@ -1155,6 +1146,12 @@
       ],
       "body": [
         {
+          "name": "kn_id",
+          "type": "string",
+          "required": true,
+          "description": "知识网络 ID。Skill 必须已挂载到该网络才能读取/执行，未挂载返回 400。"
+        },
+        {
           "name": "skill_id",
           "type": "string",
           "required": true,
@@ -1220,6 +1217,71 @@
         "warnings"
       ],
       "source": "data-access.yaml"
+    },
+    {
+      "path": "/api/agent-retrieval/v1/kn/search_capabilities",
+      "method": "POST",
+      "operation": "search_capabilities",
+      "summary": "检索该知识网络已挂载的全部能力",
+      "description": "在一个排序空间里返回该知识网络已挂载、且当前账户可见的能力：Skill、函数工具、 API 工具与 MCP 工具混排，按相关度给出，而不是每类一段。 每条带 `capability_type`，据此决定下一步：`function` 与 `mcp_tool` 用 `execute_tool` 调用（命中带裁剪过的 `input_schema`，只保留业务入参，服务地址等 传输信息不下发），`skill` 用 `get_skill_content` 读取、`execute_skill` 执行。 `types` 按能力类型收窄；函数工具还可用 `metadata_types` 再分 `openapi`（API 工具） 与 `function`。两者都只在挂载集内收窄，越不出去。 `limit` 默认 20、上限 100：工具类命中都带一份入参 schema，调大会显著占用上下文。 命中数超过 `limit` 时 `truncated=true` 并给出 `message`。 回填 schema 时单个工具箱取列表失败会跳过该箱而不是整体失败：一个被撤销或损坏的 工具箱不该让调用方看不到其余所有能力。 **不带 `query` 时成员集由挂载决定，不由索引决定**：没有查询词就没有要排序的东西， 此时按绑定顺序列出挂载集，索引只用来补名称、说明与 `metadata_type`，索引没收录",
+      "query": [
+        {
+          "name": "response_format",
+          "type": "string",
+          "required": false,
+          "description": "",
+          "enum": [
+            "json",
+            "toon"
+          ]
+        }
+      ],
+      "body": [
+        {
+          "name": "kn_id",
+          "type": "string",
+          "required": true,
+          "description": "知识网络 ID。范围取自该网络的能力绑定；未挂载任何能力时返回空列表并给出提示。"
+        },
+        {
+          "name": "query",
+          "type": "string",
+          "required": false,
+          "description": "可选。在该网络已挂载的能力内按名称与说明排序。留空则按绑定顺序列出全部， 此时不依赖检索索引。"
+        },
+        {
+          "name": "types",
+          "type": "array",
+          "required": false,
+          "description": "可选。收窄到某几类能力，留空为全部。只在挂载集内收窄，越不出去。"
+        },
+        {
+          "name": "metadata_types",
+          "type": "array",
+          "required": false,
+          "description": "可选。把 `function` 类再分开：`openapi` 是 API 工具，`function` 是函数。 留空为两者都要。与 `types` 是并且关系。这一项只有检索索引答得出，索引不可用时 本接口报错，不会当作没传。"
+        },
+        {
+          "name": "owner_id",
+          "type": "string",
+          "required": false,
+          "description": "可选。只看某个来源：函数工具的工具箱、MCP 工具的 Server。Skill 没有来源， 传了这个就不会返回 Skill。取自本接口此前返回的 `owner_id`。"
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "required": false,
+          "description": "可选。最多返回多少条。工具类命中都带入参 schema。"
+        }
+      ],
+      "declares_context": true,
+      "returns": [
+        "capabilities",
+        "message",
+        "total_matched",
+        "truncated"
+      ],
+      "source": "tool.yaml"
     },
     {
       "path": "/api/agent-retrieval/v1/kn/search_instance",

--- a/python/scripts/capture_kn_contract.py
+++ b/python/scripts/capture_kn_contract.py
@@ -38,12 +38,7 @@ RETIRED = {"kn_search"}
 
 #: Measured behaviour a caller cannot learn from the spec. Kept short and rare:
 #: most surprises belong in the capture itself, not in prose beside it.
-NOTES = {
-    "find_skills": (
-        "实测：网络没有绑定技能时返回 404 BknBackend.ObjectType.ObjectTypeNotFound"
-        "(“对象类不存在”)。对象类是存在的，这个错误码指错了方向。"
-    ),
-}
+NOTES: dict[str, str] = {}
 
 
 def resolve(schema: Any, spec: dict[str, Any], section: str = "schemas") -> dict[str, Any]:

--- a/python/tests/test_kn_rest.py
+++ b/python/tests/test_kn_rest.py
@@ -189,7 +189,7 @@ def test_unset_optional_arguments_are_not_sent(deploy: Deploy) -> None:
 def test_a_route_that_sends_the_network_still_sends_it(deploy: Deploy) -> None:
     """`kn_id` is the first argument everywhere, but only the routes that declare
     it put it on the wire."""
-    kn.find_skills(KN, "order", context=CONTEXT)
+    kn.search_capabilities(KN, context=CONTEXT)
     kn.run_sql(KN, "SELECT 1 FROM {{.r}}", context=CONTEXT)
 
     assert deploy.bodies[0]["kn_id"] == KN

--- a/skills/openbkn/references/context.md
+++ b/skills/openbkn/references/context.md
@@ -261,15 +261,23 @@ openbkn context get-logic-properties <kn> --args '{
 openbkn context get-action-info <kn> --args '{"at_id": "at-1", "_instance_identity": {"id": "123"}}'
 ```
 
-### Skill recall
+### Capability search
+
+One ranking over every kind the network mounted — skills, functions, API tools
+and MCP tools — so "what can do this?" is one call, not one per kind.
 
 ```bash
-openbkn context find-skills <kn> <object-type-id> --top-k 5
+openbkn context search-capabilities <kn> --query "treatment" --limit 5
+openbkn context search-capabilities <kn> --types skill
+openbkn context search-capabilities <kn> --types function --metadata-types openapi
 ```
 
-`<object-type-id>` → `object_type_id`, `--top-k n` → `top_k` (1–20). For the
-richer args (skill_query, instance_identities) use the generic path:
-`tool-call <kn> find_skills --args '{"object_type_id":"ot_drug","skill_query":"treatment","top_k":5}'`.
+Each hit carries `capability_type`, which decides what comes next: `function`
+and `mcp_tool` are called through `execute_tool` with the returned
+`input_schema`, `skill` is read with `get_skill_content` and run with
+`execute_skill`. Omit `--query` to list what is mounted, in mount order.
+
+Replaces `find-skills` and the tool-only search, removed in bkn-foundry#1401.
 
 ### Standard MCP resources & prompts
 

--- a/src/api/context-loader.ts
+++ b/src/api/context-loader.ts
@@ -558,15 +558,32 @@ export function queryObjectInstance(
   return callTool(ctx, knId, "query_object_instance", args);
 }
 
-export function findSkills(
+/** Capability kinds a knowledge network can mount. `function` covers API tools too; split those
+ * apart with `metadataTypes`. */
+export type CapabilityType = "skill" | "function" | "mcp_tool";
+
+/** One ranking over every kind the network mounted (bkn-foundry#1370).
+ *
+ * Replaces find_skills and search_tools, which were this call with the kinds pinned and were
+ * removed in bkn-foundry#1401. */
+export function searchCapabilities(
   ctx: RequestContext,
   knId: string,
-  objectTypeId: string,
-  topK?: number,
+  opts: {
+    query?: string;
+    types?: CapabilityType[];
+    metadataTypes?: ("openapi" | "function")[];
+    ownerId?: string;
+    limit?: number;
+  } = {},
 ): Promise<unknown> {
-  const args: Record<string, unknown> = { object_type_id: objectTypeId };
-  if (topK !== undefined) args.top_k = topK;
-  return callTool(ctx, knId, "find_skills", args);
+  const args: Record<string, unknown> = {};
+  if (opts.query !== undefined) args.query = opts.query;
+  if (opts.types?.length) args.types = opts.types;
+  if (opts.metadataTypes?.length) args.metadata_types = opts.metadataTypes;
+  if (opts.ownerId !== undefined) args.owner_id = opts.ownerId;
+  if (opts.limit !== undefined) args.limit = opts.limit;
+  return callTool(ctx, knId, "search_capabilities", args);
 }
 
 /** Progressive KN-detail disclosure level: `summary` (skeleton + property names) | `full`. */

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -11,6 +11,11 @@ import { printJson } from "../utils/output.js";
 import { clientFrom, conversationSource, outputOptions, platformOf } from "./_shared.js";
 
 const int = (v: string) => Number.parseInt(v, 10);
+const list = (v: string) =>
+  v
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
 const collectArg = (v: string, prev: string[]): string[] => {
   prev.push(v);
   return prev;
@@ -117,12 +122,28 @@ export function contextCommand(): Command {
     });
 
   cmd
-    .command("find-skills <kn-id> <object-type-id>")
-    .description("Recall skills for an object type")
-    .option("--top-k <n>", "max skills (1-20)", int)
-    .action(async (knId: string, otId: string, opts, cmd: Command) => {
+    .command("search-capabilities <kn-id>")
+    .description(
+      "Rank every capability the network mounted: skills, functions, API tools, MCP tools",
+    )
+    .option("--query <text>", "rank by relevance; omit to list in mount order")
+    .option("--types <list>", "comma-separated: skill,function,mcp_tool", list)
+    .option(
+      "--metadata-types <list>",
+      "comma-separated: openapi,function (splits function tools)",
+      list,
+    )
+    .option("--owner-id <id>", "one toolbox or MCP server")
+    .option("--limit <n>", "max results (1-100)", int)
+    .action(async (knId: string, opts, cmd: Command) => {
       printJson(
-        await clientFrom(cmd).context.findSkills(knId, otId, opts.topK),
+        await clientFrom(cmd).context.searchCapabilities(knId, {
+          query: opts.query,
+          types: opts.types,
+          metadataTypes: opts.metadataTypes,
+          ownerId: opts.ownerId,
+          limit: opts.limit,
+        }),
         outputOptions(cmd),
       );
     });
@@ -492,7 +513,7 @@ rewriting it with \`run-sql\` produces a number the platform will not agree with
       "templates",
       "prompts",
       "prompt",
-      "find-skills",
+      "search-capabilities",
     ],
     RUN: [
       "query-object-instance",

--- a/src/commands/probe.ts
+++ b/src/commands/probe.ts
@@ -54,7 +54,7 @@ const COMMAND_TOOL: Record<string, string> = {
   "context query-metric": "query_metric",
   "context get-logic-properties": "get_logic_properties_values",
   "context get-action-info": "get_action_info",
-  "context find-skills": "find_skills",
+  "context search-capabilities": "search_capabilities",
   "context kn-detail": "get_kn_detail",
   "context object-types": "get_object_types",
   "context relation-types": "get_relation_types",

--- a/src/resources/context-loader.ts
+++ b/src/resources/context-loader.ts
@@ -9,7 +9,6 @@ import {
   callManagedTool,
   callMethod,
   callTool,
-  findSkills,
   getActionInfo,
   getKnDetail,
   getLogicProperties,
@@ -24,6 +23,7 @@ import {
   queryInstanceSubgraph,
   queryObjectInstance,
   readResource,
+  searchCapabilities,
   searchSchema,
 } from "../api/context-loader.js";
 import type { RequestContext } from "../types.js";
@@ -34,8 +34,8 @@ export function context(ctx: RequestContext) {
       searchSchema(ctx, knId, query, opts),
     queryObjectInstance: (knId: string, args: Record<string, unknown>) =>
       queryObjectInstance(ctx, knId, args),
-    findSkills: (knId: string, objectTypeId: string, topK?: number) =>
-      findSkills(ctx, knId, objectTypeId, topK),
+    searchCapabilities: (knId: string, opts?: Parameters<typeof searchCapabilities>[2]) =>
+      searchCapabilities(ctx, knId, opts),
     // Progressive schema disclosure: skeleton first (summary), then drill down.
     knDetail: (knId: string, detailLevel?: DetailLevel) => getKnDetail(ctx, knId, detailLevel),
     objectTypes: (knId: string, ids: string[]) => getObjectTypes(ctx, knId, ids),


### PR DESCRIPTION
配套 openbkn-ai/bkn-foundry#1403 —— `find_skills` 与 `search_tools` 在那边退役。两者都是 `search_capabilities` 把类型钉死的窄入口,留在原地的调用方 REST 会 404、MCP 会 `tool not found`。

## Python OSDK

`kn.py` 是从 `contracts/kn-rest.json` 生成的,契约又是从 foundry 的 OpenAPI 抓的,所以这边的改动就是**重抓 + 重生成**,没有手写。

重抓的净效果:

| | |
|---|---|
| 移除 | `find_skills` |
| 新增 | `search_capabilities`、**`execute_tool`** |

`execute_tool` 是顺带补上的:OSDK 一直能检索能力却调不了,缺口在契约抓取而不在谁忘了写——`tool.yaml` 这次把它写进契约,生成器就带出来了。

`capture_kn_contract.py` 里的 `NOTES` 一并清空。那条实测记录写的是「网络没绑技能时返回 404 ObjectTypeNotFound」,描述的是上游已经退役的那条召回路径;留着等于把一个已修的 bug 挂在一条从来没有过它的路由上。

## CLI

`context find-skills <kn> <object-type-id>` → `context search-capabilities <kn>`

对象类参数**没有保留**——它在工具被删之前很久就已经是「接受但忽略」了。类型现在是调用方的,所以 `--types` / `--metadata-types` / `--owner-id` / `--limit` 是flag,而不是包装层替你钉死。

**不做旧名别名**:别名得用不同的参数回答一个不同的问题,命令行上直接报错比「成功了但范围不是你要的」清楚。

## 测试服 14.103.77.23 实跑

该机跑的是 foundry 分支的构建。

```
$ openbkn context search-capabilities crm-management --types skill
  n=3  bkn-quick-start / 库存阈值预警通知 / production-schedule-backward-planning

$ openbkn context search-capabilities crm-management --types function --metadata-types openapi --limit 3
  n=3 truncated=true   全部 metadata_type=openapi

$ openbkn context search-capabilities crm-management --query 客户 --limit 3
  n=3 truncated=true   按相关度

$ openbkn context search-capabilities crm-management --limit 4
  按挂载顺序,命中带 input_schema
```

Python 侧 `kn.search_capabilities("crm-management", types=["skill"], limit=5)` 返回同样三个技能。

`pytest` 412 passed / 32 skipped;`vitest` 655 passed;`npm run lint` 与 `tsc --noEmit` 干净。

## 这次实跑还捞出上游一个缺口

CLI 把知识网络放在 **`X-Kn-ID` 头**里、不传 `kn_id`。`find_skills` 的 handler 有头部兜底,`search_capabilities` 没有——于是所有这类调用变成「kn_id is required」。

REST 面把网络放在 body 里,所以**再多的 REST 验证也照不出这条**;只有真的用 CLI 打一次才会撞上。已在同一个 foundry PR 里修掉(`execute_tool` 同样的缺口一并补),并加了断言。
