### PR TITLE
docs(create-skill): show a function calling another function through kn.execute_tool

### DIFF
--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -108,6 +108,35 @@ Full example (BOM level-1 kitting check):
 Details of `kn.query_metric` / `kn.run_sql` and the generated ontology layer: the bkn-osdk
 README under `python/`.
 
+### Calling another function
+
+A function may call another function mounted on the same network through the platform:
+
+```python
+from bkn_osdk import kn
+
+def handler(event):
+    answer = kn.execute_tool(event["kn_id"], event["box_id"], event["tool_id"],
+                             {"kn_id": event["kn_id"], "product": event["product"], "qty": 50})
+    body = answer.get("body", answer)           # the callee's raw response
+    if body.get("exit_code") not in (0, None):  # HTTP 200 does not mean the callee succeeded
+        return {"ok": False, "reason": body.get("stderr", "")[-300:]}
+    return {"ok": True, **(body.get("result") or {})}
+```
+
+- `kn.execute_tool` carries the sandbox's managed turn, so the callee's sandbox gets the same
+  caller credential and the trace shows the callee under this function's `execute_tool`
+  operation, with the callee's own reads below it.
+- Needs a sandbox bkn-osdk that has `kn.execute_tool` (bkn-sdk #100 or later). On an older
+  SDK the only route is `bkn_osdk.call("/api/agent-retrieval/v1/kn/execute_tool", ...)`, and
+  the request body **must** carry a `bkn_context` built from `BKN_CONVERSATION_ID`,
+  `BKN_INTERACTION_ID` and `BKN_PARENT_OPERATION_ID`; without it the callee's sandbox is
+  given no credential at all.
+- The callee's own mounting and permissions apply. There is no depth or cycle guard — do not
+  write functions that call each other.
+
+Example: [references/examples/functions/call_l1_check.py](references/examples/functions/call_l1_check.py).
+
 ### Code → tool (openbkn CLI 0.1.5+)
 
 ```bash

--- a/skills/create-skill/references/examples/functions/call_l1_check.py
+++ b/skills/create-skill/references/examples/functions/call_l1_check.py
@@ -1,0 +1,28 @@
+"""Function A calling Function B through the platform.
+
+Runs in the platform sandbox as a function tool. Nothing here names a URL, a token or a
+session: bkn-osdk reads BKN_BASE_URL / BKN_TOKEN and the managed turn
+(BKN_CONVERSATION_ID / BKN_INTERACTION_ID / BKN_PARENT_OPERATION_ID) from the sandbox
+environment, so the inner call runs as the same caller and lands in the trace as a child
+of this function's own execute_tool operation.
+
+Requires the sandbox's bkn-osdk to include `kn.execute_tool` (bkn-sdk #100 or later).
+"""
+
+from bkn_osdk import kn
+
+
+def handler(event: dict) -> dict:
+    """event: kn_id, box_id, tool_id (the function to call), product, qty."""
+    kn_id = event["kn_id"]
+    answer = kn.execute_tool(kn_id, event["box_id"], event["tool_id"],
+                             {"kn_id": kn_id, "product": event["product"], "qty": event.get("qty", 1)})
+
+    # execute_tool hands back the tool's raw response: `body.exit_code` says whether B ran,
+    # `body.result` is B's own return value. Read both — an HTTP 200 does not mean B succeeded.
+    body = answer.get("body", answer) if isinstance(answer, dict) else {}
+    if not isinstance(body, dict) or body.get("exit_code") not in (0, None):
+        return {"ok": False, "reason": (body.get("stderr") or "")[-300:] if isinstance(body, dict) else str(answer)[:300]}
+    result = body.get("result") or {}
+    return {"ok": True, "kitting_ok": result.get("kitting_ok"), "gap_count": result.get("gap_count"),
+            "gaps": (result.get("gaps") or [])[:5]}


### PR DESCRIPTION
## Summary

Refs openbkn-ai/bkn-foundry#1504 (companion of the sandbox pin bump there). `create-skill` gains a "Calling another function" section and the `call_l1_check` example: a function calls another function mounted on the same network through `kn.execute_tool`, the managed turn travels with it, and the callee runs as the same caller with its reads nested under the caller's `execute_tool` operation in the trace.

It also records the fallback for a sandbox whose bkn-osdk predates #100 — a raw `bkn_osdk.call` to `/kn/execute_tool` that must carry a hand-built `bkn_context`, otherwise the callee's sandbox receives no credential — and that the platform has no depth or cycle guard.

## Verification

Run on the test deploy with the SDK at `a877c3ab` installed into the sandbox session: the example, registered as a tool and called through Context Loader `execute_tool` inside a managed interaction, reached the callee with the caller's credential and returned its result; the trace core index shows `execute_tool` → `execute_tool` → the callee's `query_object_instance` reads with parent links intact.

Markdown and Python only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
