### PR TITLE
feat(sdk, cli): run read-only Cypher over a knowledge network's model

### DIFF
--- a/skills/openbkn/references/bkn.md
+++ b/skills/openbkn/references/bkn.md
@@ -5,6 +5,7 @@
 | KN | `list`, `get <kn> [--stats] [--export]`, `search <kn> <query> [--object-types ids] [--max-instances n] [--rerank]`（自然语言召回实例，附带命中对象类的定义）, `stats <kn>`, `export <kn>`, `create`/`update`/`delete`, `subgraph <kn> --body`. |
 | Schema | `object-type|relation-type|action-type list/get/create/update/delete` (create/update take `--body`/`--body-file`); `action-type query/execute`. |
 | Metric / concept-group / schedules | `metric …`, `concept-group …`, `action-log …`, `action-schedule …`. (No KN-level build jobs — index builds are Vega build tasks, see [vega.md](vega.md).) |
+| Cypher | `cypher <kn> --query '<cypher>' [--params '<json object>'] [--branch b]` — read-only Cypher over the network's model, straight to bkn-backend and outside any Trace session. Same subset, limits and refusals as `context run-cypher`; answers `{columns, entries}`. |
 | Paths / resources | `relation-type-paths <kn> --body`, `resources`. Both `relation-type-paths` and `subgraph` need `source_object_type_id` + `direction` (`forward` \| `backward` \| `bidirectional`) + `path_length` (1–3) in the body — omit any of them and the backend 400s. |
 | Local package | `push <dir>` (tar → import), `pull <kn> [dir]` (export → extract), `validate <dir>` (offline structural check). |
 | Build a KN | `create-from-catalog <catalog> --name <n> [--tables a,b] [--pk-map t:col]`. |

--- a/skills/openbkn/references/context.md
+++ b/skills/openbkn/references/context.md
@@ -247,6 +247,39 @@ openbkn context query-instance-subgraph <kn> --args '{
 }'
 ```
 
+### Cypher across object types — `run-cypher`
+
+When the question can be stated in object types and relation types — filter along a
+path, aggregate what it reaches — write it as read-only Cypher. Everything is named
+the way the model names it: labels are object type ids or names, relationship types
+are relation type ids or names, properties are logical property names. No resource
+id, no physical column; bkn-backend works out the joins from the relation types.
+
+```bash
+openbkn context run-cypher <kn> \
+  --query "MATCH (c:customer)<-[:rel_order_customer]-(o:order)
+           WHERE o.amount > \$floor
+           RETURN c.city AS city, count(*) AS orders ORDER BY orders DESC LIMIT 20" \
+  --params '{"floor": 100}'
+# → { "columns": [{"name": "city", "type": "string"}, ...], "entries": [{"city": ..., "orders": ...}] }
+```
+
+- Supported: several `MATCH` clauses and comma-separated paths (a repeated variable is
+  the same node); `-[:R]->`, `<-[:R]-`, undirected `-[:R]-`; `WHERE` with comparisons,
+  `IN`, `IS NULL`, `AND`/`OR`/`NOT`; `RETURN` with `AS`, `DISTINCT` and
+  `count`/`sum`/`avg`/`min`/`max` — aggregating groups by the other returned columns;
+  `ORDER BY`, `SKIP`, `LIMIT`.
+- Refused, naming the construct and its position: `OPTIONAL MATCH`, `WITH`, `UNION`,
+  variable-length paths `[:R*1..3]`, functions and arithmetic, returning a whole node
+  (`RETURN n` — return its properties instead), relationship variables `-[r:R]->`.
+- Limits: at most 8 relationships and 9 nodes per query; 1000 rows without `LIMIT`;
+  `LIMIT` above 10000 is refused.
+- `--params` is a JSON object of values. A parameter never becomes a label, relationship
+  type or property name. Quote `$name` in the shell (`\$floor` inside double quotes).
+- Fall back to `run-sql` only for what the subset cannot express (CTEs, `UNION`, window
+  functions) or for resources never modelled as object types.
+- `openbkn bkn cypher <kn> --query ...` runs the same statement outside any Trace session.
+
 ### Instance enrichment / actions — `--args <json>`
 
 ```bash

--- a/src/api/bkn-backend.ts
+++ b/src/api/bkn-backend.ts
@@ -73,6 +73,33 @@ export function listBknResources(ctx: RequestContext): Promise<unknown> {
   return request(ctx, "/api/bkn-backend/v1/resources");
 }
 
+/** Body of a Cypher query sent straight to bkn-backend. */
+export interface CypherQueryBody {
+  query: string;
+  /** Values for the `$name` parameters; values only, never identifiers. */
+  parameters?: Record<string, unknown>;
+}
+
+/**
+ * Compile and run one read-only Cypher query against a knowledge network.
+ * `POST /api/bkn-backend/v1/knowledge-networks/{kn_id}/cypher-queries[?branch=]`.
+ *
+ * A genuine POST, unlike the reads tunnelled below: no method override. Answers
+ * `{columns, entries}`; the generated SQL is never returned.
+ */
+export function runCypherQuery(
+  ctx: RequestContext,
+  knId: string,
+  body: CypherQueryBody,
+  branch?: string,
+): Promise<unknown> {
+  return request(ctx, knPath(knId, "cypher-queries"), {
+    method: "POST",
+    body,
+    query: { branch: branch || undefined },
+  });
+}
+
 /**
  * Query relation-type paths between object types (POST, caller-supplied body).
  * A read tunnelled over POST: without the override header the backend answers

--- a/src/api/context-loader.ts
+++ b/src/api/context-loader.ts
@@ -627,6 +627,35 @@ export function listTools(ctx: RequestContext, knId: string): Promise<unknown> {
   return callMethod(ctx, knId, "tools/list");
 }
 
+/** Options for {@link runCypher}. */
+export interface RunCypherOptions {
+  /** Knowledge network branch; the deploy reads `main` when omitted. */
+  branch?: string;
+  /**
+   * Values for the `$name` parameters in the query. Values only: a parameter never
+   * becomes a label, a relationship type or a property name.
+   */
+  parameters?: Record<string, unknown>;
+}
+
+/**
+ * Read-only Cypher over the network's model (`run_cypher`). Labels are object types,
+ * relationship types are relation types, properties are logical names — bkn-backend
+ * compiles the statement, so no resource id or physical column is needed. A refusal
+ * names the construct and its position; it arrives as the tool's error.
+ */
+export function runCypher(
+  ctx: RequestContext,
+  knId: string,
+  query: string,
+  opts?: RunCypherOptions,
+): Promise<unknown> {
+  const args: Record<string, unknown> = { query, response_format: "json" };
+  if (opts?.branch) args.branch = opts.branch;
+  if (opts?.parameters) args.parameters = opts.parameters;
+  return callTool(ctx, knId, "run_cypher", args);
+}
+
 /** Layer-2 subgraph query across relation-type paths (`query_instance_subgraph`). */
 export function queryInstanceSubgraph(
   ctx: RequestContext,

--- a/src/api/context-loader.ts
+++ b/src/api/context-loader.ts
@@ -478,8 +478,17 @@ export async function callTool(
   return (await callToolResult(ctx, knId, name, args, options)).value;
 }
 
+/**
+ * Tools whose `query` argument is a statement in a query language rather than the
+ * user's words. Recording it as the interaction's question would put machine text
+ * where Trace expects a person's question, so these are recorded by name, as
+ * `run_sql` (whose statement is `sql`) already is.
+ */
+const STATEMENT_QUERY_TOOLS = new Set(["run_cypher"]);
+
 /** The interaction's recorded question: the user's own words when the tool has them. */
 function questionFor(name: string, args: Record<string, unknown>): string {
+  if (STATEMENT_QUERY_TOOLS.has(name)) return name;
   return typeof args.query === "string" && args.query ? args.query : name;
 }
 

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -138,6 +138,26 @@ export function csv(value: string | undefined): string[] | undefined {
 }
 
 /** Resolve a request body from `--body '<json>'` or `--body-file <path>`. */
+/**
+ * Parse `--params` for a Cypher query: a JSON object mapping each `$name` to its value.
+ * Big integers survive as bigint, so an id past 2^53 still selects the row it names.
+ * Anything but an object is refused here — the compiler would refuse it later with
+ * less to say about which flag was wrong.
+ */
+export function cypherParams(raw: string | undefined): Record<string, unknown> | undefined {
+  if (raw === undefined) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = parseBigIntJSON(raw);
+  } catch {
+    throw new InputError("--params is not valid JSON.");
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new InputError(`--params must be a JSON object, as in '{"floor": 100}'.`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
 export function readBody(opts: { body?: string; bodyFile?: string }): unknown {
   const raw = opts.bodyFile ? readFileSync(opts.bodyFile, "utf8") : opts.body;
   if (!raw) throw new InputError("Provide --body '<json>' or --body-file <path>.");

--- a/src/commands/bkn.ts
+++ b/src/commands/bkn.ts
@@ -6,9 +6,10 @@ import { Command } from "commander";
 import { group, groupChildren, guide } from "../help/grouped-help.js";
 import { DEFAULT_LIST_LIMIT } from "../types.js";
 import { validateBknDirectory } from "../utils/bkn-validate.js";
+import { InputError } from "../utils/errors.js";
 import { printJson } from "../utils/output.js";
 import { parsePkMap } from "../utils/pk-detection.js";
-import { clientFrom, csv, outputOptions, readBody } from "./_shared.js";
+import { clientFrom, csv, cypherParams, outputOptions, readBody } from "./_shared.js";
 
 const int = (v: string) => Number.parseInt(v, 10);
 
@@ -537,6 +538,43 @@ export function bknCommand(): Command {
     });
 
   bkn
+    .command("cypher <kn-id>")
+    .description(
+      "Answer a read-only Cypher query over the network's model, outside any Trace session",
+    )
+    .requiredOption(
+      "--query <cypher>",
+      "read-only Cypher: labels are object types, relationship types are relation types",
+    )
+    .option(
+      "--params <json>",
+      "values for $name placeholders, as a JSON object: '{\"floor\": 100}'",
+    )
+    .option("--branch <branch>", "knowledge network branch (default: main)")
+    .addHelpText(
+      "after",
+      `
+The compiler behind \`openbkn context run-cypher\`, called directly: the same subset,
+the same limits, the same refusals naming the construct and its position. Answers
+{columns, entries}; the generated SQL is never returned. Nothing is recorded in BKN
+Trace — use context run-cypher when the query is part of a conversation an agent
+should be able to account for.
+
+  openbkn bkn cypher <kn-id> \\
+    --query "MATCH (c:customer)<-[:rel_order_customer]-(o:order) RETURN c.city AS city, count(*) AS orders"`,
+    )
+    .action(async (knId: string, opts, cmd: Command) => {
+      if (!opts.query.trim()) throw new InputError("--query must not be empty.");
+      printJson(
+        await clientFrom(cmd).kn.cypher(knId, opts.query, {
+          branch: opts.branch,
+          parameters: cypherParams(opts.params),
+        }),
+        outputOptions(cmd),
+      );
+    });
+
+  bkn
     .command("resources")
     .description("List BKN-backend resources")
     .action(async (_opts, cmd: Command) => {
@@ -592,6 +630,7 @@ export function bknCommand(): Command {
       "search",
       "subgraph",
       "relation-type-paths",
+      "cypher",
       "resources",
       "action-execution",
       "validate",

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -8,7 +8,13 @@ import { group, groupChildren, guide } from "../help/grouped-help.js";
 import { InputError } from "../utils/errors.js";
 import { parseBigIntJSON } from "../utils/json-bigint.js";
 import { printJson } from "../utils/output.js";
-import { clientFrom, conversationSource, outputOptions, platformOf } from "./_shared.js";
+import {
+  clientFrom,
+  conversationSource,
+  cypherParams,
+  outputOptions,
+  platformOf,
+} from "./_shared.js";
 
 const int = (v: string) => Number.parseInt(v, 10);
 const list = (v: string) =>
@@ -280,6 +286,61 @@ adds paging and --need-total but records nothing in Trace.`,
     });
 
   cmd
+    .command("run-cypher <kn-id>")
+    .description(
+      "Filter along a path and aggregate across object types with read-only Cypher over the model",
+    )
+    // Not a requiredOption, for the same reason as run-sql: `--schema` sends no query.
+    .option(
+      "--query <cypher>",
+      "read-only Cypher: labels are object types, relationship types are relation types",
+    )
+    .option(
+      "--params <json>",
+      "values for $name placeholders, as a JSON object: '{\"floor\": 100}'",
+    )
+    .option("--branch <branch>", "knowledge network branch (default: main)")
+    .option("--schema", "print this tool's argument schema from the deploy instead of calling it")
+    .addHelpText(
+      "after",
+      `
+Everything is named the way the model names it — no resource id, no physical column:
+
+  openbkn context search-schema <kn-id> "<what you are after>" --json
+      → object type and relation type ids or names, property names
+
+  openbkn context run-cypher <kn-id> \\
+    --query "MATCH (o:order)-[:rel_order_item_order]->(i:order_item)
+             WHERE o.status IN ['paid','shipped'] AND o.amount > \\$floor
+             RETURN o.status AS status, count(*) AS orders ORDER BY orders DESC LIMIT 20" \\
+    --params '{"floor": 100}'
+
+Supported: several MATCH clauses and comma-separated paths; -[:R]->, <-[:R]- and
+undirected -[:R]-; WHERE with comparisons, IN, IS NULL, AND/OR/NOT; RETURN with
+aliases, DISTINCT and count/sum/avg/min/max (grouping by the other returned columns);
+ORDER BY, SKIP, LIMIT. Refused with the construct and its position: OPTIONAL MATCH,
+WITH, UNION, variable-length paths, functions and arithmetic, returning a whole node.
+A query holds at most 8 relationships and 9 nodes; without LIMIT it returns 1000 rows,
+and LIMIT may not exceed 10000.
+
+What Cypher cannot say — CTEs, UNION, window functions — or a resource never modelled
+as an object type belongs in run-sql. The same query runs outside any Trace session
+through \`openbkn bkn cypher\`.`,
+    )
+    .action(async (knId: string, opts, cmd: Command) => {
+      if (opts.schema) return printToolSchema(cmd, knId, "run_cypher");
+      if (!opts.query)
+        throw new InputError("--query is required (or use --schema to see the shape)");
+      printJson(
+        await clientFrom(cmd).context.runCypher(knId, opts.query, {
+          branch: opts.branch,
+          parameters: cypherParams(opts.params),
+        }),
+        outputOptions(cmd),
+      );
+    });
+
+  cmd
     .command("explore-subgraph <kn-id> <object-type-id>")
     .description("Follow relations outward from one object type without naming a path first")
     // Same reason as run-sql: `--schema` answers without walking anything.
@@ -518,6 +579,7 @@ rewriting it with \`run-sql\` produces a number the platform will not agree with
     RUN: [
       "query-object-instance",
       "run-sql",
+      "run-cypher",
       "explore-subgraph",
       "query-metric",
       "query-instance-subgraph",
@@ -538,9 +600,11 @@ rewriting it with \`run-sql\` produces a number the platform will not agree with
      get-logic-properties / get-action-info  computed values, runnable actions
 
 PICKING THE RIGHT QUERY
-  Aggregation, ranking, GROUP BY or joins are not query-object-instance — send SQL through
-  \`tool-call <kn-id> run_sql\`. Unknown topology is \`tool-call <kn-id> explore_subgraph\`,
-  not a hand-built path.
+  Aggregation, ranking, GROUP BY or joins are not query-object-instance. When the question
+  can be stated in object types and relation types — filter along a path, aggregate what
+  it reaches — use \`run-cypher <kn-id>\`: model names only, no resource ids or physical
+  columns. SQL through \`run-sql <kn-id>\` is for what the Cypher subset cannot say.
+  Unknown topology is \`tool-call <kn-id> explore_subgraph\`, not a hand-built path.
 
 THE SAME ID, FOUR NAMES
   An object type's id is \`concept_id\` in search-schema output, \`id\` in kn-detail and

--- a/src/commands/probe.ts
+++ b/src/commands/probe.ts
@@ -51,6 +51,7 @@ const COMMAND_TOOL: Record<string, string> = {
   "context query-instance-subgraph": "query_instance_subgraph",
   "context explore-subgraph": "explore_subgraph",
   "context run-sql": "run_sql",
+  "context run-cypher": "run_cypher",
   "context query-metric": "query_metric",
   "context get-logic-properties": "get_logic_properties_values",
   "context get-action-info": "get_action_info",

--- a/src/resources/context-loader.ts
+++ b/src/resources/context-loader.ts
@@ -4,6 +4,7 @@
 /** Context-loader resource surface (MCP over agent-retrieval). */
 import {
   type DetailLevel,
+  type RunCypherOptions,
   type SearchSchemaOptions,
   type ToolCallOptions,
   callManagedTool,
@@ -23,6 +24,7 @@ import {
   queryInstanceSubgraph,
   queryObjectInstance,
   readResource,
+  runCypher,
   searchCapabilities,
   searchSchema,
 } from "../api/context-loader.js";
@@ -60,6 +62,8 @@ export function context(ctx: RequestContext) {
       callMethod(ctx, knId, method, params),
     queryInstanceSubgraph: (knId: string, args: Record<string, unknown>) =>
       queryInstanceSubgraph(ctx, knId, args),
+    runCypher: (knId: string, query: string, opts?: RunCypherOptions) =>
+      runCypher(ctx, knId, query, opts),
     logicProperties: (knId: string, args: Record<string, unknown>) =>
       getLogicProperties(ctx, knId, args),
     actionInfo: (knId: string, args: Record<string, unknown>) => getActionInfo(ctx, knId, args),

--- a/src/resources/knowledge-networks.ts
+++ b/src/resources/knowledge-networks.ts
@@ -17,6 +17,7 @@ import {
   listConceptGroups,
   relationTypePaths,
   removeConceptGroupMembers,
+  runCypherQuery,
   setActionScheduleStatus,
   updateActionSchedule,
   updateConceptGroup,
@@ -133,6 +134,13 @@ export function kn(ctx: RequestContext) {
       setActionScheduleStatus(ctx, knId, scheduleId, body),
     actionScheduleDelete: (knId: string, ids: string) => deleteActionSchedules(ctx, knId, ids),
     relationTypePaths: (knId: string, body: unknown) => relationTypePaths(ctx, knId, body),
+    // Straight to the compiler, outside any Trace session; `context.runCypher` is the
+    // same query recorded as part of a conversation.
+    cypher: (
+      knId: string,
+      query: string,
+      opts?: { branch?: string; parameters?: Record<string, unknown> },
+    ) => runCypherQuery(ctx, knId, { query, parameters: opts?.parameters }, opts?.branch),
     bknResources: () => listBknResources(ctx),
     createFromCatalog: (opts: CreateFromCatalogOptions) => createFromCatalog(ctx, opts),
     /** Pack a local BKN directory and upload it as a knowledge network. */

--- a/test/unit/context-loader.test.ts
+++ b/test/unit/context-loader.test.ts
@@ -10,6 +10,7 @@ import {
   getKnDetail,
   getObjectTypes,
   getRelationTypes,
+  runCypher,
 } from "../../src/api/context-loader.js";
 import { resetLifecycleCaches } from "../../src/api/lifecycle.js";
 import type { RequestContext } from "../../src/types.js";
@@ -162,6 +163,38 @@ describe("drill-down (get_object_types / get_relation_types)", () => {
     const p = toolCallBody(f);
     expect(p.name).toBe("get_relation_types");
     expect(p.arguments.ids).toEqual(["rel_a"]);
+  });
+});
+
+describe("run_cypher", () => {
+  it("sends the query as written, with branch, parameters and JSON output", async () => {
+    const f = mockMcp();
+    const query = "MATCH (o:order) WHERE o.id = $id RETURN o.no AS no";
+    await runCypher(ctx, "kn-cypher", query, {
+      branch: "dev",
+      parameters: { id: 9007199254740993n },
+    });
+
+    const p = toolCallBody(f);
+    expect(p.name).toBe("run_cypher");
+    // The query is not trimmed or rewritten: the compiler reports positions in it.
+    expect(p.arguments.query).toBe(query);
+    expect(p.arguments.branch).toBe("dev");
+    expect(p.arguments.response_format).toBe("json");
+    // An id past 2^53 has to arrive with every digit, or it selects a different row.
+    const raw = rpcCalls(f)
+      .map(([, init]) => init.body as string)
+      .find((body) => body.includes('"tools/call"'));
+    expect(raw).toContain('"id":9007199254740993');
+  });
+
+  it("leaves branch and parameters out when they were not given", async () => {
+    const f = mockMcp();
+    await runCypher(ctx, "kn-cypher-bare", "MATCH (o:order) RETURN o.no AS no");
+
+    const p = toolCallBody(f);
+    expect(p.arguments).not.toHaveProperty("branch");
+    expect(p.arguments).not.toHaveProperty("parameters");
   });
 });
 

--- a/test/unit/cypher-command.test.ts
+++ b/test/unit/cypher-command.test.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 OpenBKN. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the project root.
+
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { runCypher, cypher } = vi.hoisted(() => ({
+  runCypher: vi.fn(async () => ({ columns: [], entries: [] })),
+  cypher: vi.fn(async () => ({ columns: [], entries: [] })),
+}));
+
+vi.mock("../../src/commands/_shared.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/commands/_shared.js")>();
+  return {
+    ...actual,
+    clientFrom: vi.fn(() => ({ context: { runCypher }, kn: { cypher } })),
+  };
+});
+
+import { bknCommand } from "../../src/commands/bkn.js";
+import { contextCommand } from "../../src/commands/context.js";
+
+function program(): Command {
+  return new Command("openbkn")
+    .exitOverride()
+    .option("--json")
+    .option("--compact")
+    .addCommand(contextCommand())
+    .addCommand(bknCommand());
+}
+
+function run(...argv: string[]): Promise<Command> {
+  return program().parseAsync(["node", "openbkn", "--json", ...argv]);
+}
+
+// The commands print their answer; keep it out of the test output.
+beforeEach(() => {
+  vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(process.stdout.write).mockRestore();
+});
+
+const QUERY = "MATCH (o:order) WHERE o.id = $id RETURN o.no AS no";
+
+describe("openbkn context run-cypher", () => {
+  it("passes the query, branch and parameters, keeping big integers exact", async () => {
+    await run(
+      "context",
+      "run-cypher",
+      "kn-a",
+      "--query",
+      QUERY,
+      "--branch",
+      "dev",
+      "--params",
+      '{"id": 9007199254740993}',
+    );
+    expect(runCypher).toHaveBeenCalledWith("kn-a", QUERY, {
+      branch: "dev",
+      parameters: { id: 9007199254740993n },
+    });
+  });
+
+  it("requires --query unless --schema was asked for, before calling the deploy", async () => {
+    await expect(run("context", "run-cypher", "kn-a")).rejects.toThrow("--query is required");
+    expect(runCypher).not.toHaveBeenCalled();
+  });
+
+  it("refuses --params that is not a JSON object, before calling the deploy", async () => {
+    await expect(
+      run("context", "run-cypher", "kn-a", "--query", QUERY, "--params", "[1, 2]"),
+    ).rejects.toThrow("--params must be a JSON object");
+    await expect(
+      run("context", "run-cypher", "kn-a", "--query", QUERY, "--params", "{not json"),
+    ).rejects.toThrow("--params is not valid JSON");
+    expect(runCypher).not.toHaveBeenCalled();
+  });
+});
+
+describe("openbkn bkn cypher", () => {
+  it("sends the query straight to bkn-backend with branch and parameters", async () => {
+    await run("bkn", "cypher", "kn-a", "--query", QUERY, "--params", '{"id": 7}');
+    expect(cypher).toHaveBeenCalledWith("kn-a", QUERY, {
+      branch: undefined,
+      parameters: { id: 7 },
+    });
+  });
+
+  it("refuses an empty query before calling the deploy", async () => {
+    await expect(run("bkn", "cypher", "kn-a", "--query", "   ")).rejects.toThrow(
+      "--query must not be empty",
+    );
+    expect(cypher).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/knowledge-networks.test.ts
+++ b/test/unit/knowledge-networks.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { relationTypePaths } from "../../src/api/bkn-backend.js";
+import { relationTypePaths, runCypherQuery } from "../../src/api/bkn-backend.js";
 import {
   dryRunMetric,
   executeActionType,
@@ -222,6 +222,36 @@ describe("reads tunnelled over POST", () => {
       "/api/bkn-backend/v1/knowledge-networks/kn-1/relation-type-paths",
     );
     expect(header(init, "X-HTTP-Method-Override")).toBe("GET");
+  });
+});
+
+describe("cypher queries", () => {
+  it("cypher-queries is a plain POST carrying the query, parameters and branch", async () => {
+    const f = mockFetch();
+    await runCypherQuery(
+      ctx,
+      "kn-1",
+      {
+        query: "MATCH (o:order) WHERE o.id = $id RETURN o.no AS no",
+        parameters: { id: 9007199254740993n },
+      },
+      "dev",
+    );
+    const [url, init] = firstCall(f);
+    const parsed = new URL(url);
+    expect(parsed.pathname).toBe("/api/bkn-backend/v1/knowledge-networks/kn-1/cypher-queries");
+    expect(parsed.searchParams.get("branch")).toBe("dev");
+    expect(init.method).toBe("POST");
+    // A real POST, unlike the tunnelled reads beside it.
+    expect(new Headers(init.headers).get("X-HTTP-Method-Override")).toBeNull();
+    expect(init.body as string).toContain('"id":9007199254740993');
+  });
+
+  it("cypher-queries sends no branch parameter when none was asked for", async () => {
+    const f = mockFetch();
+    await runCypherQuery(ctx, "kn-1", { query: "MATCH (o:order) RETURN o.no AS no" });
+    const [url] = firstCall(f);
+    expect(new URL(url).searchParams.has("branch")).toBe(false);
   });
 });
 

--- a/test/unit/lifecycle.test.ts
+++ b/test/unit/lifecycle.test.ts
@@ -2,7 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See the LICENSE file in the project root.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { callManagedTool, callTool, searchSchema } from "../../src/api/context-loader.js";
+import {
+  callManagedTool,
+  callTool,
+  runCypher,
+  searchSchema,
+} from "../../src/api/context-loader.js";
 import { searchInstance } from "../../src/api/knowledge-networks.js";
 import { releaseLifecycleSessions, resetLifecycleCaches } from "../../src/api/lifecycle.js";
 import type { RequestContext } from "../../src/types.js";
@@ -932,6 +937,17 @@ describe("managed lifecycle on MCP business tools", () => {
       conversation_id: "conv_1",
       interaction_id: "int_1",
     });
+  });
+
+  // run_cypher's `query` is a Cypher statement, not something a person asked. Trace
+  // records the interaction's question as the user's words, so the statement stays out.
+  it("records run_cypher by tool name, not its statement, as the question", async () => {
+    const recorded = mockDeploy({ catalog: V2_CATALOG });
+    await runCypher(freshCtx(), "kn-managed-cypher", "MATCH (o:order) RETURN count(*) AS n");
+
+    expect(recorded.toolCalls.map((c) => c.name)).toEqual(["bkn_start_interaction", "run_cypher"]);
+    expect(recorded.toolCalls[0]?.arguments.question).toBe("run_cypher");
+    expect(recorded.toolCalls[1]?.arguments.query).toBe("MATCH (o:order) RETURN count(*) AS n");
   });
 
   it("passes a caller-built bkn_context through untouched and opens no session", async () => {


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] `openbkn context run-cypher <kn-id>` — read-only Cypher through Context Loader's `run_cypher` tool, recorded in BKN Trace (RUN)
- [x] `openbkn bkn cypher <kn-id>` — the same statement straight to bkn-backend's `POST /knowledge-networks/{kn_id}/cypher-queries`, no Trace session (READ)
- [x] SDK surface: `client.context.runCypher(knId, query, { branch, parameters })` and `client.kn.cypher(knId, query, { branch, parameters })`
- [x] Docs: `skills/openbkn/references/context.md` and `bkn.md` — the accepted subset, the refused constructs, the limits, and when to use `run-sql` instead

---

## Why

- Related Issue: none — requested directly by the owner to bring the SDK up to the Cypher capability that bkn-foundry ships.
- Related Feature: bkn-foundry Cypher compiler (openbkn-ai/bkn-foundry#1443, #1445, #1447, #1451, #1460) and Context Loader `run_cypher` (openbkn-ai/bkn-foundry#1455; main via #1490)
- Background: a question that spans object types — filter along a path, aggregate what it reaches — could only go through `run-sql`, which makes the caller resolve every object type to a resource id and every property to a physical column. Cypher states it in the model's own names, and the backend works out the joins from the relation types.

---

## How

- Key implementation points:
  - Layering as `AGENTS.md` requires: `commands → resources → api`. The context path is a typed wrapper over `callTool`, so the managed Trace interaction and receipts come from the existing machinery; it sends `response_format: "json"` like the other typed wrappers.
  - The direct path is a plain POST — no `X-HTTP-Method-Override`, unlike the tunnelled reads beside it — with `branch` as a query parameter.
  - `--params` is a JSON object parsed with `parseBigIntJSON` (the shared `cypherParams` helper), so an id past 2^53 keeps every digit; a non-object or invalid JSON is refused before any request is sent. The query text is not trimmed or rewritten, since the compiler reports refusals by line and column.
  - Self-describing surface: sections set explicitly (`run-cypher` in RUN alongside `run-sql`; `cypher` in READ alongside `subgraph`), the context `guide()` routes model-shaped questions to `run-cypher`, and `--probe` decides `context run-cypher` from the deploy's MCP tool catalog.
  - The help example writes `\$floor`: an unescaped `$floor` inside double quotes is expanded by the shell to nothing and the copied command sends a broken query.
- Breaking changes (API, config, database, etc.): none — two new commands and two new SDK methods.

---

## Testing

- [x] Unit tests passed locally — `npm run lint` (biome + tsc) and `npm test` (652 passed). New: API-level tests for both endpoints (tool name and arguments, plain POST, branch parameter, bigint parameters on the wire) and command-level tests (arguments passed through, `--query` and `--params` validation before any request).
- [ ] Integration tests passed locally — N/A: the E2E entry is not part of this change.
- [x] Verified in test environment

Test notes:

Against the main-line test server (14.103.77.23, read-only queries):

- `openbkn bkn cypher fullchain_ecommerce_20260902 --query 'MATCH (p:payment) RETURN p.payment_status AS status, count(*) AS n ORDER BY n DESC LIMIT 5'` → `success 11461 / refunded 443 / refunding 286`
- two hops with a parameter (`MATCH (o:order)-[:rel_order_user]->(u:user) WHERE o.order_status = $s RETURN count(*) AS n`, `--params '{"s":"completed"}'`) → `8808`
- an unsupported construct surfaces the compiler's refusal with its position: `[BknBackend.Cypher.Unsupported] line 1:0: OPTIONAL MATCH is not supported`
- `openbkn context run-cypher` on that server answers `tool 'run_cypher' not found`: main's Context Loader gains the tool with openbkn-ai/bkn-foundry#1490, and `--probe` reports it unavailable until then.

---

## Risk & Rollback

- Potential risks: low — additive commands and methods; nothing existing changes behaviour. On a deploy without the tool or the endpoint the commands fail with the backend's own error.
- Rollback plan: revert this commit.

---

## Additional Notes

- The success path of `context run-cypher` was not exercised through the CLI. The only deploy that has the tool today runs 0.1.4-yf, and the platform-version preflight from #95 refuses every request there: 0.1.4-yf's bkn-backend has no `/api/bkn-backend/v1/health` (404), while main has it. That is independent of this change but means the current SDK cannot talk to 0.1.4-yf deploys at all; it needs a decision on either side. The Context Loader tool itself was verified on that deploy through its REST face.
- The Python OSDK is not touched: its context-loader functions are generated from a contract frozen from bkn-foundry's OpenAPI, and `cypher.yaml` reaches foundry main with #1490. It can be regenerated after that.
